### PR TITLE
docs: replace mermaid pipeline diagram with ASCII flowchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,20 @@ false positives over up to three iterations. Output is a validated vulnerability
 report in your console, as JSON, or as SARIF for GitHub Code Scanning / GitLab
 Security Dashboard.
 
-```mermaid
-flowchart TD
-    A[Project files] --> B["1. Ingestion — scans .php / .twig / .yaml / .xml recursively"]
-    B --> C["2. Mapping — classifies Controllers, Entities, Voters, Forms, Routes"]
-    C --> D["3. Audit — Attacker ⚔ Reviewer multi-agent loop (up to 3 iterations)"]
-    D --> E[Validated vulnerability report: console, JSON, or SARIF]
+```text
+  Project files
+       │
+       ▼
+  1. Ingestion — scans .php / .twig / .yaml / .xml recursively
+       │
+       ▼
+  2. Mapping — classifies Controllers, Entities, Voters, Forms, Routes
+       │
+       ▼
+  3. Audit — Attacker ⚔ Reviewer multi-agent loop (up to 3 iterations)
+       │
+       ▼
+  Validated vulnerability report: console, JSON, or SARIF
 ```
 
 ---

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -101,6 +101,25 @@ final class AuditOrchestratorTest extends TestCase
         self::assertCount(1, $auditContext->vulnerabilities());
     }
 
+    public function test_it_breaks_early_when_iteration_yields_no_new_unique_findings(): void
+    {
+        // Iter 1: attacker returns vuln v1 → reviewer accepts → persisted (newFindings=1, loop continues).
+        // Iter 2: attacker returns the same vuln → duplicate, not persisted (newFindings=0) → break.
+        // audit.iterations must be 2 (not maxIterations=3). Kills:
+        //   - Break_ on line 79 (break → continue would let the loop run to iteration 3).
+        //   - DecrementInteger on line 78 (0 === → -1 === would never trigger early exit).
+        $this->attackerLlm->method('complete')->willReturn(
+            $this->attackerResponse([$this->vulnPayload(title: 'Vuln v1')]),
+        );
+        $this->reviewerLlm->method('complete')->willReturn($this->reviewerAcceptResponse());
+
+        $auditContext = $this->makeContextWithMapping();
+
+        $this->auditOrchestrator->orchestrate($auditContext);
+
+        self::assertSame(2, $auditContext->getMeta('audit.iterations'));
+    }
+
     public function test_it_filters_low_confidence_findings(): void
     {
         $this->attackerLlm->method('complete')->willReturn(


### PR DESCRIPTION
Packagist's markdown renderer (cebe/markdown) does not support
mermaid blocks; the diagram also fails to render on some GitHub
clients (mobile, embeds). Replace the mermaid block in README
with an ASCII flowchart that renders identically on Packagist,
GitHub web/mobile, IDEs, and terminals while preserving the
original five-stage labels.

https://claude.ai/code/session_01LFs2CKrdHcCuiALCq4BcAC