### PR TITLE
feat(bundle): restrict service registration to dev and test environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,19 +119,35 @@ Full details: [`docs/architecture.md`](docs/architecture.md)
 
 ## Bundle Configuration
 
+Register the bundle for `dev` and `test` only in `config/bundles.php`, and wrap
+every `symfony_security_auditor.yaml` block in `when@dev:` / `when@test:` so
+prod never tries to load the (absent) extension. `loadExtension` is also a no-op
+outside dev/test as a safety net.
+
 Minimal:
 
 ```yaml
-symfony_security_auditor:
-    model: 'claude-opus-4-5'
+when@dev:
+    symfony_security_auditor:
+        model: 'claude-opus-4-5'
+
+when@test:
+    symfony_security_auditor:
+        model: 'claude-opus-4-5'
 ```
 
 Split-model (larger attacker, faster reviewer):
 
 ```yaml
-symfony_security_auditor:
-    attacker_model: 'claude-opus-4-5'
-    reviewer_model: 'claude-haiku-4-5'
+when@dev:
+    symfony_security_auditor:
+        attacker_model: 'claude-opus-4-5'
+        reviewer_model: 'claude-haiku-4-5'
+
+when@test:
+    symfony_security_auditor:
+        attacker_model: 'claude-opus-4-5'
+        reviewer_model: 'claude-haiku-4-5'
 ```
 
 Swapping LLM providers requires only `config/packages/ai.yaml` changes — no code

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,10 @@ return [
 ];
 ```
 
+The bundle enforces the same restriction internally: even if registered under
+`['all' => true]`, `loadExtension()` is a no-op outside `dev` and `test`, so the
+auditor cannot accidentally ship to prod.
+
 ---
 
 ## Bundle Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,9 +41,14 @@ return [
 ];
 ```
 
-The bundle enforces the same restriction internally: even if registered under
-`['all' => true]`, `loadExtension()` is a no-op outside `dev` and `test`, so the
-auditor cannot accidentally ship to prod.
+The bundle enforces the same restriction internally: `loadExtension()` is a
+no-op outside `dev` and `test`, so a misregistered `['all' => true]` cannot wire
+the auditor into prod. Even with that safety net, **always scope your config
+file with `when@dev:` / `when@test:` (see below)** — otherwise Symfony will
+reject `config/packages/symfony_security_auditor.yaml` at compile time in prod
+with _"There is no extension able to load the configuration for
+symfony_security_auditor"_, because the bundle class itself is not loaded in
+that env.
 
 ---
 
@@ -89,44 +94,65 @@ names must be supported by the platform configured in `ai.yaml`.
 | `cache.dir`            | `string` | `%kernel.cache_dir%/symfony_security_auditor/attacker` | Cache storage path. Created on first write.                                                                                                                                                                                                                                   |
 | `cache.prompt_caching` | `bool`   | `true`                                                 | Opt into provider-side prompt caching by setting `cache_control: ephemeral` on every LLM call. Default `true` — Anthropic honors it for ~90% input-token discount; other providers silently ignore the flag (zero cost to leave on).                                          |
 
+> All examples below wrap the `symfony_security_auditor:` block in `when@dev:`
+> and `when@test:`. The wrapping is **required** when the bundle is registered
+> for `dev` and `test` only (the recommendation above) — without it, Symfony
+> fails at compile time in prod. Duplicate the block across the two envs, or use
+> a YAML anchor to keep it DRY.
+
 ### Simple mode — one model for both roles
 
 ```yaml
 # config/packages/symfony_security_auditor.yaml
-symfony_security_auditor:
-    model: 'claude-opus-4-5'
+when@dev:
+    symfony_security_auditor:
+        model: 'claude-opus-4-5'
+
+when@test:
+    symfony_security_auditor:
+        model: 'claude-opus-4-5'
 ```
 
 ### Split mode — separate models per role
 
 ```yaml
 # config/packages/symfony_security_auditor.yaml
-symfony_security_auditor:
-    attacker_model: 'claude-opus-4-5'   # powerful model for discovery
-    reviewer_model: 'claude-haiku-4-5'  # faster model for validation
+when@dev:
+    symfony_security_auditor:
+        attacker_model: 'claude-opus-4-5'   # powerful model for discovery
+        reviewer_model: 'claude-haiku-4-5'  # faster model for validation
+
+when@test:
+    symfony_security_auditor:
+        attacker_model: 'claude-opus-4-5'
+        reviewer_model: 'claude-haiku-4-5'
 ```
 
 ### Full configuration example
 
 ```yaml
 # config/packages/symfony_security_auditor.yaml
-symfony_security_auditor:
-    attacker_model: 'claude-opus-4-5'
-    reviewer_model: 'claude-haiku-4-5'
-    scan:
-        excluded_dirs:
-            - 'legacy'
-            - 'tests/fixtures/generated'
-        respect_gitignore: true
-        max_file_size_kb: 256
-    audit:
-        max_iterations: 5
-        min_confidence: 0.7
-        reviewer_batch_size: 5
-        tools_enabled: true
-    cache:
-        enabled: true
-        prompt_caching: true
+_symfony_security_auditor: &symfony_security_auditor
+    symfony_security_auditor:
+        attacker_model: 'claude-opus-4-5'
+        reviewer_model: 'claude-haiku-4-5'
+        scan:
+            excluded_dirs:
+                - 'legacy'
+                - 'tests/fixtures/generated'
+            respect_gitignore: true
+            max_file_size_kb: 256
+        audit:
+            max_iterations: 5
+            min_confidence: 0.7
+            reviewer_batch_size: 5
+            tools_enabled: true
+        cache:
+            enabled: true
+            prompt_caching: true
+
+when@dev: *symfony_security_auditor
+when@test: *symfony_security_auditor
 ```
 
 ---
@@ -232,6 +258,9 @@ Provider-specific parameters such as `max_tokens` and `temperature` are passed
 via the model name. Two syntaxes are supported in
 `symfony_security_auditor.yaml`.
 
+> Same `when@dev:` / `when@test:` wrapping rule applies — omitted below for
+> readability.
+
 ### Query-string syntax
 
 ```yaml
@@ -275,9 +304,15 @@ ai:
 ### `config/packages/symfony_security_auditor.yaml`
 
 ```yaml
-symfony_security_auditor:
-    attacker_model: 'claude-opus-4-5'   # deep reasoning for vuln discovery
-    reviewer_model: 'claude-haiku-4-5'  # fast + cheap for false-positive filtering
+when@dev:
+    symfony_security_auditor:
+        attacker_model: 'claude-opus-4-5'   # deep reasoning for vuln discovery
+        reviewer_model: 'claude-haiku-4-5'  # fast + cheap for false-positive filtering
+
+when@test:
+    symfony_security_auditor:
+        attacker_model: 'claude-opus-4-5'
+        reviewer_model: 'claude-haiku-4-5'
 ```
 
 The attacker agent receives all source files grouped into chunks of 10, sorted

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,17 +57,37 @@ corresponding `symfony/ai-*-platform` package is installed.
 ### `audit:run` not registered / unknown command
 
 `SymfonySecurityAuditorBundle` is registered for `dev` and `test` only by
-default. Run from those environments:
+design. Run from those environments:
 
 ```bash
 APP_ENV=dev bin/console audit:run /path/to/project
 ```
 
-To enable in `prod`, change `config/bundles.php`:
+The bundle's `loadExtension` is a hard no-op outside `dev` and `test`, so
+flipping `config/bundles.php` to `['all' => true]` will _not_ make the command
+available in prod — services are still skipped. This is intentional: the auditor
+calls remote LLMs with your source code and is not meant to run in production.
 
-```php
-VinceAmstoutz\SymfonySecurityAuditor\SymfonySecurityAuditorBundle::class => ['all' => true],
+### `There is no extension able to load the configuration for "symfony_security_auditor"` (prod / staging)
+
+Your `config/packages/symfony_security_auditor.yaml` is loaded in every env, but
+the bundle class only exists in `dev` and `test`. Wrap the block in `when@dev:`
+/ `when@test:`:
+
+```yaml
+# config/packages/symfony_security_auditor.yaml
+when@dev:
+    symfony_security_auditor:
+        model: 'claude-opus-4-5'
+
+when@test:
+    symfony_security_auditor:
+        model: 'claude-opus-4-5'
 ```
+
+See
+[configuration.md → Bundle Registration](configuration.md#bundle-registration)
+for the full pattern.
 
 ### `[ERROR] Path "/x" is not a valid directory`
 

--- a/src/SymfonySecurityAuditorBundle.php
+++ b/src/SymfonySecurityAuditorBundle.php
@@ -34,6 +34,12 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 final class SymfonySecurityAuditorBundle extends AbstractBundle
 {
+    /**
+     * Environments where the bundle wires its services. Outside this list the
+     * extension is a no-op so the auditor cannot accidentally ship to prod.
+     */
+    public const SUPPORTED_ENVIRONMENTS = ['dev', 'test'];
+
     public function configure(DefinitionConfigurator $definition): void
     {
         $definition->rootNode()
@@ -132,6 +138,10 @@ final class SymfonySecurityAuditorBundle extends AbstractBundle
      */
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
+        if (!\in_array($builder->getParameter('kernel.environment'), self::SUPPORTED_ENVIRONMENTS, true)) {
+            return;
+        }
+
         $container->import('../config/services.php');
 
         $attackerModel = $config['attacker_model'] ?? $config['model'];

--- a/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
+++ b/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
@@ -250,6 +250,27 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
         self::assertSame(1, $kernel->getContainer()->getParameter('symfony_security_auditor.audit.max_tool_iterations'));
     }
 
+    public function test_bundle_registers_services_in_dev_environment(): void
+    {
+        $kernel = $this->boot(['model' => 'gpt-4o'], 'dev');
+
+        self::assertSame('gpt-4o', $kernel->getContainer()->getParameter('symfony_security_auditor.attacker_model'));
+    }
+
+    public function test_bundle_skips_service_registration_in_prod_environment(): void
+    {
+        $kernel = $this->boot(['model' => 'gpt-4o'], 'prod');
+
+        self::assertFalse($kernel->getContainer()->hasParameter('symfony_security_auditor.attacker_model'));
+    }
+
+    public function test_bundle_skips_service_registration_in_unknown_environment(): void
+    {
+        $kernel = $this->boot(['model' => 'gpt-4o'], 'staging');
+
+        self::assertFalse($kernel->getContainer()->hasParameter('symfony_security_auditor.attacker_model'));
+    }
+
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/bundle_test_'.uniqid('', true);
@@ -271,10 +292,10 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     /**
      * @param array<string, mixed> $bundleConfig
      */
-    private function boot(array $bundleConfig): Kernel
+    private function boot(array $bundleConfig, string $environment = 'test'): Kernel
     {
         $tmpDir = $this->tmpDir;
-        $kernel = new class('test', true, $tmpDir, $bundleConfig) extends Kernel {
+        $kernel = new class($environment, true, $tmpDir, $bundleConfig) extends Kernel {
             /** @var array<string, mixed> */
             private array $bundleConfig;
 


### PR DESCRIPTION
Bundle loadExtension now no-ops outside the SUPPORTED_ENVIRONMENTS list
(`dev`, `test`), so installing under `['all' => true]` in bundles.php
no longer wires the auditor into prod containers.