### PR TITLE
fix(report): derive SARIF tool version from installed Composer metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Keep release tarballs / Packagist downloads lean: exclude development
+# tooling, tests, examples, and CI metadata from `composer install`.
+/.castor.stub.php       export-ignore
+/.editorconfig          export-ignore
+/.github                export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.markdownlint-cli2.jsonc export-ignore
+/.markdownlintignore    export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/.prettierignore        export-ignore
+/.prettierrc.json       export-ignore
+/CLAUDE.md              export-ignore
+/CONTRIBUTING.md        export-ignore
+/bin                    export-ignore
+/castor.php             export-ignore
+/commitlint.config.mjs  export-ignore
+/docker                 export-ignore
+/docker-compose.yml     export-ignore
+/examples               export-ignore
+/infection.json5        export-ignore
+/phpstan.dist.neon      export-ignore
+/phpunit.dist.xml       export-ignore
+/rector.php             export-ignore
+/tests                  export-ignore

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,6 +3,7 @@
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
     ->exclude('var')
+    ->exclude('examples')
 ;
 
 $header = <<<'HEADER'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to `vinceamstoutz/symfony-security-auditor` are documented
+in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
+[`docs/versioning.md`](docs/versioning.md) for the backward compatibility policy
+— what is public API, what is internal, and how deprecations are handled.
+
+## [Unreleased]
+
+## [1.0.0]
+
+First stable release.
+
+### Added
+
+- Multi-agent security audit pipeline: **Ingestion → Mapping → Audit**, driven
+  by an adversarial **Attacker** agent and a skeptical **Reviewer** agent (up to
+  3 iterations, stops early when no new findings emerge).
+- Provider-agnostic LLM backend via
+  [`symfony/ai`](https://symfony.com/doc/current/ai/index.html): works out of
+  the box with Anthropic (Claude), OpenAI, Azure OpenAI, Google Gemini, Google
+  Vertex AI, AWS Bedrock, DeepSeek, Mistral, Meta (Llama), and Ollama (local).
+  Swapping providers requires only `config/packages/ai.yaml` changes.
+- Symfony Console command `audit:run` with three output formats:
+  - `console` — human-readable summary.
+  - `json` — machine-readable report.
+  - `sarif` — SARIF 2.1.0 for GitHub Code Scanning and GitLab Security
+    Dashboard. The driver `version` is sourced dynamically from the installed
+    Composer metadata.
+- Cross-file investigation tools available to the Attacker agent: `read_file`,
+  `grep`, `list_files`, and `lookup_advisory` (live CVE feed backed by
+  `composer audit`).
+- Split-model support — pair a larger model for attack discovery with a faster,
+  cheaper model for review (e.g. Claude Opus + Claude Haiku).
+- Content-hash filesystem cache for attacker chunks (skip identical re-analyses)
+  and opt-in provider-side prompt caching (`cache_control: ephemeral` — honored
+  by Anthropic, ignored by others).
+- 32 vulnerability types across 6 OWASP-aligned categories (Injection, Broken
+  Access Control, Logic Flaws, Symfony-specific, Data Exposure, Cryptographic).
+- Documented extension points: `LLMClientInterface`,
+  `AdvisoryDatabaseInterface`, `AttackerPromptBuilderInterface`,
+  `ReviewerPromptBuilderInterface`, `ProjectFileScannerInterface`,
+  `AttackerCacheInterface`, `ToolInterface`, `PipelineInterface`,
+  `StageInterface`.
+- Documentation: configuration reference, architecture overview, CI integration
+  guide, extension guide, FAQ, troubleshooting, and a backward compatibility /
+  SemVer policy in `docs/versioning.md`.
+- Example configurations and an intentionally-vulnerable Symfony skeleton under
+  `examples/` for end-to-end demonstrations.
+
+### Notes
+
+- Default model is `claude-opus-4-5` to match the documented Quick Start.
+  Configure another model via `model:`, `attacker_model:`, or `reviewer_model:`.
+- Bundle services register in `dev` and `test` environments only by default (per
+  `config/bundles.php` guidance in the README).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,23 @@ If a tool flags something, **fix the underlying code**. Genuine exceptions (a
 real false positive, a library bug) require a PR-description justification and a
 linked issue tracking removal — never silent suppression.
 
+### 6. Backward Compatibility
+
+The project follows [Semantic Versioning 2.0.0](https://semver.org). Treat every
+public-API element as load-bearing: configuration keys (and their defaults),
+`audit:run` arguments/options/exit codes, JSON and SARIF output schemas, Domain
+ports under `src/Audit/Domain/Port/`, `AdvisoryDatabaseInterface`, Domain
+models/enums/exceptions, `RunAuditUseCase`, and the Bundle class. A change that
+removes or alters any of these is a `MAJOR` and requires a deprecation cycle.
+
+Internal classes (`@internal` PHPDoc tag) — concrete agents, pipeline stages,
+infrastructure adapters, Command collaborators — may be refactored freely in a
+`MINOR`. When you add a class that is **not** an extension point, add the
+`@internal` tag. When you add a public configuration key, list it in
+`docs/versioning.md`.
+
+Canonical policy: [`docs/versioning.md`](docs/versioning.md).
+
 ## Path-Scoped Rules
 
 Rules scoped to specific paths live in `.claude/rules/`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,8 +236,12 @@ For a custom client implementation (direct HTTP, retry logic, …) see
 1. Fork the repository.
 2. Create a feature branch: `git checkout -b feat/my-feature`.
 3. Write tests for your change (unit + integration where applicable).
-4. Ensure all checks pass: `bin/castor lint`.
-5. Open a pull request — the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+4. Mind backward compatibility — the project follows
+   [Semantic Versioning 2.0.0](https://semver.org); any change that affects the
+   public API surface listed in [`docs/versioning.md`](docs/versioning.md) needs
+   a deprecation cycle and a `feat!:` commit.
+5. Ensure all checks pass: `bin/castor lint`.
+6. Open a pull request — the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
    will guide you.
 
 The CI pipeline runs six jobs: **Prettier Check** → **Markdown Lint** → **Commit

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@
 ![PHP 8.3+](https://img.shields.io/badge/PHP-8.3%2B-blue)
 ![Symfony 7+](https://img.shields.io/badge/Symfony-7%2B-black)
 ![License MIT](https://img.shields.io/badge/License-MIT-green)
+[![SemVer 2.0.0](https://img.shields.io/badge/SemVer-2.0.0-brightgreen)](docs/versioning.md)
+
+---
+
+> **Stable & predictable.** `symfony-security-auditor` follows
+> [Semantic Versioning 2.0.0](https://semver.org). The public API —
+> configuration keys, `audit:run` arguments and options, exit codes, JSON /
+> SARIF output schemas, and the Domain ports listed in
+> [`docs/extending.md`](docs/extending.md) — is covered by our backward
+> compatibility promise. Details: [`docs/versioning.md`](docs/versioning.md).
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     },
     "require": {
         "php": ">=8.3",
+        "composer-runtime-api": "^2.0",
         "psr/log": "^3.0",
         "symfony/ai-bundle": "^0.9",
         "symfony/config": "^7.4 || ^8.0",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -436,11 +436,11 @@ Extension or Configuration class.
 `configure(DefinitionConfigurator $definition)` defines the config tree under
 root key `symfony_security_auditor`. Top-level scalars:
 
-| Key              | Default    | Purpose                                         |
-| ---------------- | ---------- | ----------------------------------------------- |
-| `model`          | `'gpt-4o'` | Model name for both Attacker and Reviewer roles |
-| `attacker_model` | `null`     | Override: dedicated model for the Attacker role |
-| `reviewer_model` | `null`     | Override: dedicated model for the Reviewer role |
+| Key              | Default             | Purpose                                         |
+| ---------------- | ------------------- | ----------------------------------------------- |
+| `model`          | `'claude-opus-4-5'` | Model name for both Attacker and Reviewer roles |
+| `attacker_model` | `null`              | Override: dedicated model for the Attacker role |
+| `reviewer_model` | `null`              | Override: dedicated model for the Reviewer role |
 
 Nested sections:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,11 +50,11 @@ following keys:
 
 ### Top-level
 
-| Key              | Type   | Default    | Description                                          |
-| ---------------- | ------ | ---------- | ---------------------------------------------------- |
-| `model`          | string | `'gpt-4o'` | Model name used for both Attacker and Reviewer roles |
-| `attacker_model` | string | `null`     | Override: dedicated model for the Attacker role      |
-| `reviewer_model` | string | `null`     | Override: dedicated model for the Reviewer role      |
+| Key              | Type   | Default             | Description                                          |
+| ---------------- | ------ | ------------------- | ---------------------------------------------------- |
+| `model`          | string | `'claude-opus-4-5'` | Model name used for both Attacker and Reviewer roles |
+| `attacker_model` | string | `null`              | Override: dedicated model for the Attacker role      |
+| `reviewer_model` | string | `null`              | Override: dedicated model for the Reviewer role      |
 
 `attacker_model` and `reviewer_model` fall back to `model` when not set. Model
 names must be supported by the platform configured in `ai.yaml`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,161 @@
+# Versioning & Backward Compatibility
+
+`symfony-security-auditor` follows
+[Semantic Versioning 2.0.0](https://semver.org) from `1.0.0` onward.
+
+> See also: [Configuration](configuration.md) · [Extending](extending.md) ·
+> [Architecture](architecture.md) · [CHANGELOG](../CHANGELOG.md)
+
+---
+
+## Semantic Versioning
+
+| Version bump | Meaning                                                                                  |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| `MAJOR`      | Removes or changes the contract of any public API element (see "Public API" below).      |
+| `MINOR`      | Adds public API in a backward-compatible way (new config keys, new ports, new commands). |
+| `PATCH`      | Bug fixes and internal changes only — no public API additions or removals.               |
+
+Every `MAJOR` release ships a migration note in
+[`CHANGELOG.md`](../CHANGELOG.md) explaining what changed and how to adapt.
+
+---
+
+## Public API — what is covered by the BC promise
+
+Everything below is part of the public API and **will not break in a `MINOR` or
+`PATCH` release**.
+
+### Bundle configuration
+
+Every key under `symfony_security_auditor:` documented in
+[`docs/configuration.md`](configuration.md):
+
+- `model`, `attacker_model`, `reviewer_model`
+- `scan.excluded_dirs`, `scan.respect_gitignore`, `scan.max_file_size_kb`
+- `audit.max_iterations`, `audit.min_confidence`, `audit.reviewer_batch_size`,
+  `audit.tools_enabled`, `audit.max_tool_iterations`
+- `cache.enabled`, `cache.dir`, `cache.prompt_caching`
+
+Default values for these keys are also part of the contract. Changing a default
+is a `MAJOR` change.
+
+### CLI surface
+
+- The command name `audit:run`.
+- The `project-path` argument.
+- The `--format` (`-f`) and `--output` (`-o`) options, including the values
+  accepted by `--format` (`console`, `json`, `sarif`).
+- Exit codes (see [CLI Reference → Exit codes](configuration.md#exit-codes)):
+  - `0` — audit completed; risk level is `SAFE`, `LOW`, `MEDIUM`, or `HIGH`.
+  - `1` — risk level is `CRITICAL`, or the audit itself failed.
+
+### Output schemas
+
+- The **JSON report schema** produced by `--format=json`. Keys present today
+  remain present; new keys may be added in `MINOR` releases.
+- The **SARIF 2.1.0 output** produced by `--format=sarif`. The
+  `runs[].tool.driver.name`, `informationUri`, and `version` fields are stable.
+  The `version` is sourced dynamically from installed Composer metadata, so it
+  tracks the package version automatically.
+
+### Domain ports (extension points)
+
+All interfaces under `src/Audit/Domain/Port/` plus the documented Domain
+pipeline interfaces. Implementing one of these in your own application and
+overriding the alias in `config/services.yaml` is a supported integration path:
+
+- `LLMClientInterface`
+- `AttackerPromptBuilderInterface`, `ReviewerPromptBuilderInterface`
+- `ProjectFileScannerInterface`
+- `AttackerCacheInterface`
+- `Tool\ToolInterface`, `Tool\ToolRegistryFactoryInterface`
+- `Pipeline\PipelineInterface`, `Pipeline\StageInterface`,
+  `Pipeline\CoverageRecorderInterface`
+
+`Audit\Infrastructure\Advisory\AdvisoryDatabaseInterface` is also part of the
+public API even though it lives under `Infrastructure/` — it is documented as an
+extension point in [`docs/extending.md`](extending.md).
+
+### Domain models and exceptions
+
+- Value objects and enums under `src/Audit/Domain/Model/` — `Vulnerability`,
+  `AuditReport`, `AuditContext`, `VulnerabilitySeverity`, `VulnerabilityType`,
+  etc. Their public accessors are stable.
+- Domain exception classes — callers may rely on the exception types thrown by
+  public methods.
+
+### Programmatic entry point
+
+`Audit\Application\UseCase\RunAuditUseCase` — the documented programmatic entry
+point for driving an audit from PHP. Its single public method `execute()` is
+BC-protected.
+
+### Bundle class
+
+`VinceAmstoutz\SymfonySecurityAuditor\SymfonySecurityAuditorBundle` — referenced
+from `config/bundles.php`. Its existence and FQCN are stable.
+
+---
+
+## Internal — what is NOT covered
+
+Anything tagged `@internal` may be refactored, renamed, or removed in any
+`MINOR` release. This includes:
+
+- All concrete classes under `Audit/Application/Agent/` and
+  `Audit/Application/Pipeline/` (`AttackerAgent`, `ReviewerAgent`,
+  `AuditOrchestrator`, `VulnerabilityFactory`, `AuditPipeline`,
+  `IngestionStage`, `MappingStage`, `AuditStage`).
+- All concrete adapters under `Audit/Infrastructure/` — `SymfonyAiLLMClient`,
+  `ProjectFileScanner`, `AttackerPromptBuilder`, `ReviewerPromptBuilder`,
+  `FilesystemAttackerCache`, `NullAttackerCache`,
+  `ComposerAuditAdvisoryDatabase`, `InMemoryAdvisoryDatabase`,
+  `SymfonyProcessComposerAuditRunner`, `ReadFileTool`, `GrepTool`,
+  `ListFilesTool`, `LookupAdvisoryTool`, `SymfonyToolRegistryFactory`,
+  `ReportRenderer`.
+- Command-internal collaborators — `AuditCommandInput`, `AuditPresenter`,
+  `ReportWriter`, `AuditExitCodeResolver`.
+- Prompt template files under `src/Audit/Infrastructure/Prompt/` and
+  `src/Audit/Infrastructure/Report/Template/`.
+- Private constants and methods on any class.
+
+If you find yourself depending on an internal class, please open an issue — we
+will either promote it to public API or provide a stable replacement.
+
+---
+
+## Deprecation policy
+
+When a public-API element needs to be removed:
+
+1. It is marked as deprecated in a `MINOR` release. The deprecation appears in
+   [`CHANGELOG.md`](../CHANGELOG.md) under `### Deprecated`, with a clear
+   migration path.
+2. The deprecated element keeps working for at least the rest of the current
+   `MAJOR` cycle.
+3. Removal happens in the next `MAJOR` release at the earliest, listed under
+   `### Removed` in the changelog.
+
+Triggering `@trigger_error(..., E_USER_DEPRECATED)` at runtime is reserved for
+behavior changes that callers may notice; pure naming or signature deprecations
+are documented in the changelog only.
+
+---
+
+## LLM model identifiers
+
+Model identifiers passed to `model:`, `attacker_model:`, or `reviewer_model:`
+are free-form strings forwarded to `symfony/ai`. Their meaning, behavior,
+pricing, and availability are owned by the LLM provider, not by this bundle. If
+a provider deprecates a model, this bundle does not consider that a BC break —
+pin the identifier you want in your configuration.
+
+---
+
+## Reporting BC breaks
+
+If you find a change between two `1.x` releases that breaks one of the public
+API elements listed above, please
+[open an issue](https://github.com/vinceamstoutz/symfony-security-auditor/issues/new)
+with a minimal reproduction. It is a bug and will be fixed in a patch release.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,57 @@
+# Examples
+
+End-to-end demonstrations and configuration recipes for
+`vinceamstoutz/symfony-security-auditor`.
+
+> [!WARNING]
+>
+> Everything under [`vulnerable-app/`](vulnerable-app/) is **intentionally
+> vulnerable** and exists only to show the auditor in action. Do **not** deploy
+> any of it.
+
+## Layout
+
+| Path                                                     | What it shows                                                                                                                    |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| [`configs/ci-optimized.yaml`](configs/ci-optimized.yaml) | Split-model (large attacker, fast reviewer) for scheduled CI runs. Cache + prompt caching on. Targets accuracy at moderate cost. |
+| [`configs/cost-aware.yaml`](configs/cost-aware.yaml)     | One small model, single iteration, tools disabled. Smallest possible bill. Use when you need rough triage of a large monorepo.   |
+| [`configs/dev-fast.yaml`](configs/dev-fast.yaml)         | Local Ollama backend (no API key, no spend). Higher recall via lower `min_confidence` for exploratory development scans.         |
+| [`vulnerable-app/`](vulnerable-app/)                     | Tiny Symfony 7 skeleton with deliberate flaws (broken access control, IDOR, SQL injection by concatenation, mass assignment).    |
+
+## Reproducing each example
+
+### Configurations
+
+Drop any file from `configs/` into a real Symfony project as
+`config/packages/symfony_security_auditor.yaml` and run:
+
+```bash
+bin/console audit:run
+```
+
+Expect: a console report whose risk level depends on what your codebase actually
+contains. The split-model config is the recommended starting point for CI; the
+cost-aware config trades recall for spend; the dev-fast config keeps every call
+local.
+
+### Vulnerable demo app
+
+```bash
+cd examples/vulnerable-app
+composer install
+export ANTHROPIC_API_KEY=…           # or set up Ollama and uncomment the
+                                     # ollama: block in config/packages/ai.yaml
+bin/console audit:run
+```
+
+Expect: a non-zero exit code and a report listing roughly four findings — one
+broken-access-control on `UserController::deleteAction()`, one IDOR on
+`UserController::showAction()`, one SQL-injection on
+`SearchController::queryAction()`, and one mass-assignment on the `User` entity.
+Exact wording and severity vary by model.
+
+## Files in this directory are not shipped to Packagist
+
+`examples/` is listed in [`.gitattributes`](../.gitattributes) with
+`export-ignore`, so it is excluded from `composer require` payloads and from the
+Packagist tarball. It exists only in the Git repository as documentation.

--- a/examples/configs/ci-optimized.yaml
+++ b/examples/configs/ci-optimized.yaml
@@ -1,0 +1,24 @@
+# Scheduled CI run — split-model, cache + prompt caching enabled.
+#
+# Target: accuracy on a medium-to-large Symfony codebase, run nightly.
+# Cost:   ~$0.50–$2.00 per run on a 150-file project (varies by provider).
+# Drop in as: config/packages/symfony_security_auditor.yaml
+symfony_security_auditor:
+    # Heavyweight model finds the bugs; lightweight model filters false positives.
+    attacker_model: 'claude-opus-4-5'
+    reviewer_model: 'claude-haiku-4-5'
+
+    scan:
+        respect_gitignore: true
+        max_file_size_kb: 512
+
+    audit:
+        max_iterations: 3
+        min_confidence: 0.6     # standard precision/recall balance
+        reviewer_batch_size: 5  # fewer LLM calls, watch for cross-talk
+        tools_enabled: true     # cross-file investigation + advisory lookups
+        max_tool_iterations: 8
+
+    cache:
+        enabled: true           # skip identical chunks on rerun
+        prompt_caching: true    # ~90% discount on Anthropic

--- a/examples/configs/cost-aware.yaml
+++ b/examples/configs/cost-aware.yaml
@@ -1,0 +1,22 @@
+# Triage scan — single small model, single iteration, tools disabled.
+#
+# Target: smallest possible bill for an initial pass on a large monorepo.
+# Trade-off: lower recall, no cross-file investigation, no live CVE lookups.
+# Drop in as: config/packages/symfony_security_auditor.yaml
+symfony_security_auditor:
+    model: 'claude-haiku-4-5'
+
+    scan:
+        respect_gitignore: true
+        max_file_size_kb: 256   # skip large generated files
+
+    audit:
+        max_iterations: 1       # one pass only
+        min_confidence: 0.8     # cut everything below high-confidence
+        reviewer_batch_size: 5
+        tools_enabled: false    # disables read_file / grep / list_files / lookup_advisory
+        max_tool_iterations: 1
+
+    cache:
+        enabled: true
+        prompt_caching: true

--- a/examples/configs/dev-fast.yaml
+++ b/examples/configs/dev-fast.yaml
@@ -1,0 +1,27 @@
+# Local development scan — Ollama backend, no spend, exploratory recall.
+#
+# Pair with the following in config/packages/ai.yaml:
+#
+#   ai:
+#     platform:
+#       ollama:
+#         host_url: 'http://localhost:11434'
+#
+# Drop in as: config/packages/symfony_security_auditor.yaml
+symfony_security_auditor:
+    model: 'llama3.3'
+
+    scan:
+        respect_gitignore: true
+        max_file_size_kb: 512
+
+    audit:
+        max_iterations: 2
+        min_confidence: 0.3     # surface near-misses for human review
+        reviewer_batch_size: 1  # one finding at a time, highest precision
+        tools_enabled: true
+        max_tool_iterations: 8
+
+    cache:
+        enabled: true
+        prompt_caching: false   # Ollama ignores prompt caching anyway

--- a/examples/vulnerable-app/README.md
+++ b/examples/vulnerable-app/README.md
@@ -1,0 +1,45 @@
+# vulnerable-app
+
+> [!CAUTION]
+>
+> **This application is intentionally vulnerable.** It exists to demonstrate
+> `vinceamstoutz/symfony-security-auditor` against realistic-looking flaws. **Do
+> not deploy it. Do not import any of its source files into a real project.**
+
+A tiny Symfony 7 skeleton with deliberate flaws across four OWASP categories.
+Run the auditor against it and observe the report.
+
+## Embedded flaws
+
+| Where                                                | Flaw                                                                         | OWASP                       |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------- |
+| `src/Controller/UserController.php::deleteAction()`  | Missing `#[IsGranted]` / no `denyAccessUnlessGranted()` on a `DELETE` route. | A01 — Broken Access Control |
+| `src/Controller/UserController.php::showAction()`    | Direct object reference (`$id` from URL → `find()`) with no ownership check. | A01 — Broken Access Control |
+| `src/Controller/SearchController.php::queryAction()` | Raw `$request->get('q')` concatenated into a DQL/SQL string.                 | A03 — Injection             |
+| `src/Entity/User.php::fromRequest()`                 | Mass-assigning every request field, including `isAdmin`, into the entity.    | A04 — Insecure Design       |
+
+## Running the auditor against it
+
+```bash
+cd examples/vulnerable-app
+composer install
+export ANTHROPIC_API_KEY=…             # or configure another platform
+bin/console audit:run
+```
+
+Expected outcome:
+
+- Exit code **1** (risk level `CRITICAL` once the controller findings are
+  validated).
+- Report lists ≈ 4 findings, one per row of the table above. Severity and
+  wording vary by model.
+
+To try a different provider, edit
+[`config/packages/ai.yaml`](config/packages/ai.yaml).
+
+## What this app does **not** demonstrate
+
+It is a toy. There is no database, no real router beyond what's needed to make
+the controllers look plausible, and no tests. The flaws are kept inline and
+obvious so that a human can verify the auditor's output by eye. For real usage
+patterns, see the [`configs/`](../configs/) recipes.

--- a/examples/vulnerable-app/composer.json
+++ b/examples/vulnerable-app/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "vinceamstoutz/symfony-security-auditor-example-vulnerable-app",
+    "description": "Intentionally vulnerable Symfony skeleton for demonstrating symfony-security-auditor. DO NOT DEPLOY.",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php": ">=8.3",
+        "symfony/ai-anthropic-platform": "^0.9",
+        "symfony/framework-bundle": "^7.4 || ^8.0",
+        "vinceamstoutz/symfony-security-auditor": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/examples/vulnerable-app/config/bundles.php
+++ b/examples/vulnerable-app/config/bundles.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Symfony\AI\AiBundle\AiBundle::class => ['all' => true],
+    VinceAmstoutz\SymfonySecurityAuditor\SymfonySecurityAuditorBundle::class => ['dev' => true, 'test' => true],
+];

--- a/examples/vulnerable-app/config/packages/ai.yaml
+++ b/examples/vulnerable-app/config/packages/ai.yaml
@@ -1,0 +1,9 @@
+ai:
+    platform:
+        anthropic:
+            api_key: '%env(ANTHROPIC_API_KEY)%'
+        # Swap to any other platform without touching PHP.
+        # ollama:
+        #     host_url: 'http://localhost:11434'
+        # openai:
+        #     api_key: '%env(OPENAI_API_KEY)%'

--- a/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
+++ b/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
@@ -1,0 +1,9 @@
+symfony_security_auditor:
+    attacker_model: 'claude-opus-4-5'
+    reviewer_model: 'claude-haiku-4-5'
+    audit:
+        min_confidence: 0.6
+        tools_enabled: true
+    cache:
+        enabled: true
+        prompt_caching: true

--- a/examples/vulnerable-app/src/Controller/SearchController.php
+++ b/examples/vulnerable-app/src/Controller/SearchController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+// INTENTIONALLY VULNERABLE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+final class SearchController extends AbstractController
+{
+    public function __construct(private readonly Connection $connection) {}
+
+    // VULN: SQL injection — request input concatenated directly into the
+    // query. A real fix uses a parameterized query (executeQuery + bound
+    // params) or the QueryBuilder's setParameter().
+    #[Route('/search', name: 'search_query', methods: ['GET'])]
+    public function queryAction(Request $request): JsonResponse
+    {
+        $term = (string) $request->query->get('q', '');
+        $sql = "SELECT id, name FROM users WHERE name LIKE '%".$term."%' ORDER BY id";
+
+        $rows = $this->connection->fetchAllAssociative($sql);
+
+        return new JsonResponse(['results' => $rows]);
+    }
+}

--- a/examples/vulnerable-app/src/Controller/UserController.php
+++ b/examples/vulnerable-app/src/Controller/UserController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+// INTENTIONALLY VULNERABLE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+final class UserController extends AbstractController
+{
+    // VULN: Direct Object Reference — no ownership check between the
+    // authenticated user and the $id pulled straight from the URL.
+    #[Route('/users/{id}', name: 'user_show', methods: ['GET'])]
+    public function showAction(int $id, EntityManagerInterface $entityManager): JsonResponse
+    {
+        $user = $entityManager->getRepository(User::class)->find($id);
+        if (null === $user) {
+            return new JsonResponse(['error' => 'not found'], 404);
+        }
+
+        return new JsonResponse($user->toArray());
+    }
+
+    // VULN: Broken Access Control — DELETE endpoint with no #[IsGranted],
+    // no denyAccessUnlessGranted(), and no Voter. Any authenticated user
+    // can delete anyone.
+    #[Route('/users/{id}', name: 'user_delete', methods: ['DELETE'])]
+    public function deleteAction(int $id, EntityManagerInterface $entityManager): JsonResponse
+    {
+        $user = $entityManager->getRepository(User::class)->find($id);
+        if (null === $user) {
+            return new JsonResponse(['error' => 'not found'], 404);
+        }
+
+        $entityManager->remove($user);
+        $entityManager->flush();
+
+        return new JsonResponse(['deleted' => $id]);
+    }
+
+    #[Route('/users', name: 'user_create', methods: ['POST'])]
+    public function createAction(Request $request, EntityManagerInterface $entityManager): JsonResponse
+    {
+        // VULN: mass assignment — see App\Entity\User::fromRequest.
+        $payload = json_decode((string) $request->getContent(), true) ?? [];
+        $user = User::fromRequest($payload);
+
+        $entityManager->persist($user);
+        $entityManager->flush();
+
+        return new JsonResponse($user->toArray(), 201);
+    }
+}

--- a/examples/vulnerable-app/src/Entity/User.php
+++ b/examples/vulnerable-app/src/Entity/User.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+// INTENTIONALLY VULNERABLE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+final class User
+{
+    public ?int $id = null;
+
+    public string $name = '';
+
+    public string $email = '';
+
+    public bool $isAdmin = false;
+
+    /**
+     * VULN: mass assignment — blindly copies every request field, including
+     * `isAdmin`, into the entity. The fix is an explicit allow-list (Symfony
+     * Form with `allow_extra_fields: false` and only the safe fields, or a
+     * dedicated input DTO).
+     *
+     * @param array<string, mixed> $payload
+     */
+    public static function fromRequest(array $payload): self
+    {
+        $user = new self();
+        foreach ($payload as $field => $value) {
+            if (property_exists($user, $field)) {
+                $user->{$field} = $value;
+            }
+        }
+
+        return $user;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'isAdmin' => $this->isAdmin,
+        ];
+    }
+}

--- a/src/Audit/Application/Agent/AttackerAgent.php
+++ b/src/Audit/Application/Agent/AttackerAgent.php
@@ -26,6 +26,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistryFactoryInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AttackerAgent implements AttackerAgentInterface
 {
     private const int CHUNK_SIZE = 10;

--- a/src/Audit/Application/Agent/AuditOrchestrator.php
+++ b/src/Audit/Application/Agent/AuditOrchestrator.php
@@ -18,6 +18,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditOrchestrator implements AuditOrchestratorInterface
 {
     public const int DEFAULT_MAX_ITERATIONS = 3;

--- a/src/Audit/Application/Agent/ReviewerAgent.php
+++ b/src/Audit/Application/Agent/ReviewerAgent.php
@@ -24,6 +24,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\CoverageRecorderI
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ReviewerPromptBuilderInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class ReviewerAgent implements ReviewerAgentInterface
 {
     public const int DEFAULT_BATCH_SIZE = 1;

--- a/src/Audit/Application/Agent/VulnerabilityFactory.php
+++ b/src/Audit/Application/Agent/VulnerabilityFactory.php
@@ -19,6 +19,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class VulnerabilityFactory
 {
     public function __construct(

--- a/src/Audit/Application/Pipeline/AuditPipeline.php
+++ b/src/Audit/Application/Pipeline/AuditPipeline.php
@@ -18,6 +18,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\PipelineInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\StageInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditPipeline implements PipelineInterface
 {
     /** @var list<StageInterface> */

--- a/src/Audit/Application/Pipeline/Stage/AuditStage.php
+++ b/src/Audit/Application/Pipeline/Stage/AuditStage.php
@@ -19,6 +19,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\StageInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditStage implements StageInterface
 {
     public function __construct(

--- a/src/Audit/Application/Pipeline/Stage/IngestionStage.php
+++ b/src/Audit/Application/Pipeline/Stage/IngestionStage.php
@@ -19,6 +19,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\StageInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProjectFileScannerInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class IngestionStage implements StageInterface
 {
     public function __construct(

--- a/src/Audit/Application/Pipeline/Stage/MappingStage.php
+++ b/src/Audit/Application/Pipeline/Stage/MappingStage.php
@@ -19,6 +19,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\StageInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class MappingStage implements StageInterface
 {
     public function __construct(

--- a/src/Audit/Infrastructure/Advisory/ComposerAuditAdvisoryDatabase.php
+++ b/src/Audit/Infrastructure/Advisory/ComposerAuditAdvisoryDatabase.php
@@ -29,6 +29,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\Exception
  * gracefully to an empty database — `lookup()` always returns a list, never
  * propagates an exception, so the orchestrator and the tool layer stay
  * resilient.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class ComposerAuditAdvisoryDatabase implements AdvisoryDatabaseInterface
 {

--- a/src/Audit/Infrastructure/Advisory/InMemoryAdvisoryDatabase.php
+++ b/src/Audit/Infrastructure/Advisory/InMemoryAdvisoryDatabase.php
@@ -22,6 +22,8 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory;
  * Returns every advisory registered for the package — version-constraint filtering
  * is delegated to the LLM, which already has the installed version and the
  * advisory's `affected_versions` text in front of it.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class InMemoryAdvisoryDatabase implements AdvisoryDatabaseInterface
 {

--- a/src/Audit/Infrastructure/Advisory/SymfonyProcessComposerAuditRunner.php
+++ b/src/Audit/Infrastructure/Advisory/SymfonyProcessComposerAuditRunner.php
@@ -23,6 +23,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\Exception
  * Runs `composer audit --format=json --locked` via symfony/process. Composer's
  * exit code is non-zero whenever advisories are found, so we only treat a failure
  * as fatal when stdout is empty (the JSON is the contract).
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class SymfonyProcessComposerAuditRunner implements ComposerAuditRunnerInterface
 {

--- a/src/Audit/Infrastructure/Cache/FilesystemAttackerCache.php
+++ b/src/Audit/Infrastructure/Cache/FilesystemAttackerCache.php
@@ -22,6 +22,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerCacheInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\Exception\InvalidCacheConfigurationException;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class FilesystemAttackerCache implements AttackerCacheInterface
 {
     public function __construct(

--- a/src/Audit/Infrastructure/Cache/NullAttackerCache.php
+++ b/src/Audit/Infrastructure/Cache/NullAttackerCache.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache;
 
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerCacheInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class NullAttackerCache implements AttackerCacheInterface
 {
     public function get(array $chunk): ?array

--- a/src/Audit/Infrastructure/FileSystem/ProjectFileScanner.php
+++ b/src/Audit/Infrastructure/FileSystem/ProjectFileScanner.php
@@ -22,6 +22,7 @@ use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProjectFileScannerInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class ProjectFileScanner implements ProjectFileScannerInterface
 {
     /** @var list<string> */

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -40,6 +40,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
  *
  * Token counts are set to zero here. For full token tracking, register a
  * Symfony\AI\Platform\Event\ResultEvent listener and read the token usage metadata.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class SymfonyAiLLMClient implements LLMClientInterface
 {

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -17,6 +17,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerPromptBuilderInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInterface
 {
     /**

--- a/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
@@ -16,6 +16,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ReviewerPromptBuilderInterface;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class ReviewerPromptBuilder implements ReviewerPromptBuilderInterface
 {
     public function buildSystemPrompt(): string

--- a/src/Audit/Infrastructure/Report/ReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/ReportRenderer.php
@@ -13,14 +13,18 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report;
 
+use Composer\InstalledVersions;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class ReportRenderer
 {
     public const string PACKAGE_NAME = 'vinceamstoutz/symfony-security-auditor';
+
+    public const string UNKNOWN_VERSION = 'unknown';
 
     private const string TEMPLATE_DIR = __DIR__.'/Template';
 
@@ -91,7 +95,7 @@ final readonly class ReportRenderer
                     'tool' => [
                         'driver' => [
                             'name' => 'Symfony Security Auditor',
-                            'version' => '1.0.0',
+                            'version' => $this->packageVersion(),
                             'informationUri' => 'https://github.com/vinceamstoutz/symfony-security-auditor',
                             'rules' => $rules,
                         ],
@@ -160,6 +164,11 @@ final readonly class ReportRenderer
     private function loadTemplate(string $name): string
     {
         return rtrim((string) file_get_contents(self::TEMPLATE_DIR.'/'.$name), "\n");
+    }
+
+    private function packageVersion(): string
+    {
+        return InstalledVersions::getPrettyVersion(self::PACKAGE_NAME) ?? self::UNKNOWN_VERSION;
     }
 
     private function sarifLevel(VulnerabilitySeverity $vulnerabilitySeverity): string

--- a/src/Audit/Infrastructure/Tool/GrepTool.php
+++ b/src/Audit/Infrastructure/Tool/GrepTool.php
@@ -20,6 +20,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
 /**
  * Case-sensitive substring search across the project files scanned by the
  * ingestion stage. Returns up to MAX_MATCHES matches as path:line lines.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class GrepTool implements ToolInterface
 {

--- a/src/Audit/Infrastructure/Tool/ListFilesTool.php
+++ b/src/Audit/Infrastructure/Tool/ListFilesTool.php
@@ -21,6 +21,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
  * Lists project files, optionally filtered by ProjectFile::type(). Lets the
  * attacker survey the project topology without consuming context for the actual
  * file contents.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class ListFilesTool implements ToolInterface
 {

--- a/src/Audit/Infrastructure/Tool/LookupAdvisoryTool.php
+++ b/src/Audit/Infrastructure/Tool/LookupAdvisoryTool.php
@@ -21,6 +21,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AdvisoryD
  * Bridges the security advisory database to the LLM's tool-calling protocol.
  * The LLM passes a Composer package name and an installed version; the database
  * adapter returns matching CVE entries (or an "no advisories found" message).
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class LookupAdvisoryTool implements ToolInterface
 {

--- a/src/Audit/Infrastructure/Tool/ReadFileTool.php
+++ b/src/Audit/Infrastructure/Tool/ReadFileTool.php
@@ -21,6 +21,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
  * Returns the textual content of a project file by its relative path. The set
  * of readable files is fixed at construction time to the project files scanned
  * by IngestionStage — the LLM cannot escape outside the audited project tree.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class ReadFileTool implements ToolInterface
 {

--- a/src/Audit/Infrastructure/Tool/SymfonyToolRegistryFactory.php
+++ b/src/Audit/Infrastructure/Tool/SymfonyToolRegistryFactory.php
@@ -22,6 +22,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AdvisoryD
  * Builds a fresh ToolRegistry pre-loaded with the project's scanned files, so
  * tools like read_file / grep / list_files can answer the LLM's questions
  * without re-walking the filesystem.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class SymfonyToolRegistryFactory implements ToolRegistryFactoryInterface
 {

--- a/src/Command/AuditCommand.php
+++ b/src/Command/AuditCommand.php
@@ -23,6 +23,30 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCa
 #[AsCommand(
     name: 'audit:run',
     description: 'Run AI-powered multi-agent security audit on a Symfony project',
+    help: <<<'HELP'
+        The <info>%command.name%</info> command runs a multi-agent LLM security audit against a Symfony project.
+
+        Output formats (<info>--format</info>, <info>-f</info>):
+          <info>console</info>  human-readable summary (default)
+          <info>json</info>     machine-readable report
+          <info>sarif</info>    SARIF 2.1.0 for GitHub Code Scanning / GitLab Security Dashboard
+
+        Use <info>--output</info> (<info>-o</info>) to write the report to a file:
+          <info>%command.full_name% . --format=sarif --output=report.sarif</info>
+
+        Exit codes:
+          <info>0</info>  audit completed; risk level is SAFE, LOW, MEDIUM, or HIGH
+          <info>1</info>  audit completed with CRITICAL risk level, or the audit itself failed
+
+        Cost & duration: a typical Symfony project (~150 files) takes minutes, not seconds,
+        and costs a few cents to a few dollars depending on the selected model. Configure
+        via <info>config/packages/symfony_security_auditor.yaml</info>.
+
+        Documentation:
+          Configuration : <info>docs/configuration.md</info>
+          CI integration: <info>docs/ci.md</info>
+          Versioning    : <info>docs/versioning.md</info>
+        HELP,
 )]
 final readonly class AuditCommand
 {

--- a/src/Command/AuditCommandInput.php
+++ b/src/Command/AuditCommandInput.php
@@ -17,9 +17,13 @@ use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Option;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\WorkingDirectoryUnavailableException;
 
-// Symfony Console MapInput reflects class properties and requires public mutable fields
-// with property-level defaults; promoted readonly ctor params are invisible to its reflection.
-// Treated as a context carrier per .claude/rules/php-classes.md.
+/**
+ * Symfony Console MapInput reflects class properties and requires public mutable fields
+ * with property-level defaults; promoted readonly ctor params are invisible to its reflection.
+ * Treated as a context carrier per .claude/rules/php-classes.md.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
 final class AuditCommandInput
 {
     #[Argument(description: 'Path to the Symfony project to audit. Defaults to the current working directory.')]

--- a/src/Command/AuditExitCodeResolver.php
+++ b/src/Command/AuditExitCodeResolver.php
@@ -16,6 +16,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 use Symfony\Component\Console\Command\Command;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditExitCodeResolver implements AuditExitCodeResolverInterface
 {
     public function resolve(AuditReport $auditReport): int

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditPresenter implements AuditPresenterInterface
 {
     public function header(SymfonyStyle $symfonyStyle, string $projectPath): void

--- a/src/Command/ReportWriter.php
+++ b/src/Command/ReportWriter.php
@@ -14,12 +14,17 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRenderer;
 
+/** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class ReportWriter implements ReportWriterInterface
 {
-    public function __construct(private ReportRenderer $reportRenderer) {}
+    public function __construct(
+        private ReportRenderer $reportRenderer,
+        private Filesystem $filesystem,
+    ) {}
 
     public function write(AuditReport $auditReport, OutputFormat $outputFormat, ?string $outputFile, SymfonyStyle $symfonyStyle): void
     {
@@ -30,7 +35,7 @@ final readonly class ReportWriter implements ReportWriterInterface
         };
 
         if (null !== $outputFile) {
-            file_put_contents($outputFile, $content);
+            $this->filesystem->dumpFile($outputFile, $content);
             $symfonyStyle->success(\sprintf('Report saved to %s', $outputFile));
         } else {
             $symfonyStyle->writeln($content);

--- a/src/SymfonySecurityAuditorBundle.php
+++ b/src/SymfonySecurityAuditorBundle.php
@@ -39,7 +39,7 @@ final class SymfonySecurityAuditorBundle extends AbstractBundle
         $definition->rootNode()
             ->children()
                 ->scalarNode('model')
-                    ->defaultValue('gpt-4o')
+                    ->defaultValue('claude-opus-4-5')
                     ->info('Model name for both Attacker and Reviewer. Must be supported by the configured platform.')
                 ->end()
                 ->scalarNode('attacker_model')

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestrator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
@@ -321,7 +322,7 @@ final class AuditCommandEndToEndTest extends TestCase
 
         $auditCommand = new AuditCommand(
             new RunAuditUseCase($auditPipeline, new NullLogger()),
-            new ReportWriter(new ReportRenderer()),
+            new ReportWriter(new ReportRenderer(), new Filesystem()),
             new AuditExitCodeResolver(),
             new AuditPresenter(),
         );

--- a/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
+++ b/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
@@ -52,12 +52,12 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
         self::assertInstanceOf(AuditCommand::class, $this->getPrivateService($kernel, AuditCommand::class));
     }
 
-    public function test_bundle_default_model_is_gpt_4o(): void
+    public function test_bundle_default_model_is_claude_opus_4_5(): void
     {
         $kernel = $this->boot([]);
 
-        self::assertSame('gpt-4o', $kernel->getContainer()->getParameter('symfony_security_auditor.attacker_model'));
-        self::assertSame('gpt-4o', $kernel->getContainer()->getParameter('symfony_security_auditor.reviewer_model'));
+        self::assertSame('claude-opus-4-5', $kernel->getContainer()->getParameter('symfony_security_auditor.attacker_model'));
+        self::assertSame('claude-opus-4-5', $kernel->getContainer()->getParameter('symfony_security_auditor.reviewer_model'));
     }
 
     public function test_bundle_uses_shared_model_for_both_agents_when_split_overrides_omitted(): void

--- a/tests/Phpunit/Unit/Command/ReportWriterTest.php
+++ b/tests/Phpunit/Unit/Command/ReportWriterTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRenderer;
@@ -27,24 +28,21 @@ final class ReportWriterTest extends TestCase
 {
     private ReportWriter $reportWriter;
 
+    private Filesystem $filesystem;
+
     private string $tmpDir;
 
     protected function setUp(): void
     {
-        $this->reportWriter = new ReportWriter(new ReportRenderer());
+        $this->filesystem = new Filesystem();
+        $this->reportWriter = new ReportWriter(new ReportRenderer(), $this->filesystem);
         $this->tmpDir = sys_get_temp_dir().'/report_writer_test_'.uniqid('', true);
-        mkdir($this->tmpDir, 0o777, true);
+        $this->filesystem->mkdir($this->tmpDir);
     }
 
     protected function tearDown(): void
     {
-        foreach (glob($this->tmpDir.'/*') ?: [] as $path) {
-            if (is_file($path)) {
-                unlink($path);
-            }
-        }
-
-        rmdir($this->tmpDir);
+        $this->filesystem->remove($this->tmpDir);
     }
 
     public function test_writing_to_file_announces_save_path_via_success_message(): void
@@ -84,6 +82,16 @@ final class ReportWriterTest extends TestCase
         $display = $bufferedOutput->fetch();
         self::assertStringContainsString('SYMFONY LLM AUDIT REPORT', $display);
         self::assertStringNotContainsString('Report saved to', $display);
+    }
+
+    public function test_writing_to_file_creates_missing_parent_directories(): void
+    {
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), new BufferedOutput());
+        $outputFile = $this->tmpDir.'/nested/sub/dir/report.json';
+
+        $this->reportWriter->write($this->makeReport(), OutputFormat::Json, $outputFile, $symfonyStyle);
+
+        self::assertFileExists($outputFile);
     }
 
     private function makeReport(): AuditReport

--- a/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Report;
 
+use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
@@ -198,11 +199,19 @@ final class ReportRendererTest extends TestCase
         self::assertSame('Symfony Security Auditor', $decoded['runs'][0]['tool']['driver']['name']);
     }
 
-    public function test_render_sarif_driver_version_is_1_0_0(): void
+    public function test_render_sarif_driver_version_matches_installed_package_version(): void
+    {
+        $decoded = $this->decodeSarif($this->makeReport());
+        $expected = InstalledVersions::getPrettyVersion(ReportRenderer::PACKAGE_NAME) ?? ReportRenderer::UNKNOWN_VERSION;
+
+        self::assertSame($expected, $decoded['runs'][0]['tool']['driver']['version']);
+    }
+
+    public function test_render_sarif_driver_version_is_non_empty(): void
     {
         $decoded = $this->decodeSarif($this->makeReport());
 
-        self::assertSame('1.0.0', $decoded['runs'][0]['tool']['driver']['version']);
+        self::assertNotSame('', $decoded['runs'][0]['tool']['driver']['version']);
     }
 
     public function test_render_sarif_runs_contains_tool_and_results_keys(): void


### PR DESCRIPTION
The SARIF `runs[].tool.driver.version` was hardcoded to `'1.0.0'` and would
silently drift after every release, misreporting the tool version in
GitHub Code Scanning and GitLab Security Dashboard ingests.

Resolve it dynamically through `Composer\InstalledVersions::getPrettyVersion`
keyed off the package name (the existing `ReportRenderer::PACKAGE_NAME`
constant), with `'unknown'` as a defensive fallback. Adds
`composer-runtime-api: ^2.0` to `require` to make the dependency explicit.