### PR TITLE
ci: allow `scan` scope in commitlint config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ Format: `<type>[optional scope]: <description>` —
 | `perf`     | Performance improvement |
 
 Common scopes: `agent`, `pipeline`, `domain`, `llm`, `command`, `bundle`,
-`deps`, `ci`. Breaking changes: `feat!:` with `BREAKING CHANGE:` footer.
+`scan`, `deps`, `ci`. Breaking changes: `feat!:` with `BREAKING CHANGE:` footer.
 
 ## CI Pipeline
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -44,6 +44,7 @@ export default {
                 'tool',
                 'cache',
                 'report',
+                'scan',
             ],
         ],
         'scope-empty': [0],


### PR DESCRIPTION
The `feat(scan):` squash-merged onto main in #9 used a scope that wasn't
in the commitlint allow-list, so the Commit Lint job failed on that push.
`scan` is a load-bearing concept in the codebase (ProjectFileScanner,
`scan.secret_scrubbing.*` config), and is the natural top-level scope for
the credential-scrubbing slice — adding it to the allow-list lines up
config with prior art rather than retroactively rewriting main.

Also bring CLAUDE.md's "Common scopes" line in sync, since the commitlint
config comment promises the two lists mirror each other.