### PR TITLE
test(agent): kill escaped MethodCallRemoval mutant in ReviewerAgent rejection path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-05-24
+
+### Fixed
+
+- Mutation gate now kills the `MethodCallRemoval` mutant on the
+  `logReviewDecision()` call inside the rejected-finding early-return branch of
+  `ReviewerAgent::applyReview()`. Existing tests covered the accepted /
+  severity-elevated paths but left the rejection-path debug log unasserted, so
+  removing the call escaped Infection — added a targeted unit test that
+  exercises a rejected review and asserts the `'Vulnerability reviewed'` debug
+  entry is emitted with `accepted => false`. No production code change.
+
 ## [1.1.0] — 2026-05-24
 
 ### Added
@@ -240,6 +252,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.1.1]:
+  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.1.1
 [1.1.0]:
   https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.1.0
 [1.0.0]:

--- a/tests/Phpunit/Unit/Application/Agent/ReviewerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/ReviewerAgentTest.php
@@ -576,6 +576,50 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    public function test_it_logs_debug_review_decision_when_finding_is_rejected(): void
+    {
+        // Covers MethodCallRemoval on the logReviewDecision call inside the
+        // `if (!$accepted)` early-return branch in applyReview(). Without an
+        // assertion on the rejected-path debug log, removing that call escapes.
+        $vulnerability = $this->makeVulnerability();
+        $debugLogs = [];
+
+        $logger = self::createStub(LoggerInterface::class);
+        $logger->method('info');
+        $logger->method('debug')->willReturnCallback(
+            static function (string $msg, array $ctx = []) use (&$debugLogs): void {
+                $debugLogs[] = [$msg, $ctx];
+            },
+        );
+
+        $this->llmClient
+            ->method('complete')
+            ->willReturn(LLMResponse::create(
+                (string) json_encode(['accepted' => false, 'reviewer_notes' => 'false positive']),
+                10, 10, 'claude', 'end_turn',
+            ));
+
+        $reviewerAgent = new ReviewerAgent(
+            llmClient: $this->llmClient,
+            reviewerPromptBuilder: new ReviewerPromptBuilder(),
+            logger: $logger,
+        );
+
+        $reviewerAgent->review([$vulnerability], [], new NullCoverageRecorder());
+
+        $reviewedLogs = array_values(array_filter(
+            $debugLogs,
+            static fn (array $entry): bool => 'Vulnerability reviewed' === $entry[0],
+        ));
+
+        self::assertCount(1, $reviewedLogs);
+        self::assertSame([
+            'id' => $vulnerability->id(),
+            'accepted' => false,
+            'notes' => 'false positive',
+        ], $reviewedLogs[0][1]);
+    }
+
     public function test_it_logs_debug_review_decision_when_severity_is_elevated(): void
     {
         // Covers MethodCallRemoval on the logReviewDecision call after severity elevation


### PR DESCRIPTION
Adds a unit test asserting that logReviewDecision() emits its
"Vulnerability reviewed" debug entry when applyReview() takes the
!accepted early-return branch. The accepted / severity-elevated paths
already had this assertion; the rejection path didn't, so Infection's
MethodCallRemoval on src/Audit/Application/Agent/ReviewerAgent.php:280
escaped on main and dropped Covered MSI below 100%.

Pure test addition — no production code change.

Release: v1.1.1.