### PR TITLE
fix(llm): omit temperature option unless explicitly set

### DIFF
--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -48,7 +48,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RateLimit\Retr
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class SymfonyAiLLMClient implements LLMClientInterface
 {
-    public const float DEFAULT_TEMPERATURE = 0.0;
+    public const ?float DEFAULT_TEMPERATURE = null;
 
     public const bool DEFAULT_PROMPT_CACHING = false;
 
@@ -58,7 +58,7 @@ final readonly class SymfonyAiLLMClient implements LLMClientInterface
         private PlatformInterface $platform,
         private string $model,
         private LoggerInterface $logger,
-        private float $temperature = self::DEFAULT_TEMPERATURE,
+        private ?float $temperature = self::DEFAULT_TEMPERATURE,
         private bool $promptCaching = self::DEFAULT_PROMPT_CACHING,
         private ?TokenUsageRecorder $tokenUsageRecorder = null,
         private ?RetryPolicy $retryPolicy = null,
@@ -337,7 +337,15 @@ final readonly class SymfonyAiLLMClient implements LLMClientInterface
      */
     private function baseOptions(): array
     {
-        $options = ['temperature' => $this->temperature];
+        // `temperature` is rejected by some newer Claude models (e.g.
+        // extended-thinking variants of Sonnet 4.6). Send only when the
+        // operator explicitly opted in; otherwise let the provider apply
+        // its own default.
+        $options = [];
+        if (null !== $this->temperature) {
+            $options['temperature'] = $this->temperature;
+        }
+
         if ($this->promptCaching) {
             $options['cache_control'] = ['type' => 'ephemeral'];
         }

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -144,6 +144,28 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('cache_control', $invocationOptionsCapture->options);
     }
 
+    public function test_complete_omits_temperature_when_left_at_default(): void
+    {
+        // Some newer Claude models (e.g. extended-thinking variants of Sonnet 4.6)
+        // reject the `temperature` option. With no explicit opt-in, it must not
+        // appear in the options bag so the provider applies its own default.
+        $invocationOptionsCapture = new InvocationOptionsCapture();
+        $inMemoryPlatform = new InMemoryPlatform(
+            /** @param array<string, mixed> $options */
+            static function (object $model, mixed $input, array $options) use ($invocationOptionsCapture): TextResult {
+                $invocationOptionsCapture->options ??= $options;
+
+                return new TextResult('out');
+            },
+        );
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient($inMemoryPlatform, 'test-model', new NullLogger());
+        $symfonyAiLLMClient->complete('s', 'u');
+
+        self::assertNotNull($invocationOptionsCapture->options);
+        self::assertArrayNotHasKey('temperature', $invocationOptionsCapture->options);
+    }
+
     public function test_complete_passes_prompt_caching_flag_when_enabled(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();


### PR DESCRIPTION
Some newer Claude models (e.g. extended-thinking variants of Sonnet 4.6)
reject `temperature` outright, returning a 400 that surfaces as
NonTransientLLMFailureException and aborts the audit before any chunk is
analysed.

Default DEFAULT_TEMPERATURE to null and skip the option in baseOptions()
when the operator did not opt in. Operators that still want a specific
temperature can either pass it to the constructor or set it through the
model URI options (`model: 'claude-opus-4-7?temperature=0.2'`), which is
unchanged.