### PR TITLE
test(llm): kill UnwrapTrim and ArrayOneItem mutants in LLM seam

### DIFF
--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -204,6 +204,39 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(['type' => 'json_object'], $invocationOptionsCapture->options['response_format']);
     }
 
+    public function test_complete_passes_all_base_options_together_when_multiple_flags_enabled(): void
+    {
+        // With each option exercised individually the base-options array carries
+        // at most one entry, so an ArrayOneItem mutator on the return is silently
+        // absorbed (single-item slices equal the original). Enabling temperature
+        // + prompt caching + provider JSON mode together makes the full array
+        // observable: the mutant would drop two of the three keys.
+        $invocationOptionsCapture = new InvocationOptionsCapture();
+        $inMemoryPlatform = new InMemoryPlatform(
+            /** @param array<string, mixed> $options */
+            static function (object $model, mixed $input, array $options) use ($invocationOptionsCapture): TextResult {
+                $invocationOptionsCapture->options ??= $options;
+
+                return new TextResult('out');
+            },
+        );
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(
+            $inMemoryPlatform,
+            'test-model',
+            new NullLogger(),
+            temperature: 0.5,
+            promptCaching: true,
+            providerJsonMode: true,
+        );
+        $symfonyAiLLMClient->complete('s', 'u');
+
+        self::assertNotNull($invocationOptionsCapture->options);
+        self::assertSame(0.5, $invocationOptionsCapture->options['temperature']);
+        self::assertSame(['type' => 'ephemeral'], $invocationOptionsCapture->options['cache_control']);
+        self::assertSame(['type' => 'json_object'], $invocationOptionsCapture->options['response_format']);
+    }
+
     public function test_complete_omits_response_format_when_provider_json_mode_disabled(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();

--- a/tests/Phpunit/Unit/Infrastructure/LLM/LLMResponseTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/LLMResponseTest.php
@@ -225,4 +225,19 @@ final class LLMResponseTest extends TestCase
 
         self::assertSame([1, 2, 3], $llmResponse->parseJson());
     }
+
+    public function test_parse_json_trims_non_json_whitespace_around_scalar_to_reach_array_guard(): void
+    {
+        // Vertical tab (\x0b) is removed by `trim()` but rejected by `json_decode`
+        // as a control character — and unlike an array payload, a scalar offers
+        // no `[`/`{` opener for the balanced-block extractor to recover from.
+        // With `trim()`: the inner `"scalar"` decodes and fails the `!is_array`
+        // guard → RuntimeException. Without `trim()` (UnwrapTrim mutant): the
+        // first decode throws on `\x0b`, the extractor finds no opener, and the
+        // original JsonException is rethrown — pins the `trim()` call.
+        $llmResponse = LLMResponse::create("\x0b\"scalar\"\x0b", 10, 5, 'claude', 'end_turn');
+
+        $this->expectException(RuntimeException::class);
+        $llmResponse->parseJson();
+    }
 }


### PR DESCRIPTION
CI reported two escaped mutants after #65:

- `LLMResponse::parseJson` — `UnwrapTrim` on `trim($content)` survived
  because the balanced-block extractor recovers from `\x0b`/`\x00` around
  an array payload even when leading whitespace breaks `json_decode`. Add
  a scalar-payload case so the fallback has no `[`/`{` opener to lean on:
  with `trim()`, the inner string decodes and `!is_array` raises a
  `RuntimeException`; without `trim()`, the original `JsonException` is
  rethrown — the expectation distinguishes them.

- `SymfonyAiLLMClient::baseOptions` — `ArrayOneItem` on the return
  survived because each existing test exercises a single option in
  isolation (single-item slices equal the original). Add a test that
  enables `temperature`, `promptCaching`, and `providerJsonMode` together
  and asserts all three keys reach the platform, exposing the slice.