### PR TITLE
fix(infrastructure): skip Symfony env refs in inline secret scrubber

### DIFF
--- a/src/Audit/Infrastructure/FileSystem/RegexSecretScrubber.php
+++ b/src/Audit/Infrastructure/FileSystem/RegexSecretScrubber.php
@@ -73,18 +73,15 @@ final readonly class RegexSecretScrubber implements SecretScrubberInterface
     public function scrub(string $content): string
     {
         foreach ($this->patterns as $label => $pattern) {
-            $replacement = match ($label) {
-                'env_assignment' => '$1=***REDACTED:'.$label.'***',
-                'inline_assignment' => '$1***REDACTED:'.$label.'***$3',
-                default => '***REDACTED:'.$label.'***',
-            };
-
             // `@` silences the PCRE warning so a runaway user-supplied pattern
             // hitting the backtrack limit returns null cleanly instead of
             // escalating to a PHPUnit fail-on-warning. The null branch lets
             // the scrub `continue` with the next pattern instead of aborting
             // the whole pipeline.
-            $result = @preg_replace($pattern, $replacement, $content);
+            $result = 'inline_assignment' === $label
+                ? @preg_replace_callback($pattern, $this->redactInlineAssignment(...), $content)
+                : @preg_replace($pattern, $this->replacementFor($label), $content);
+
             if (null === $result) {
                 continue;
             }
@@ -93,6 +90,39 @@ final readonly class RegexSecretScrubber implements SecretScrubberInterface
         }
 
         return $content;
+    }
+
+    private function replacementFor(string $label): string
+    {
+        return match ($label) {
+            'env_assignment' => '$1=***REDACTED:'.$label.'***',
+            default => '***REDACTED:'.$label.'***',
+        };
+    }
+
+    /**
+     * @param array<int|string, string> $match
+     */
+    private function redactInlineAssignment(array $match): string
+    {
+        if ($this->isConfigPlaceholder($match[2])) {
+            return $match[0];
+        }
+
+        return $match[1].'***REDACTED:inline_assignment***'.$match[3];
+    }
+
+    /**
+     * Detects Symfony parameter references (`%env(FOO)%`, `%kernel.secret%`) and shell-style
+     * env expansions (`$FOO`, `${FOO}`). These are configuration indirections, not committed
+     * secrets — redacting them produces a false positive when an LLM sees the placeholder
+     * marker and reports an "inline credential" vulnerability for code that follows the
+     * recommended Symfony secrets pattern.
+     */
+    private function isConfigPlaceholder(string $value): bool
+    {
+        return 1 === preg_match('/\A%[^%\s]+%\z/', $value)
+            || 1 === preg_match('/\A\$\{?[A-Za-z_]\w*\}?\z/', $value);
     }
 
     private function validatePattern(string $pattern): ?string

--- a/tests/Phpunit/Unit/Infrastructure/FileSystem/RegexSecretScrubberTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/FileSystem/RegexSecretScrubberTest.php
@@ -105,6 +105,26 @@ final class RegexSecretScrubberTest extends TestCase
         ];
     }
 
+    #[DataProvider('symfonyPlaceholderCases')]
+    public function test_it_leaves_symfony_placeholder_values_unmodified(string $input): void
+    {
+        $output = $this->regexSecretScrubber->scrub($input);
+
+        self::assertSame($input, $output);
+        self::assertStringNotContainsString('***REDACTED:inline_assignment***', $output);
+    }
+
+    /** @return iterable<string, array{0: string}> */
+    public static function symfonyPlaceholderCases(): iterable
+    {
+        yield 'env_reference_in_yaml' => ["api_key: '%env(ANTHROPIC_API_KEY)%'"];
+        yield 'env_reference_with_processor' => ["password: '%env(string:DB_PASSWORD)%'"];
+        yield 'container_parameter_reference' => ["secret: '%kernel.secret%'"];
+        yield 'shell_env_brace' => ["api_key: '\${ANTHROPIC_API_KEY}'"];
+        yield 'shell_env_bare' => ["api_key: '\$ANTHROPIC_API_KEY'"];
+        yield 'php_array_env_reference' => ["'api_key' => '%env(ANTHROPIC_API_KEY)%'"];
+    }
+
     public function test_it_leaves_non_credential_content_unmodified(): void
     {
         $code = "<?php\n\nclass UserController {\n    public function indexAction(): Response\n    {\n        return new Response('hello');\n    }\n}\n";


### PR DESCRIPTION
## Summary

Fixes: False-positive on %env(...)% / ${VAR} placeholders

## Type of change

- [x] Bug fix
 
## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)
