### PR TITLE
fix(agent): instruct attacker to converge within tool-call budget

### DIFF
--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -26,7 +26,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 1;
+    public const int PROMPT_VERSION = 2;
 
     /**
      * Skill-block emission order — by attack-surface priority, NOT alphabetical.
@@ -300,6 +300,12 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             - Consider the FULL call chain, not just single function calls
             - Cross-reference controllers, voters, services, and entities together
             - Return ONLY the JSON array, no prose, no markdown fences
+
+            Tool Usage Discipline:
+            - You have a LIMITED, finite tool-call budget per chunk. Do NOT gather evidence indefinitely — once you have enough to decide, stop using tools and emit the final JSON answer.
+            - The moment you have sufficient evidence (either confirming a finding or ruling one out), STOP calling tools and produce the JSON. Continuing "to be thorough" wastes the budget and risks running out before you can answer.
+            - If your initial scan of the provided files surfaces no exploitable findings, emit `[]` immediately. Do NOT keep calling tools hunting for something that is not there.
+            - Once you have decided to answer, your response MUST contain ONLY the JSON array — no prose, no reasoning, no further tool calls. Any deviation (additional tool calls after the decision, explanatory text, partial JSON) causes the response to be discarded as malformed.
             PROMPT;
     }
 

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -308,7 +308,7 @@ final class AttackerPromptBuilderTest extends TestCase
     {
         $prompt = $this->attackerPromptBuilder->buildSystemPrompt();
 
-        self::assertStringEndsWith('Return ONLY the JSON array, no prose, no markdown fences', $prompt);
+        self::assertStringEndsWith('causes the response to be discarded as malformed.', $prompt);
     }
 
     public function test_base_prompt_has_no_trailing_separator_when_files_have_no_matching_skill(): void
@@ -321,7 +321,7 @@ final class AttackerPromptBuilderTest extends TestCase
 
         $prompt = $this->attackerPromptBuilder->buildSystemPrompt([$projectFile]);
 
-        self::assertStringEndsWith('Return ONLY the JSON array, no prose, no markdown fences', $prompt);
+        self::assertStringEndsWith('causes the response to be discarded as malformed.', $prompt);
     }
 
     public function test_skill_block_is_separated_from_base_by_exactly_one_blank_line(): void
@@ -335,7 +335,7 @@ final class AttackerPromptBuilderTest extends TestCase
         $prompt = $this->attackerPromptBuilder->buildSystemPrompt([$projectFile]);
 
         self::assertStringContainsString(
-            "Return ONLY the JSON array, no prose, no markdown fences\n\n<skills role=\"controller\">",
+            "causes the response to be discarded as malformed.\n\n<skills role=\"controller\">",
             $prompt,
         );
     }
@@ -509,5 +509,17 @@ final class AttackerPromptBuilderTest extends TestCase
         $prompt = $this->attackerPromptBuilder->buildSystemPrompt([$projectFile]);
 
         self::assertStringContainsString("new Process(['ls', '-la'])", $prompt);
+    }
+
+    public function test_prompt_version_is_bumped_when_tool_usage_discipline_section_is_added(): void
+    {
+        self::assertSame(2, AttackerPromptBuilder::PROMPT_VERSION);
+    }
+
+    public function test_base_prompt_instructs_model_to_converge_within_tool_call_budget(): void
+    {
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString('tool-call budget', $prompt);
     }
 }


### PR DESCRIPTION
## Summary

Fixes: Attacker prompt "Tool Usage Discipline" section + PROMPT_VERSION bumped 1→2

## Type of change

- [x] Bug fix
 
## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)
