### PR TITLE
Refactor/progress bar dry run cleanup

### DIFF
--- a/.claude/rules/no-comments.md
+++ b/.claude/rules/no-comments.md
@@ -1,0 +1,41 @@
+# No-Comments Rule
+
+A comment is a symptom of code that doesn't speak for itself. Before writing
+one, fix the code instead.
+
+## Default: no comment
+
+Do not write `//` comment blocks in production or test code. Self-documenting
+names beat prose every time.
+
+## When tempted to comment, do this instead
+
+| Temptation                              | Fix                                                  |
+| --------------------------------------- | ---------------------------------------------------- |
+| Explain what a block does               | Extract a method with a descriptive name             |
+| Explain why a value was chosen          | Introduce a named constant                           |
+| Explain an algorithm step               | Extract + name each step as a private method         |
+| Pin a mutation-test rationale in a test | Write the assertion so its failure message is clear  |
+| Explain an `if` condition               | Extract a predicate method (`isSingleBalancedBlock`) |
+
+## Allowed (rare, one line only)
+
+A single `//` line is acceptable only for an **external constraint** that truly
+cannot be expressed in code and would take a reader hours to rediscover:
+
+- A provider quirk not documented in their public API (e.g. a model that rejects
+  a standard option).
+- A PCRE engine edge-case that forces an unusual operator.
+- A regulatory or third-party requirement that drives a non-obvious choice.
+
+Even then: one line, no multi-sentence prose.
+
+## Never
+
+- Multi-line `//` blocks explaining design rationale.
+- "Mutation-pinning" comments in tests (`// Pins the X mutant — removing this
+  assertion allows Y`). If the test name and assertion are clear, the pin is
+  implicit.
+- Commented-out code.
+- Redundant docblocks on `final readonly` classes that just repeat the
+  constructor parameters.

--- a/.claude/rules/no-comments.md
+++ b/.claude/rules/no-comments.md
@@ -33,9 +33,9 @@ Even then: one line, no multi-sentence prose.
 ## Never
 
 - Multi-line `//` blocks explaining design rationale.
-- "Mutation-pinning" comments in tests (`// Pins the X mutant — removing this
-  assertion allows Y`). If the test name and assertion are clear, the pin is
-  implicit.
+- "Mutation-pinning" comments in tests
+  (`// Pins the X mutant — removing this assertion allows Y`). If the test name
+  and assertion are clear, the pin is implicit.
 - Commented-out code.
 - Redundant docblocks on `final readonly` classes that just repeat the
   constructor parameters.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -218,9 +218,9 @@ distinct edge-case behavior — those stay as separate test methods.
 - **`$this->expectNotToPerformAssertions()`** — forbidden. A test with no
   assertions is a test that can never fail on a logic mutation. If the only
   observable contract is "does not throw", express it structurally: use
-  `expects(self::never())` on a mock collaborator, or fire a follow-up call
-  that asserts a return value. If you truly cannot assert anything, delete the
-  test — dead coverage is worse than no coverage.
+  `expects(self::never())` on a mock collaborator, or fire a follow-up call that
+  asserts a return value. If you truly cannot assert anything, delete the test —
+  dead coverage is worse than no coverage.
 
 ## Quality Gates
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -215,6 +215,12 @@ distinct edge-case behavior — those stay as separate test methods.
 - Test name describes HOW (`uses_array_chunk`) instead of WHAT
   (`reviews_in_batches_of_five`).
 - Test breaks after a pure rename or extract-method refactor.
+- **`$this->expectNotToPerformAssertions()`** — forbidden. A test with no
+  assertions is a test that can never fail on a logic mutation. If the only
+  observable contract is "does not throw", express it structurally: use
+  `expects(self::never())` on a mock collaborator, or fire a follow-up call
+  that asserts a return value. If you truly cannot assert anything, delete the
+  test — dead coverage is worse than no coverage.
 
 ## Quality Gates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,37 +66,36 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `recommendation.contents[locale]`) followed by a trailing `[]` previously had
   the answer dropped — the first `[` was extracted as `[locale]`, failed to
   decode, and the recovery never tried the actual JSON tail.
+- `audit:run --dry-run` no longer shows
+  `RISK LEVEL: SAFE / No validated vulnerabilities found / Audit complete` —
+  output that implied a real audit had run and found nothing. Dry-run is a
+  **cost estimate only**: no LLM calls, no vulnerability scan. The new output
+  shows the estimated token counts and cost, followed by
+  `Dry run — no LLM calls were made. This is a cost estimate only.` /
+  `Dry run complete.`. For `--format=json/sarif --output=<file>` the structured
+  report is still written to disk so cost data is machine-readable; the human
+  summary is shown alongside. For `--format=json/sarif` piped to stdout, only
+  the machine-readable output is emitted.
 
 ### Added
 
 - `audit:run` now renders a live **console progress bar** while the pipeline
-  runs. Each of the three stages (Ingestion → Mapping → Audit) advances the
-  bar by one step; the stage name appears as the bar message. The bar is
-  suppressed automatically for `--format=json/sarif` piped to stdout and for
-  `--dry-run`. Implemented via a new `ConsoleProgressReporter` (Infrastructure)
-  driven by the existing `pipeline.started / stage.started / stage.completed /
-  pipeline.completed` events that `AuditPipeline` already emits, and wired
-  through a new `ProgressReporterHolder` mutable delegate so the live
-  `SymfonyStyle` output handle can be injected at invocation time without
-  changing `PipelineInterface`.
-
-### Fixed
-
-- `audit:run --dry-run` no longer shows `RISK LEVEL: SAFE / No validated
-  vulnerabilities found / Audit complete` — output that implied a real audit
-  had run and found nothing. Dry-run is a **cost estimate only**: no LLM calls,
-  no vulnerability scan. The new output shows the estimated token counts and
-  cost, followed by `Dry run — no LLM calls were made. This is a cost estimate
-  only.` / `Dry run complete.`. For `--format=json/sarif --output=<file>` the
-  structured report is still written to disk so cost data is machine-readable;
-  the human summary is shown alongside. For `--format=json/sarif` piped to
-  stdout, only the machine-readable output is emitted.
+  runs. Each of the three stages (Ingestion → Mapping → Audit) advances the bar
+  by one step; the stage name appears as the bar message. The bar is suppressed
+  automatically for `--format=json/sarif` piped to stdout and for `--dry-run`.
+  Implemented via a new `ConsoleProgressReporter` (Infrastructure) driven by the
+  existing
+  `pipeline.started / stage.started / stage.completed / pipeline.completed`
+  events that `AuditPipeline` already emits, and wired through a new
+  `ProgressReporterHolder` mutable delegate so the live `SymfonyStyle` output
+  handle can be injected at invocation time without changing
+  `PipelineInterface`.
 
 ### Refactored
 
 - Removed multi-line `//` comment blocks from `src/` that explained what
-  self-evident code does. A new `.claude/rules/no-comments.md` rule codifies
-  the policy: comments signal poorly written code; fix the code instead.
+  self-evident code does. A new `.claude/rules/no-comments.md` rule codifies the
+  policy: comments signal poorly written code; fix the code instead.
 
 ## [1.3.1] — 2026-05-26 — Watertight
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Refactored
 
-- Removed multi-line `//` comment blocks from `src/` that explained what
+- Removed multi-line `//` comment blocks from `src/` and `tests/` that explained what
   self-evident code does. A new `.claude/rules/no-comments.md` rule codifies the
   policy: comments signal poorly written code; fix the code instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
-## [1.3.2] — 2026-05-26
+## [1.3.2] — 2026-05-26 — Sieve
 
 ### Fixed
 
@@ -67,7 +67,13 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   the answer dropped — the first `[` was extracted as `[locale]`, failed to
   decode, and the recovery never tried the actual JSON tail.
 
-## [1.3.1] — 2026-05-26
+### Refactored
+
+- Removed multi-line `//` comment blocks from `src/` that explained what
+  self-evident code does. A new `.claude/rules/no-comments.md` rule codifies
+  the policy: comments signal poorly-written code; fix the code instead.
+
+## [1.3.1] — 2026-05-26 — Watertight
 
 ### Tooling
 
@@ -77,7 +83,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   that the recovery path returns the decoded array (not the wrapping list) after
   stripping fences. No production code change.
 
-## [1.3.0] — 2026-05-26
+## [1.3.0] — 2026-05-26 — Bonsaï
 
 ### Added
 
@@ -134,7 +140,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   512-byte `content_preview` of the LLM response so the actual shape of an
   unrecoverable payload is diagnosable without re-running the audit.
 
-## [1.2.1] — 2026-05-25
+## [1.2.1] — 2026-05-25 — High Temperature
 
 ### Fixed
 
@@ -512,18 +518,18 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
   `config/bundles.php` guidance in the README).
 
 [1.3.2]:
-  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.3.2
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.3.2
 [1.3.1]:
-  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.3.1
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.3.1
 [1.3.0]:
-  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.3.0
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.3.0
 [1.2.1]:
-  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.2.1
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.2.1
 [1.2.0]:
-  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.2.0
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.2.0
 [1.1.1]:
-  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.1.1
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.1.1
 [1.1.0]:
-  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.1.0
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.1.0
 [1.0.0]:
-  https://github.com/vinceamstoutz/symfony-security-auditor/releases/tag/v1.0.0
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,31 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   the answer dropped — the first `[` was extracted as `[locale]`, failed to
   decode, and the recovery never tried the actual JSON tail.
 
+### Added
+
+- `audit:run` now renders a live **console progress bar** while the pipeline
+  runs. Each of the three stages (Ingestion → Mapping → Audit) advances the
+  bar by one step; the stage name appears as the bar message. The bar is
+  suppressed automatically for `--format=json/sarif` piped to stdout and for
+  `--dry-run`. Implemented via a new `ConsoleProgressReporter` (Infrastructure)
+  driven by the existing `pipeline.started / stage.started / stage.completed /
+  pipeline.completed` events that `AuditPipeline` already emits, and wired
+  through a new `ProgressReporterHolder` mutable delegate so the live
+  `SymfonyStyle` output handle can be injected at invocation time without
+  changing `PipelineInterface`.
+
+### Fixed
+
+- `audit:run --dry-run` no longer shows `RISK LEVEL: SAFE / No validated
+  vulnerabilities found / Audit complete` — output that implied a real audit
+  had run and found nothing. Dry-run is a **cost estimate only**: no LLM calls,
+  no vulnerability scan. The new output shows the estimated token counts and
+  cost, followed by `Dry run — no LLM calls were made. This is a cost estimate
+  only.` / `Dry run complete.`. For `--format=json/sarif --output=<file>` the
+  structured report is still written to disk so cost data is machine-readable;
+  the human summary is shown alongside. For `--format=json/sarif` piped to
+  stdout, only the machine-readable output is emitted.
+
 ### Refactored
 
 - Removed multi-line `//` comment blocks from `src/` that explained what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 - Removed multi-line `//` comment blocks from `src/` that explained what
   self-evident code does. A new `.claude/rules/no-comments.md` rule codifies
-  the policy: comments signal poorly-written code; fix the code instead.
+  the policy: comments signal poorly written code; fix the code instead.
 
 ## [1.3.1] — 2026-05-26 — Watertight
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,3 +245,5 @@ Rules scoped to specific paths live in `.claude/rules/`:
   interfaces/SOLID, single responsibility, Symfony components in `src/**`.
 - [`testing.md`](.claude/rules/testing.md) — TDD red/green/refactor, stub vs
   mock, suite layout, mutation score.
+- [`no-comments.md`](.claude/rules/no-comments.md) — no multi-line comment
+  blocks; comments signal poorly-written code; fix the code instead.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,19 @@ third-party packages.
 
 ### Console mode (truncated)
 
+The command renders a live progress bar while the pipeline runs (suppressed for
+`--format=json/sarif` to stdout and for `--dry-run`):
+
+```text
+ Running audit pipeline...
+ ─────────────────────────
+ 1/3 [=======>                  ]  33% — ingestion
+ 2/3 [===============>          ]  67% — mapping
+ 3/3 [==========================] 100% — audit
+```
+
+Full output after the pipeline completes:
+
 ```text
 ══════════════════════════════════════════════════════════════════════
   🔍 SYMFONY LLM AUDIT REPORT — AUDIT-a1b2c3d4
@@ -262,26 +275,22 @@ bin/console audit:run --dry-run
 ```
 
 ```text
-══════════════════════════════════════════════════════════════════════
-  🔍 SYMFONY LLM AUDIT REPORT — AUDIT-b7e2f901
-  vinceamstoutz/symfony-security-auditor
-══════════════════════════════════════════════════════════════════════
+ Symfony LLM Security Auditor
+ =============================
 
-  Project : /var/www/my-app
-  Started : 2026-05-22 09:10:44
-  Duration: 0.0s
-  Files   : 142 scanned
-  Tokens  : ~52,400 in / ~4,200 out (claude-opus-4-7)  [estimate]
-  Cost    : $0.3670 (estimated)
+ Project: /var/www/my-app
+ Pipeline: Ingestion → Mapping → Audit (Attacker ⚔ Reviewer)
 
-──────────────────────────────────────────────────────────────────────
-  RISK LEVEL: SAFE  (Score: 0)
-──────────────────────────────────────────────────────────────────────
+ Estimating audit cost (dry run)...
+ ───────────────────────────────────
 
-  ✅  No validated vulnerabilities found.
+ * Model : claude-opus-4-7
+ * Tokens: 52,400 in / 4,200 out (total: 56,600)
+ * Cost  : $0.3670 (estimate)
 
+ ! [NOTE] Dry run — no LLM calls were made. This is a cost estimate only.
 
- [OK] Estimate complete. No LLM calls were made.
+ [OK] Dry run complete.
 ```
 
 No LLM calls are made; exit code is always `0`.

--- a/config/services.php
+++ b/config/services.php
@@ -58,8 +58,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay\UsleepSl
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RetryPolicy;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TransientFailureClassifier;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Pricing\StaticPricingProvider;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ConsoleProgressReporter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\LoggerProgressReporter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\NullProgressReporter;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\AttackerPromptBuilder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\ReviewerPromptBuilder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRenderer;
@@ -179,7 +181,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $defaultsConfigurator->set(NullProgressReporter::class);
     $defaultsConfigurator->set(LoggerProgressReporter::class)
         ->args([service('logger')]);
-    $defaultsConfigurator->alias(ProgressReporterInterface::class, NullProgressReporter::class);
+    $defaultsConfigurator->set(ProgressReporterHolder::class);
+    $defaultsConfigurator->alias(ProgressReporterInterface::class, ProgressReporterHolder::class);
 
     $defaultsConfigurator->set(AuditPipeline::class)
         ->args([
@@ -281,6 +284,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(AuditExitCodeResolverInterface::class),
             service(AuditPresenterInterface::class),
             service(EstimateAuditCostUseCase::class),
+            service(ProgressReporterHolder::class),
         ])
         ->tag('console.command');
 };

--- a/config/services.php
+++ b/config/services.php
@@ -58,7 +58,6 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay\UsleepSl
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RetryPolicy;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TransientFailureClassifier;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Pricing\StaticPricingProvider;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ConsoleProgressReporter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\LoggerProgressReporter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\NullProgressReporter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;

--- a/src/Audit/Application/Agent/AttackerAgent.php
+++ b/src/Audit/Application/Agent/AttackerAgent.php
@@ -143,9 +143,6 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
             throw $budgetExceededException;
         } catch (LLMProviderException $llmProviderException) {
-            // Non-transient failure (missing platform config, auth error, retired model).
-            // Every subsequent chunk will fail identically — abort immediately so the
-            // audit does not silently return a false-negative SAFE result.
             $this->recordChunkCoverage($chunk, 'errored', $coverageRecorder);
 
             throw $llmProviderException;

--- a/src/Audit/Application/Scan/ScanPathFilter.php
+++ b/src/Audit/Application/Scan/ScanPathFilter.php
@@ -38,10 +38,6 @@ final readonly class ScanPathFilter
      */
     public static function apply(array $files, array $scanPaths): array
     {
-        // The empty-`$scanPaths` case is handled by the empty-`$normalized` check
-        // below: an empty input loop produces an empty `$normalized`, and we
-        // return `$files` unchanged from there. Keeping a single fall-through
-        // path avoids equivalent mutants on a redundant early return.
         $normalized = [];
         foreach ($scanPaths as $scanPath) {
             $trimmed = trim($scanPath);

--- a/src/Audit/Domain/Port/LLMResponse.php
+++ b/src/Audit/Domain/Port/LLMResponse.php
@@ -87,17 +87,9 @@ final readonly class LLMResponse
         $content = (string) preg_replace('/```\s*/', '', $content);
         $content = trim($content);
 
-        // Raw json_decode (over symfony/serializer) is deliberate: the LLM emits free-form
-        // payloads whose shape we cannot pre-declare as a class. We only need array hydration
-        // here; downstream factories (e.g. VulnerabilityFactory) handle structural validation.
         try {
             $decoded = json_decode($content, true, self::JSON_MAX_DEPTH, \JSON_THROW_ON_ERROR);
         } catch (JsonException $jsonException) {
-            // When tools are enabled the LLM sometimes returns prose around the JSON
-            // despite the "Return ONLY the JSON array" prompt instruction. The first
-            // `[`/`{` may belong to prose (e.g. PHP-style `array[key]` references) —
-            // walk every opener position and return the first balanced block that
-            // decodes successfully. If none decode, rethrow the original exception.
             $decoded = $this->recoverDecodedJsonBlock($content) ?? throw $jsonException;
         }
 

--- a/src/Audit/Infrastructure/Cache/FilesystemAttackerCache.php
+++ b/src/Audit/Infrastructure/Cache/FilesystemAttackerCache.php
@@ -47,9 +47,6 @@ final readonly class FilesystemAttackerCache implements AttackerCacheInterface
         try {
             $raw = $this->filesystem->readFile($path);
 
-            // Raw json_decode (over symfony/serializer) is deliberate: cache stores opaque
-            // vulnerability dicts that VulnerabilityFactory::fromList() tolerates partially,
-            // so we want array hydration only, no class-targeted decoding.
             $decoded = json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
             if (!\is_array($decoded)) {
                 return null;

--- a/src/Audit/Infrastructure/FileSystem/ProjectFileScanner.php
+++ b/src/Audit/Infrastructure/FileSystem/ProjectFileScanner.php
@@ -111,12 +111,6 @@ final readonly class ProjectFileScanner implements ProjectFileScannerInterface
         }
 
         foreach ($explicitFiles as $explicitFile) {
-            // Run Symfony Finder against the parent directory restricted to
-            // the exact basename and depth 0. This piggy-backs on the same
-            // `->size('<= NK')` filter Finder uses for the directory scan,
-            // so we avoid hand-rolling a `kb * 1024` byte conversion or a
-            // `filesize()` check (and the mutation-test debt that comes with
-            // either) — Symfony Components First (`.claude/rules/php-classes.md`).
             $explicitFinder = (new Finder())
                 ->files()
                 ->in(\dirname($explicitFile))

--- a/src/Audit/Infrastructure/FileSystem/RegexSecretScrubber.php
+++ b/src/Audit/Infrastructure/FileSystem/RegexSecretScrubber.php
@@ -73,11 +73,6 @@ final readonly class RegexSecretScrubber implements SecretScrubberInterface
     public function scrub(string $content): string
     {
         foreach ($this->patterns as $label => $pattern) {
-            // `@` silences the PCRE warning so a runaway user-supplied pattern
-            // hitting the backtrack limit returns null cleanly instead of
-            // escalating to a PHPUnit fail-on-warning. The null branch lets
-            // the scrub `continue` with the next pattern instead of aborting
-            // the whole pipeline.
             $result = 'inline_assignment' === $label
                 ? @preg_replace_callback($pattern, $this->redactInlineAssignment(...), $content)
                 : @preg_replace($pattern, $this->replacementFor($label), $content);

--- a/src/Audit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiter.php
+++ b/src/Audit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiter.php
@@ -155,11 +155,6 @@ final class TokenBucketRateLimiter implements RateLimiterInterface
         $this->requestsUsed = 0;
         $this->inputTokensUsed = 0;
         $this->outputTokensUsed = 0;
-        // pendingInputEstimate is left untouched here on purpose: acquire()
-        // always overwrites it before reading, and record() sets it back to
-        // 0 after reconciling. Resetting it here would only be observable
-        // if record() ran without a preceding acquire() — which the LLM
-        // client never does (acquire→record is the only legal pairing).
     }
 
     private function nextWindowStart(): DateTimeImmutable
@@ -176,11 +171,6 @@ final class TokenBucketRateLimiter implements RateLimiterInterface
 
     private function sleepUntil(DateTimeImmutable $from, DateTimeImmutable $to): void
     {
-        // `Uu` formats the instant as a contiguous "seconds + microseconds"
-        // integer string (e.g. "1735732800001234"); PHP coerces the
-        // numeric-string subtraction to a native int, so the delta is in
-        // microseconds without going through floats. Dividing by 1_000 and
-        // ceil'ing yields the smallest sleep that does not undershoot.
         $deltaUs = $to->format('Uu') - $from->format('Uu');
         $this->sleeper->sleep((int) ceil($deltaUs / 1_000));
     }

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -257,12 +257,6 @@ final readonly class SymfonyAiLLMClient implements LLMClientInterface
 
             try {
                 $deferredResult = $this->platform->invoke($this->model, $messageBag, $options);
-                // Eager resolution: force the HTTP body read here so 4xx/5xx
-                // errors surface inside this retry wrapper instead of escaping
-                // later from `asText()`/`getResult()` in `complete()` /
-                // `completeWithTools()`. `DeferredResult::getResult()` caches
-                // its converted output, so the subsequent caller-side calls
-                // see the same instance with no extra cost.
                 $deferredResult->getResult();
 
                 return $deferredResult;
@@ -337,10 +331,6 @@ final readonly class SymfonyAiLLMClient implements LLMClientInterface
      */
     private function baseOptions(): array
     {
-        // `temperature` is rejected by some newer Claude models (e.g.
-        // extended-thinking variants of Sonnet 4.6). Send only when the
-        // operator explicitly opted in; otherwise let the provider apply
-        // its own default.
         $options = [];
         if (null !== $this->temperature) {
             $options['temperature'] = $this->temperature;
@@ -351,10 +341,6 @@ final readonly class SymfonyAiLLMClient implements LLMClientInterface
         }
 
         if ($this->providerJsonMode) {
-            // OpenAI-compatible JSON mode. Honored by OpenAI / Mistral / Ollama;
-            // Anthropic does not expose this knob and the option is silently
-            // dropped by providers that do not recognize it. The prompt
-            // contract ("Return ONLY the JSON array") remains authoritative.
             $options['response_format'] = ['type' => 'json_object'];
         }
 

--- a/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
@@ -75,9 +75,10 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
 
     private function onPipelineCompleted(): void
     {
-        if ($this->progressBar === null) {
+        if (!$this->progressBar instanceof ProgressBar) {
             return;
         }
+
         $this->progressBar->finish();
         $this->output->writeln('');
     }

--- a/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
+
+/**
+ * Renders a Symfony ProgressBar to the console.
+ *
+ * Driven by the four pipeline events emitted by AuditPipeline:
+ *   pipeline.started  → creates and starts a bar sized to stage count
+ *   stage.started     → updates the bar message to the current stage name
+ *   stage.completed   → advances the bar by one step
+ *   pipeline.completed → finishes the bar and writes a trailing newline
+ *
+ * All other events are silently ignored. Mutable because ProgressBar is
+ * stateful (tracks current step, format, and output position).
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final class ConsoleProgressReporter implements ProgressReporterInterface
+{
+    private ?ProgressBar $progressBar = null;
+
+    public function __construct(private readonly OutputInterface $output) {}
+
+    /**
+     * {@inheritDoc}
+     */
+    public function report(string $event, array $context = []): void
+    {
+        match ($event) {
+            'pipeline.started' => $this->onPipelineStarted($context),
+            'stage.started' => $this->onStageStarted($context),
+            'stage.completed' => $this->onStageCompleted(),
+            'pipeline.completed' => $this->onPipelineCompleted(),
+            default => null,
+        };
+    }
+
+    /** @param array<string, mixed> $context */
+    private function onPipelineStarted(array $context): void
+    {
+        $stages = \is_array($context['stages'] ?? null) ? $context['stages'] : [];
+        $this->progressBar = new ProgressBar($this->output, \count($stages));
+        $this->progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% — %message%');
+        $this->progressBar->setMessage('starting…');
+        $this->progressBar->start();
+    }
+
+    /** @param array<string, mixed> $context */
+    private function onStageStarted(array $context): void
+    {
+        $this->progressBar?->setMessage(\is_string($context['stage'] ?? null) ? $context['stage'] : '');
+        $this->progressBar?->display();
+    }
+
+    private function onStageCompleted(): void
+    {
+        $this->progressBar?->advance();
+    }
+
+    private function onPipelineCompleted(): void
+    {
+        if ($this->progressBar === null) {
+            return;
+        }
+        $this->progressBar->finish();
+        $this->output->writeln('');
+    }
+}

--- a/src/Audit/Infrastructure/Progress/ProgressReporterHolder.php
+++ b/src/Audit/Infrastructure/Progress/ProgressReporterHolder.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress;
+
+use Throwable;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
+
+/**
+ * Mutable delegate that wires the ProgressReporterInterface seam between
+ * DI container construction time and command invocation time.
+ *
+ * AuditPipeline (and the DI container) receive this holder as the
+ * ProgressReporterInterface implementation. AuditCommand calls setDelegate()
+ * at the start of __invoke() to swap in a ConsoleProgressReporter built
+ * from the live SymfonyStyle. Prior to that call the holder behaves as a
+ * NullProgressReporter.
+ *
+ * Reporter exceptions are swallowed so a misbehaving delegate cannot abort
+ * the audit (contract guarantee from ProgressReporterInterface).
+ *
+ * Mutable by design — non-readonly because the delegate is set after
+ * construction. See .claude/rules/php-classes.md for the opt-out policy.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final class ProgressReporterHolder implements ProgressReporterInterface
+{
+    private ProgressReporterInterface $delegate;
+
+    public function __construct()
+    {
+        $this->delegate = new NullProgressReporter();
+    }
+
+    public function setDelegate(ProgressReporterInterface $reporter): void
+    {
+        $this->delegate = $reporter;
+    }
+
+    public function report(string $event, array $context = []): void
+    {
+        try {
+            $this->delegate->report($event, $context);
+        } catch (Throwable) {
+        }
+    }
+}

--- a/src/Audit/Infrastructure/Progress/ProgressReporterHolder.php
+++ b/src/Audit/Infrastructure/Progress/ProgressReporterHolder.php
@@ -36,22 +36,22 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInter
  */
 final class ProgressReporterHolder implements ProgressReporterInterface
 {
-    private ProgressReporterInterface $delegate;
+    private ProgressReporterInterface $progressReporter;
 
     public function __construct()
     {
-        $this->delegate = new NullProgressReporter();
+        $this->progressReporter = new NullProgressReporter();
     }
 
-    public function setDelegate(ProgressReporterInterface $reporter): void
+    public function setDelegate(ProgressReporterInterface $progressReporter): void
     {
-        $this->delegate = $reporter;
+        $this->progressReporter = $progressReporter;
     }
 
     public function report(string $event, array $context = []): void
     {
         try {
-            $this->delegate->report($event, $context);
+            $this->progressReporter->report($event, $context);
         } catch (Throwable) {
         }
     }

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -314,9 +314,6 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      */
     private function skillsForFiles(array $files): string
     {
-        // No need to deduplicate the type list — SKILL_PRIORITY drives the
-        // outer loop and only emits each priority type once, regardless of
-        // how many times it appears in $presentTypes.
         $presentTypes = array_map(
             static fn (ProjectFile $projectFile): string => $projectFile->type(),
             $files,

--- a/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
@@ -97,10 +97,6 @@ final readonly class ReviewerPromptBuilder implements ReviewerPromptBuilderInter
 
     public function buildSystemPrompt(): string
     {
-        // Sections are assembled via implode + array literal — NOT a concat
-        // chain — so Infection's `Concat` / `ConcatOperandRemoval` mutators
-        // have no `.` operators to attack. Order is enforced by the array
-        // literal and locked in by the ordering test on this builder.
         return implode("\n\n", [
             self::CORE_INSTRUCTIONS,
             self::SEVERITY_RUBRIC,

--- a/src/Audit/Infrastructure/Report/ReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/ReportRenderer.php
@@ -51,9 +51,6 @@ final readonly class ReportRenderer
 
     private function renderCostBreakdown(AuditReport $auditReport): string
     {
-        // An empty byRole produces an empty $lines, which implode joins to ''.
-        // Keeping a single fall-through path avoids an equivalent ReturnRemoval
-        // mutant on a redundant `if ([] === $byRole) return '';` early return.
         $lines = [];
         foreach ($auditReport->cost()->byRole() as $role => $entry) {
             $lines[] = \sprintf(

--- a/src/Command/AuditCommand.php
+++ b/src/Command/AuditCommand.php
@@ -21,6 +21,8 @@ use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByBudgetException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\EstimateAuditCostUseCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ConsoleProgressReporter;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;
 
 #[AsCommand(
     name: 'audit:run',
@@ -60,6 +62,7 @@ final readonly class AuditCommand
         private AuditExitCodeResolverInterface $auditExitCodeResolver,
         private AuditPresenterInterface $auditPresenter,
         private EstimateAuditCostUseCase $estimateAuditCostUseCase,
+        private ProgressReporterHolder $progressReporterHolder,
     ) {}
 
     public function __invoke(
@@ -70,20 +73,28 @@ final readonly class AuditCommand
 
         $this->auditPresenter->header($symfonyStyle, $projectPath);
 
+        $scanPaths = $auditCommandInput->scanPaths();
+
         try {
-            $this->auditPresenter->runningSection($symfonyStyle);
-
-            $scanPaths = $auditCommandInput->scanPaths();
-
             if ($auditCommandInput->dryRun) {
+                $this->auditPresenter->estimatingSection($symfonyStyle);
                 $report = $this->estimateAuditCostUseCase->execute($projectPath, $scanPaths);
-                $this->reportWriter->write($report, $auditCommandInput->format, $auditCommandInput->output, $symfonyStyle);
+
+                if ($auditCommandInput->isMachineReadableFormat()) {
+                    $this->reportWriter->write($report, $auditCommandInput->format, $auditCommandInput->output, $symfonyStyle);
+                }
 
                 if (!$auditCommandInput->isMachineReadableToStdout()) {
-                    $this->auditPresenter->result($symfonyStyle, $report, Command::SUCCESS);
+                    $this->auditPresenter->dryRunResult($symfonyStyle, $report);
                 }
 
                 return Command::SUCCESS;
+            }
+
+            $this->auditPresenter->runningSection($symfonyStyle);
+
+            if (!$auditCommandInput->isMachineReadableToStdout()) {
+                $this->progressReporterHolder->setDelegate(new ConsoleProgressReporter($symfonyStyle));
             }
 
             $report = $this->runAuditUseCase->execute($projectPath, $scanPaths, $auditCommandInput->noCache);

--- a/src/Command/AuditCommandInput.php
+++ b/src/Command/AuditCommandInput.php
@@ -87,4 +87,9 @@ final class AuditCommandInput
     {
         return null === $this->output && OutputFormat::Console !== $this->format;
     }
+
+    public function isMachineReadableFormat(): bool
+    {
+        return OutputFormat::Console !== $this->format;
+    }
 }

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -37,6 +37,44 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         $symfonyStyle->section('Running audit pipeline...');
     }
 
+    public function estimatingSection(SymfonyStyle $symfonyStyle): void
+    {
+        $symfonyStyle->section('Estimating audit cost (dry run)...');
+    }
+
+    public function dryRunResult(SymfonyStyle $symfonyStyle, AuditReport $auditReport): void
+    {
+        $cost = $auditReport->cost();
+
+        if ($cost !== null) {
+            $lines = [];
+            $lines[] = \sprintf('Model : %s', $cost->primaryModel());
+            $lines[] = \sprintf(
+                'Tokens: %s in / %s out (total: %s)',
+                number_format($cost->inputTokens()),
+                number_format($cost->outputTokens()),
+                number_format($cost->totalTokens()),
+            );
+            $lines[] = \sprintf('Cost  : $%.4f (estimate)', $cost->estimatedCostUsd());
+
+            foreach ($cost->byRole() as $role => $entry) {
+                $lines[] = \sprintf(
+                    '  %-8s (%s): $%.4f — %s in / %s out',
+                    $role,
+                    $entry['model'],
+                    $entry['estimated_cost_usd'],
+                    number_format($entry['input_tokens']),
+                    number_format($entry['output_tokens']),
+                );
+            }
+
+            $symfonyStyle->listing($lines);
+        }
+
+        $symfonyStyle->note('Dry run — no LLM calls were made. This is a cost estimate only.');
+        $symfonyStyle->success('Dry run complete.');
+    }
+
     public function error(SymfonyStyle $symfonyStyle, Throwable $throwable): void
     {
         $message = $throwable instanceof InvalidArgumentException

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -46,7 +46,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
     {
         $cost = $auditReport->cost();
 
-        if ($cost !== null) {
+        if ('' !== $cost->primaryModel()) {
             $lines = [];
             $lines[] = \sprintf('Model : %s', $cost->primaryModel());
             $lines[] = \sprintf(

--- a/src/Command/AuditPresenterInterface.php
+++ b/src/Command/AuditPresenterInterface.php
@@ -24,6 +24,10 @@ interface AuditPresenterInterface
 
     public function runningSection(SymfonyStyle $symfonyStyle): void;
 
+    public function estimatingSection(SymfonyStyle $symfonyStyle): void;
+
+    public function dryRunResult(SymfonyStyle $symfonyStyle, AuditReport $auditReport): void;
+
     public function error(SymfonyStyle $symfonyStyle, Throwable $throwable): void;
 
     public function result(SymfonyStyle $symfonyStyle, AuditReport $auditReport, int $exitCode): void;

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -44,6 +44,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRende
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditExitCodeResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditPresenter;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportWriter;
 
 final class AuditCommandEndToEndTest extends TestCase
@@ -342,6 +343,7 @@ final class AuditCommandEndToEndTest extends TestCase
             new AuditExitCodeResolver(),
             new AuditPresenter(),
             $estimateAuditCostUseCase,
+            new ProgressReporterHolder(),
         );
 
         return new CommandTester($auditCommand);
@@ -387,7 +389,10 @@ final class AuditCommandEndToEndTest extends TestCase
         ]);
 
         self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
-        self::assertStringContainsString('Audit complete', $commandTester->getDisplay());
+        self::assertStringContainsString('Dry run complete', $commandTester->getDisplay());
+        self::assertStringContainsString('Dry run', $commandTester->getDisplay());
+        self::assertStringNotContainsString('Audit complete', $commandTester->getDisplay());
+        self::assertStringNotContainsString('RISK LEVEL', $commandTester->getDisplay());
     }
 
     public function test_dry_run_with_machine_readable_json_format_suppresses_success_message(): void

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -38,13 +38,13 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\NullAttacker
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\ProjectFileScanner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\CharacterBasedTokenEstimator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Pricing\StaticPricingProvider;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\AttackerPromptBuilder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\ReviewerPromptBuilder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditExitCodeResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditPresenter;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportWriter;
 
 final class AuditCommandEndToEndTest extends TestCase

--- a/tests/Phpunit/Integration/Advisory/LockfileHashedAdvisoryCacheTest.php
+++ b/tests/Phpunit/Integration/Advisory/LockfileHashedAdvisoryCacheTest.php
@@ -60,9 +60,6 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
 
     public function test_cache_hit_emits_advisory_cache_hit_debug_log_with_lockfile_hash_context(): void
     {
-        // Pins the `$this->logger->debug('Advisory cache hit', ['lockfile_hash' => …])`
-        // call against both MethodCallRemoval and ArrayItemRemoval on the context's
-        // `lockfile_hash` entry.
         $lockfileContent = '{"lock": "v1"}';
         $this->writeLockfile($lockfileContent);
         $expectedHash = hash('sha256', $lockfileContent);
@@ -179,8 +176,6 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
             $warnings,
             static fn (array $entry): bool => 'composer.lock present but unreadable; skipping advisory cache' === $entry[0],
         ));
-        // Pins both 'path' and 'error' entries against ArrayItemRemoval on the
-        // warning context.
         self::assertCount(1, $unreadableLogs);
         self::assertSame($this->projectDir.'/composer.lock', $unreadableLogs[0][1]['path']);
         self::assertSame('permission denied', $unreadableLogs[0][1]['error']);
@@ -234,8 +229,6 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
             $warnings,
             static fn (array $entry): bool => 'Advisory cache entry unreadable, falling back to live audit' === $entry[0],
         ));
-        // Pins both 'path' and 'error' entries on the warning context against
-        // ArrayItemRemoval / ArrayItem mutants.
         self::assertCount(1, $unreadableLogs);
         $path = $unreadableLogs[0][1]['path'] ?? null;
         self::assertIsString($path);
@@ -246,14 +239,6 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
 
     public function test_cache_file_is_written_at_two_char_shard_directory_under_full_hash_filename(): void
     {
-        // Pins every substr / rtrim mutant on pathForHash() against the exact
-        // on-disk layout: {cacheDir}/{first 2 chars of hash}/{full hash}.json.
-        //
-        //   - UnwrapSubstr            → shard would be the full 64-char hash
-        //   - IncrementInteger 2 → 3  → shard becomes 3 chars
-        //   - DecrementInteger 2 → 1  → shard becomes 1 char
-        //   - IncrementInteger 0 → 1  → shard takes chars 1-2 instead of 0-1
-        //   - DecrementInteger 0 → -1 → shard takes the last char instead of first
         $lockfileContent = '{"lock": "v1"}';
         $this->writeLockfile($lockfileContent);
         $expectedHash = hash('sha256', $lockfileContent);
@@ -275,9 +260,6 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
 
     public function test_cache_dir_with_trailing_slash_is_normalized_before_assembling_path(): void
     {
-        // Pins UnwrapRtrim on rtrim($this->cacheDir, '/'). The Linux kernel
-        // collapses '//' in path lookups, so asserting on glob() output is not
-        // enough; intercept the raw path the code hands to dumpFile() instead.
         $this->writeLockfile('{"lock": "v1"}');
 
         $capturedDumpPaths = [];
@@ -342,8 +324,6 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
             $warnings,
             static fn (array $entry): bool => 'Failed to write advisory cache entry' === $entry[0],
         ));
-        // Pins both 'path' and 'error' entries on the warning context against
-        // ArrayItemRemoval / ArrayItem mutants in the writeCache() catch.
         self::assertCount(1, $failureLogs);
         $path = $failureLogs[0][1]['path'] ?? null;
         self::assertIsString($path);
@@ -353,9 +333,6 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
 
     public function test_successful_cache_write_emits_advisory_cache_stored_debug_log_with_lockfile_hash(): void
     {
-        // Pins both the `$this->logger->debug('Advisory cache stored', …)` call
-        // against MethodCallRemoval and the `['lockfile_hash' => $hash]` entry
-        // against ArrayItemRemoval on the writeCache() success path.
         $lockfileContent = '{"lock": "v1"}';
         $this->writeLockfile($lockfileContent);
         $expectedHash = hash('sha256', $lockfileContent);

--- a/tests/Phpunit/Integration/Cache/FilesystemAttackerCacheTest.php
+++ b/tests/Phpunit/Integration/Cache/FilesystemAttackerCacheTest.php
@@ -278,9 +278,6 @@ final class FilesystemAttackerCacheTest extends TestCase
 
     public function test_salted_key_concatenates_salt_null_byte_and_signatures_in_that_order(): void
     {
-        // Pins the exact key-construction format `{salt}\0{sorted signatures}`
-        // against Concat / ConcatOperandRemoval mutants that would reorder
-        // operands, drop the null-byte separator, or drop the payload entirely.
         $projectFile = ProjectFile::create('src/A.php', '/app/src/A.php', 'X');
         $signatures = 'src/A.php='.hash('sha256', 'X');
         $expectedKey = hash('sha256', "claude-opus-4-7\0".$signatures);

--- a/tests/Phpunit/Integration/FileSystem/ProjectFileScannerTest.php
+++ b/tests/Phpunit/Integration/FileSystem/ProjectFileScannerTest.php
@@ -96,8 +96,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_default_included_paths_scan_src_config_templates_and_public_index(): void
     {
-        // The Symfony skeleton allow-list: PHP under src/, YAML under config/,
-        // Twig under templates/, and the single HTTP front controller.
         mkdir($this->tmpDir.'/src', 0o777, true);
         mkdir($this->tmpDir.'/config', 0o777, true);
         mkdir($this->tmpDir.'/templates', 0o777, true);
@@ -122,10 +120,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_it_skips_files_outside_default_included_paths(): void
     {
-        // `app/` and root-level scripts are NOT in HARD_EXCLUDED_DIRS but ARE
-        // outside the default allow-list. Both must be skipped so the audit
-        // surface stays bounded for non-Symfony-skeleton layouts that the
-        // operator has not explicitly opted into.
         mkdir($this->tmpDir.'/src', 0o777, true);
         mkdir($this->tmpDir.'/app', 0o777, true);
 
@@ -141,10 +135,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_it_only_includes_public_index_when_other_public_files_present(): void
     {
-        // `public/index.php` is included as an explicit file path. Sibling
-        // public/*.php files (assets, dev helpers) must NOT be picked up by
-        // the same entry — otherwise the allow-list silently fans out to the
-        // whole `public/` directory.
         mkdir($this->tmpDir.'/public', 0o777, true);
         file_put_contents($this->tmpDir.'/public/index.php', '<?php // front controller');
         file_put_contents($this->tmpDir.'/public/dev.php', '<?php // dev script');
@@ -157,9 +147,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_it_uses_custom_included_paths_when_provided(): void
     {
-        // Non-skeleton layout: operator points `included_paths` at `app/`.
-        // Files under `src/` are no longer scanned because the allow-list
-        // is replaced (not appended to).
         mkdir($this->tmpDir.'/src', 0o777, true);
         mkdir($this->tmpDir.'/app', 0o777, true);
         file_put_contents($this->tmpDir.'/src/Should.php', '<?php // ignored');
@@ -175,13 +162,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_it_logs_warning_and_returns_empty_when_no_included_paths_exist(): void
     {
-        // Operator pointed `included_paths` at a layout that doesn't exist:
-        // no scan happens, an explicit warning fires so the configuration
-        // mismatch shows up in logs rather than a silent zero-finding report.
-        // We also pin the early return by asserting the "Scan complete" info
-        // log is absent — without the `return [];`, the Finder would still
-        // walk the project and reach that log even when no files survive
-        // the allow-list filter.
         $warningLogs = [];
         $infoLogs = [];
         $logger = self::createStub(LoggerInterface::class);
@@ -196,10 +176,6 @@ final class ProjectFileScannerTest extends TestCase
             },
         );
 
-        // Anchoring file that WOULD be scanned without the early return —
-        // src/App.php matches no `nonexistent` allow-list entry, but the
-        // Finder would still reach "Scan complete" if the warning branch
-        // fell through.
         mkdir($this->tmpDir.'/src', 0o777, true);
         file_put_contents($this->tmpDir.'/src/App.php', '<?php');
 
@@ -221,10 +197,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_it_does_not_match_sibling_directory_that_shares_a_prefix_with_included_path(): void
     {
-        // Pins the `/` separator in the prefix check: `srcfoo/` shares the
-        // `src` prefix but is a sibling, not a child, of the allow-listed
-        // `src/` entry. Without the trailing slash in `str_starts_with`, the
-        // sibling would leak into the scan.
         mkdir($this->tmpDir.'/src', 0o777, true);
         mkdir($this->tmpDir.'/srcfoo', 0o777, true);
 
@@ -311,11 +283,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_it_respects_gitignore_when_enabled(): void
     {
-        // `derived` is added to `includedPaths` so the test measures
-        // gitignore filtering in isolation. Finder's `ignoreVCSIgnored()`
-        // calls `git check-ignore`, which requires a real `.git/` directory
-        // — initialize an empty git repo so the fixture mirrors a real
-        // cloned project layout.
         mkdir($this->tmpDir.'/src', 0o777, true);
         mkdir($this->tmpDir.'/derived', 0o777, true);
         file_put_contents($this->tmpDir.'/.gitignore', "derived/\n");
@@ -393,10 +360,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_it_skips_explicit_file_path_when_larger_than_configured_max_size(): void
     {
-        // Explicit file entries in `included_paths` (e.g. `public/index.php`)
-        // bypass Symfony Finder, so the size cap is enforced manually. A
-        // bloated front controller must be skipped just like an oversized
-        // file inside a scanned directory.
         mkdir($this->tmpDir.'/public', 0o777, true);
         file_put_contents(
             $this->tmpDir.'/public/index.php',
@@ -412,11 +375,6 @@ final class ProjectFileScannerTest extends TestCase
 
     public function test_it_keeps_explicit_file_at_exact_max_size_boundary(): void
     {
-        // Boundary pin for the `kb * 1024` byte conversion AND the `>` comparator
-        // on the explicit-file size cap. A file of exactly `maxFileSizeKb * 1024`
-        // bytes must be kept (size is not strictly greater than the cap), so a
-        // `* 1023`/`* 1025` mutation on the multiplier or a `>=` mutation on the
-        // comparator would push it past the threshold and drop it.
         mkdir($this->tmpDir.'/public', 0o777, true);
         // 2 KB exactly — `str_repeat('a', 2 * 1024)` is 2048 bytes on disk.
         file_put_contents($this->tmpDir.'/public/index.php', str_repeat('a', 2 * 1024));

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -146,9 +146,6 @@ final class SymfonyAiLLMClientTest extends TestCase
 
     public function test_complete_omits_temperature_when_left_at_default(): void
     {
-        // Some newer Claude models (e.g. extended-thinking variants of Sonnet 4.6)
-        // reject the `temperature` option. With no explicit opt-in, it must not
-        // appear in the options bag so the provider applies its own default.
         $invocationOptionsCapture = new InvocationOptionsCapture();
         $inMemoryPlatform = new InMemoryPlatform(
             /** @param array<string, mixed> $options */
@@ -206,11 +203,6 @@ final class SymfonyAiLLMClientTest extends TestCase
 
     public function test_complete_passes_all_base_options_together_when_multiple_flags_enabled(): void
     {
-        // With each option exercised individually the base-options array carries
-        // at most one entry, so an ArrayOneItem mutator on the return is silently
-        // absorbed (single-item slices equal the original). Enabling temperature
-        // + prompt caching + provider JSON mode together makes the full array
-        // observable: the mutant would drop two of the three keys.
         $invocationOptionsCapture = new InvocationOptionsCapture();
         $inMemoryPlatform = new InMemoryPlatform(
             /** @param array<string, mixed> $options */
@@ -1058,10 +1050,6 @@ final class SymfonyAiLLMClientTest extends TestCase
 
     public function test_eager_resolution_catches_transient_failure_thrown_from_deferred_result(): void
     {
-        // The original bug: Symfony HttpClient defers HTTP body read to
-        // `DeferredResult::getResult()`, so a 503 thrown from there escaped the
-        // retry wrapper. After the fix, `invokeWithRetry()` forces eager
-        // resolution and the retry loop catches the failure normally.
         $fakeSleeper = new FakeSleeper();
         $platform = $this->lazilyFailingPlatform([
             new RuntimeException('HTTP 503 Service Unavailable'),
@@ -1148,9 +1136,6 @@ final class SymfonyAiLLMClientTest extends TestCase
 
         $symfonyAiLLMClient->completeWithTools('sys', 'usr', $toolRegistry, 5);
 
-        // Each tool-loop iteration must call rateLimiter->record() with the
-        // tokens consumed by that specific iteration — not the cumulative
-        // total, not skipped on the tool-call iteration.
         self::assertSame([[40, 10], [60, 5]], $fakeRateLimiter->recorded);
     }
 

--- a/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
@@ -335,10 +335,6 @@ final class AttackerAgentTest extends TestCase
 
     public function test_it_truncates_long_content_in_parse_failure_log(): void
     {
-        // Preview must clip oversized LLM responses so logs stay readable
-        // and storage does not blow up on noisy provider output. Pinning the
-        // exact boundary kills IncrementInteger / DecrementInteger mutations
-        // on the byte-cap constant.
         $errorLogs = [];
         $logger = self::createStub(LoggerInterface::class);
         $logger->method('info');
@@ -728,9 +724,6 @@ final class AttackerAgentTest extends TestCase
 
     public function test_it_records_coverage_aborted_when_llm_throws_budget_exceeded(): void
     {
-        // Pins `recordChunkCoverage($chunk, 'aborted', ...)` in the BudgetExceededException
-        // catch branch — without this assertion, removing the recordCoverage call
-        // would be undetectable.
         $files = [
             $this->makeFile('src/Controller/A.php'),
             $this->makeFile('src/Controller/B.php'),
@@ -974,9 +967,6 @@ final class AttackerAgentTest extends TestCase
 
     public function test_it_propagates_llm_provider_exception_and_records_errored_coverage(): void
     {
-        // Non-transient failures (missing platform, auth errors, retired model) must
-        // NOT be swallowed. Silently returning [] would produce a false-negative SAFE
-        // report. Both propagation and coverage recording are pinned here.
         $files = [
             $this->makeFile('src/Controller/A.php'),
             $this->makeFile('src/Controller/B.php'),
@@ -1009,10 +999,6 @@ final class AttackerAgentTest extends TestCase
 
     public function test_it_propagates_exhausted_transient_failure_and_records_errored_coverage(): void
     {
-        // Rate-limit and other transient errors that exhaust all retries are wrapped in
-        // TransientLLMFailureException. Like non-transient failures, they must NOT be
-        // swallowed — every subsequent chunk will fail identically, and silently returning
-        // [] produces a false-negative SAFE result.
         $files = [
             $this->makeFile('src/Controller/A.php'),
             $this->makeFile('src/Controller/B.php'),

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -108,11 +108,6 @@ final class AuditOrchestratorTest extends TestCase
 
     public function test_it_breaks_early_when_iteration_yields_no_new_unique_findings(): void
     {
-        // Iter 1: attacker returns vuln v1 → reviewer accepts → persisted (newFindings=1, loop continues).
-        // Iter 2: attacker returns the same vuln → duplicate, not persisted (newFindings=0) → break.
-        // audit.iterations must be 2 (not maxIterations=3). Kills:
-        //   - Break_ on line 79 (break → continue would let the loop run to iteration 3).
-        //   - DecrementInteger on line 78 (0 === → -1 === would never trigger early exit).
         $attackerLlm = self::createStub(LLMClientInterface::class);
         $reviewerLlm = self::createStub(LLMClientInterface::class);
         $attackerLlm->method('complete')->willReturn(
@@ -173,9 +168,6 @@ final class AuditOrchestratorTest extends TestCase
             ->willReturnCallback(function () use (&$iterationCount): LLMResponse {
                 ++$iterationCount;
 
-                // Safety bound: if the orchestrator runs the loop more than its declared
-                // max_iterations (e.g. a faulty counter mutation), fail loud instead of
-                // looping forever. The orchestrator must call the LLM exactly 3 times.
                 if ($iterationCount > 10) {
                     throw new RuntimeException('orchestrator exceeded safety bound: '.$iterationCount.' attacker calls');
                 }
@@ -272,8 +264,6 @@ final class AuditOrchestratorTest extends TestCase
 
     public function test_it_continues_processing_remaining_reviewed_findings_after_duplicate(): void
     {
-        // If continue→break mutation occurred, processing would stop after the duplicate.
-        // This test ensures that when a dup is encountered, processing continues to the next item.
         $attackerLlm = self::createStub(LLMClientInterface::class);
         $reviewerLlm = self::createStub(LLMClientInterface::class);
         $attackerLlm->method('complete')->willReturnOnConsecutiveCalls(

--- a/tests/Phpunit/Unit/Application/Agent/ReviewerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/ReviewerAgentTest.php
@@ -699,9 +699,6 @@ final class ReviewerAgentTest extends TestCase
 
     public function test_it_logs_debug_review_decision_when_finding_is_rejected(): void
     {
-        // Covers MethodCallRemoval on the logReviewDecision call inside the
-        // `if (!$accepted)` early-return branch in applyReview(). Without an
-        // assertion on the rejected-path debug log, removing that call escapes.
         $vulnerability = $this->makeVulnerability();
         $debugLogs = [];
 

--- a/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
+++ b/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
@@ -114,9 +114,6 @@ final class BudgetTrackerTest extends TestCase
 
     public function test_cost_budget_passes_at_exact_cap_and_aborts_above(): void
     {
-        // Pins: `$this->costUsdUsed > $maxCostUsd` (vs `>=`). With cap = $5
-        // and usage = $5 exactly, the call completes; the next call (totaling
-        // $5.01) trips the cap.
         $budgetTracker = $this->budgetTracker(AuditBudget::forCost(5.0), inputPrice: 10.0);
 
         $budgetTracker->recordCall(LLMResponse::create('a', 500_000, 0, 'gpt-4o', 'end_turn')); // $5.00
@@ -131,13 +128,6 @@ final class BudgetTrackerTest extends TestCase
 
     public function test_cost_used_is_rounded_to_six_decimal_places(): void
     {
-        // Pins `round($this->costUsdUsed, 6)` — feeds 7e-7 USD (0.0000007) into the
-        // tracker via CostCalculator (which returns raw, unrounded values now).
-        //   round(7e-7, 6) = 0.000001  ← expected
-        //   round(7e-7, 5) = 0.0       (DecrementInteger kills here)
-        //   round(7e-7, 7) = 0.0000007 (IncrementInteger kills here)
-        //   floor(7e-7)    = 0.0       (RoundingFamily kills here)
-        //   ceil(7e-7)     = 1.0       (RoundingFamily kills here)
         $budgetTracker = $this->budgetTracker(AuditBudget::unlimited(), inputPrice: 0.7);
 
         $budgetTracker->recordCall(LLMResponse::create('x', 1, 0, 'gpt-4o', 'end_turn'));

--- a/tests/Phpunit/Unit/Application/Budget/CostCalculatorTest.php
+++ b/tests/Phpunit/Unit/Application/Budget/CostCalculatorTest.php
@@ -56,11 +56,6 @@ final class CostCalculatorTest extends TestCase
 
     public function test_cost_returns_raw_unrounded_value(): void
     {
-        // Rounding belongs to surfaces that present the cost to users
-        // (`AuditCost::of` and `BudgetTracker::costUsdUsed`); the calculator
-        // returns the raw float so the accumulator can preserve precision
-        // across multiple calls. Float arithmetic introduces a tiny binary
-        // imprecision (~1e-22 here), hence assertEqualsWithDelta.
         $costCalculator = new CostCalculator($this->fixedPricing(0.1, 0.4));
 
         // 7 input tokens @ 0.1/1M = 7e-7 = 0.0000007 (unrounded mathematically;

--- a/tests/Phpunit/Unit/Application/Scan/ScanPathFilterTest.php
+++ b/tests/Phpunit/Unit/Application/Scan/ScanPathFilterTest.php
@@ -103,11 +103,6 @@ final class ScanPathFilterTest extends TestCase
 
     public function test_blank_entries_do_not_short_circuit_subsequent_scan_paths(): void
     {
-        // Pins the `continue` inside the normalize loop against a `break` mutant.
-        // With `continue` (correct), the blank entry is skipped and 'apps/api' is
-        // still added to the filter. With `break` (mutant), the loop exits before
-        // 'apps/api' is normalized, leaving the filter empty and returning every
-        // input file (including the one that should have been dropped).
         $projectFile = $this->file('apps/api/src/A.php');
         $dropped = $this->file('apps/web/src/B.php');
 
@@ -118,8 +113,6 @@ final class ScanPathFilterTest extends TestCase
 
     public function test_backslashes_in_scan_path_are_normalized_to_forward_slashes(): void
     {
-        // Pins the `str_replace('\\', '/', $trimmed)` call against UnwrapStrReplace.
-        // Without normalization (mutant), 'apps\\api' would not match 'apps/api/...'.
         $projectFile = $this->file('apps/api/src/A.php');
 
         $filtered = ScanPathFilter::apply([$projectFile], ['apps\\api']);
@@ -129,11 +122,6 @@ final class ScanPathFilterTest extends TestCase
 
     public function test_file_matching_multiple_scan_paths_is_added_only_once(): void
     {
-        // Pins the `break` inside the per-file prefix loop against a `continue` mutant.
-        // With `break` (correct), a file matching the first prefix is added and the
-        // inner loop exits. With `continue` (mutant), the file is appended once per
-        // matching prefix — here 'apps/api' and 'apps/api/src' both match, so the
-        // mutant would emit the file twice.
         $file = $this->file('apps/api/src/A.php');
 
         $filtered = ScanPathFilter::apply([$file], ['apps/api', 'apps/api/src']);

--- a/tests/Phpunit/Unit/Application/Stage/StagesTest.php
+++ b/tests/Phpunit/Unit/Application/Stage/StagesTest.php
@@ -363,9 +363,6 @@ final class StagesTest extends TestCase
 
     public function test_mapping_stage_skips_path_roles_pairs_outside_access_control_block(): void
     {
-        // Covers the early return when 'access_control' key is absent. The regex would
-        // otherwise still match path:/roles: pairs from unrelated YAML — e.g., a routing file
-        // with per-route role guards — which should not feed the access_control map.
         $mappingStage = new MappingStage(new NullLogger());
         $auditContext = AuditContext::forProject($this->tmpDir);
 
@@ -591,9 +588,6 @@ final class StagesTest extends TestCase
 
     public function test_mapping_stage_returns_immediately_and_sets_empty_mapping_when_no_files(): void
     {
-        // Tests ReturnRemoval on `return;` after the no-files guard.
-        // If removed, the code proceeds to array_filter etc. on empty array — result is same mapping,
-        // but the logger.warning call distinguishes the paths.
         $mappingStage = new MappingStage(new NullLogger());
         $auditContext = AuditContext::forProject($this->tmpDir);
 

--- a/tests/Phpunit/Unit/Application/UseCase/EstimateAuditCostUseCaseTest.php
+++ b/tests/Phpunit/Unit/Application/UseCase/EstimateAuditCostUseCaseTest.php
@@ -96,12 +96,6 @@ final class EstimateAuditCostUseCaseTest extends TestCase
 
     public function test_output_token_estimate_uses_ceil_of_output_ratio(): void
     {
-        // Pins: `(int) ceil($input * $outputRatio)`. With input=100, ratio=0.155:
-        //   ceil(100 * 0.155) = ceil(15.5) = 16
-        //   floor(100 * 0.155) = 15
-        //   round(100 * 0.155) = 16  (banker's rounding gives 16 here)
-        //   ceil(100 / 0.155) ≈ 646
-        // Also pins `*` vs `/` for outputRatio.
         $estimateAuditCostUseCase = $this->makeUseCase(
             files: [$this->makeProjectFile('a.php', 'aaa')],
             tokenEstimator: $this->fixedEstimator(perRoundTokens: 100),
@@ -149,8 +143,6 @@ final class EstimateAuditCostUseCaseTest extends TestCase
 
     public function test_logs_starting_message_with_project_path_context(): void
     {
-        // Pins: logger.info('Estimating ...', ['project' => $projectPath]) — both
-        // MethodCallRemoval (entire call gone) and ArrayItemRemoval (empty context).
         $logCalls = [];
         $logger = self::createStub(LoggerInterface::class);
         $logger->method('info')->willReturnCallback(
@@ -177,8 +169,6 @@ final class EstimateAuditCostUseCaseTest extends TestCase
 
     public function test_logs_ready_message_with_estimate_breakdown(): void
     {
-        // Pins: logger.info('Dry-run estimate ready', [...]) — both MethodCallRemoval
-        // and the ArrayItemRemoval for each context field.
         $logCalls = [];
         $logger = self::createStub(LoggerInterface::class);
         $logger->method('info')->willReturnCallback(
@@ -240,16 +230,6 @@ final class EstimateAuditCostUseCaseTest extends TestCase
 
     public function test_attacker_cost_in_breakdown_is_rounded_to_six_decimals(): void
     {
-        // Pins `round($attackerCostUsd, 6)` against the RoundingFamily mutants
-        // (ceil/floor) and the IncrementInteger/DecrementInteger mutants on the
-        // precision argument (6 → 5 or 6 → 7).
-        //   inputPricePerMillion = 1.234567, 100 input tokens, 0 output, 1 iter
-        //   attackerCost = (100 / 1_000_000) * 1.234567 = 0.0001234567
-        //   round(_, 6) → 0.000123  (correct)
-        //   round(_, 5) → 0.00012   (DecrementInteger)
-        //   round(_, 7) → 0.0001235 (IncrementInteger)
-        //   floor       → 0.0
-        //   ceil        → 1.0
         $estimateAuditCostUseCase = $this->makeUseCase(
             files: [$this->makeProjectFile('a.php', 'aaa')],
             tokenEstimator: $this->fixedEstimator(perRoundTokens: 100),
@@ -266,16 +246,6 @@ final class EstimateAuditCostUseCaseTest extends TestCase
 
     public function test_reviewer_cost_in_breakdown_is_rounded_to_six_decimals(): void
     {
-        // Same family of mutants as the attacker test, applied to the
-        // `round($reviewerCostUsd, 6)` line.
-        //   inputPricePerMillion = 1.234567, attacker input = 100, reviewerInputRatio = 0.5
-        //   reviewerInput = ceil(100 * 0.5) = 50; reviewer output = 0
-        //   reviewerCost = (50 / 1_000_000) * 1.234567 = 0.0000617283(5)
-        //   round(_, 6) → 0.000062  (correct, 7th decimal is 8 → round up)
-        //   round(_, 5) → 0.00006   (DecrementInteger)
-        //   round(_, 7) → 0.0000617 (IncrementInteger)
-        //   floor       → 0.0
-        //   ceil        → 1.0
         $estimateAuditCostUseCase = $this->makeUseCase(
             files: [$this->makeProjectFile('a.php', 'aaa')],
             tokenEstimator: $this->fixedEstimator(perRoundTokens: 100),
@@ -292,10 +262,6 @@ final class EstimateAuditCostUseCaseTest extends TestCase
 
     public function test_estimated_cost_sums_attacker_and_reviewer_contributions(): void
     {
-        // Pins `$attackerCostUsd + $reviewerCostUsd` against the Plus → Minus mutant.
-        //   attackerCost = 0.0001234567, reviewerCost = 0.00006172835
-        //   sum      = 0.00018518505 → AuditCost::of rounds to 6 decimals → 0.000185
-        //   minus    = 0.00006172835 → rounds to 0.000062 (clearly different)
         $estimateAuditCostUseCase = $this->makeUseCase(
             files: [$this->makeProjectFile('a.php', 'aaa')],
             tokenEstimator: $this->fixedEstimator(perRoundTokens: 100),
@@ -312,12 +278,6 @@ final class EstimateAuditCostUseCaseTest extends TestCase
 
     public function test_reviewer_input_token_estimate_uses_ceil_not_floor_or_round(): void
     {
-        // Pins `(int) ceil($attackerInputTokens * $this->reviewerInputRatio)` against
-        // floor / round mutants on the reviewer estimation.
-        //   attackerInput = 100, reviewerInputRatio = 0.234 → 23.4
-        //   ceil  → 24  (correct)
-        //   floor → 23
-        //   round → 23  (banker's rounding)
         $estimateAuditCostUseCase = $this->makeUseCase(
             files: [$this->makeProjectFile('a.php', 'aaa')],
             tokenEstimator: $this->fixedEstimator(perRoundTokens: 100),
@@ -333,13 +293,6 @@ final class EstimateAuditCostUseCaseTest extends TestCase
 
     public function test_reviewer_output_token_estimate_uses_ceil_not_floor_or_round(): void
     {
-        // Pins `(int) ceil($reviewerInputTokens * $this->outputRatio)` for the
-        // reviewer output line against both floor AND round mutants.
-        //   reviewerInput = ceil(100 * 0.5) = 50, outputRatio = 0.146
-        //   50 * 0.146 = 7.3
-        //   ceil  → 8  (correct)
-        //   floor → 7
-        //   round → 7  (banker's rounding rounds half-down here, but 7.3 < 7.5 anyway)
         $estimateAuditCostUseCase = $this->makeUseCase(
             files: [$this->makeProjectFile('a.php', 'aaa')],
             tokenEstimator: $this->fixedEstimator(perRoundTokens: 100),

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -150,9 +150,9 @@ final class AuditPresenterTest extends TestCase
         $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
 
         $auditContext = AuditContext::forProject($this->tmpDir);
-        $report = AuditReport::fromContext($auditContext, AuditCost::of(1000, 200, 0.0123, 'claude-opus-4-7'));
+        $auditReport = AuditReport::fromContext($auditContext, AuditCost::of(1000, 200, 0.0123, 'claude-opus-4-7'));
 
-        $this->auditPresenter->dryRunResult($symfonyStyle, $report);
+        $this->auditPresenter->dryRunResult($symfonyStyle, $auditReport);
 
         $display = $bufferedOutput->fetch();
         self::assertStringContainsString('claude-opus-4-7', $display);

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditCost;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
@@ -114,6 +115,49 @@ final class AuditPresenterTest extends TestCase
         $this->auditPresenter->runningSection($symfonyStyle);
 
         self::assertStringContainsString('Running audit pipeline', $bufferedOutput->fetch());
+    }
+
+    public function test_estimating_section_emits_dry_run_section_header(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->estimatingSection($symfonyStyle);
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('dry run', $display);
+        self::assertStringNotContainsString('Running audit pipeline', $display);
+    }
+
+    public function test_dry_run_result_shows_completion_without_audit_language(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->dryRunResult($symfonyStyle, AuditReport::fromContext(AuditContext::forProject($this->tmpDir)));
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('Dry run complete', $display);
+        self::assertStringContainsString('no LLM calls', $display);
+        self::assertStringNotContainsString('Audit complete', $display);
+        self::assertStringNotContainsString('RISK LEVEL', $display);
+        self::assertStringNotContainsString('vulnerabilities found', $display);
+    }
+
+    public function test_dry_run_result_shows_cost_breakdown_when_cost_present(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $auditContext = AuditContext::forProject($this->tmpDir);
+        $report = AuditReport::fromContext($auditContext, AuditCost::of(1000, 200, 0.0123, 'claude-opus-4-7'));
+
+        $this->auditPresenter->dryRunResult($symfonyStyle, $report);
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('claude-opus-4-7', $display);
+        self::assertStringContainsString('1,000', $display);
+        self::assertStringContainsString('0.0123', $display);
     }
 
     private function makeCriticalReport(): AuditReport

--- a/tests/Phpunit/Unit/Domain/Configuration/BundleConfigurationTest.php
+++ b/tests/Phpunit/Unit/Domain/Configuration/BundleConfigurationTest.php
@@ -123,9 +123,6 @@ final class BundleConfigurationTest extends TestCase
 
     public function test_from_array_tolerates_omitted_provider_json_mode_key_for_bc(): void
     {
-        // BC guard: callers that built their array against the 1.0 shape (no
-        // provider_json_mode key) must keep working. fromArray must default
-        // the missing key to false rather than warning about an undefined index.
         $config = $this->treeBuilderOutput();
         unset($config['provider_json_mode']);
 

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -41,12 +41,6 @@ final class AuditCostTest extends TestCase
 
     public function test_cost_is_rounded_to_six_decimal_places(): void
     {
-        // Pins `round(X, 6)` precision exactly. With X = 5e-7:
-        //   round(5e-7, 6) = 0.000001 (rounds up at position 7)
-        //   round(5e-7, 5) = 0.0       (DecrementInteger mutation)
-        //   round(5e-7, 7) = 0.0000005 (IncrementInteger mutation)
-        //   floor(5e-7)    = 0.0       (RoundingFamily mutation)
-        //   ceil(5e-7)     = 1.0       (RoundingFamily mutation)
         $auditCost = AuditCost::of(0, 0, 0.0000005, 'm');
 
         self::assertSame(0.000001, $auditCost->estimatedCostUsd());

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTest.php
@@ -70,9 +70,6 @@ final class VulnerabilityTest extends TestCase
 
     public function test_id_matches_expected_format(): void
     {
-        // Tests that generateId produces exactly 8 uppercase hex chars after 'VULN-'.
-        // Kills UnwrapSubstr (removing substr → full sha1 = 40 chars instead of 8)
-        // and UnwrapStrToUpper (lowercase hex).
         $vulnerability = $this->makeVulnerability();
 
         self::assertMatchesRegularExpression('/^VULN-[A-F0-9]{8}$/', $vulnerability->id());

--- a/tests/Phpunit/Unit/Infrastructure/FileSystem/RegexSecretScrubberTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/FileSystem/RegexSecretScrubberTest.php
@@ -20,9 +20,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\RegexSe
 
 final class RegexSecretScrubberTest extends TestCase
 {
-    // Credential-shaped prefixes split as constants so neither PHP CS Fixer's
-    // `no_useless_concat_operator` rule nor GitHub's secret scanner sees a
-    // contiguous match in the source. Concatenation happens at runtime.
+    // Credential-shaped prefixes split as constants so GitHub's secret scanner does not flag the source.
     private const string AWS = 'AKIA';
 
     private const string GHP = 'ghp';
@@ -175,10 +173,6 @@ final class RegexSecretScrubberTest extends TestCase
 
     public function test_inline_assignment_redaction_preserves_key_and_quotes(): void
     {
-        // Pins the `'inline_assignment' => '$1***REDACTED:...***$3'` match arm.
-        // If the arm is removed, the default replacement `***REDACTED:inline_assignment***`
-        // is used and the entire match (including the `password: "` prefix and closing
-        // `"`) is replaced — the key and surrounding quotes disappear.
         $output = $this->regexSecretScrubber->scrub('password: "supersecretvalue"');
 
         self::assertSame('password: "***REDACTED:inline_assignment***"', $output);
@@ -186,9 +180,6 @@ final class RegexSecretScrubberTest extends TestCase
 
     public function test_env_assignment_redaction_preserves_key_prefix(): void
     {
-        // Pins the `'env_assignment' => '$1=***REDACTED:...***'` match arm.
-        // Removing the arm would fall back to the default replacement and erase
-        // the leading `KEY_NAME=` text.
         $output = $this->regexSecretScrubber->scrub('STRIPE_SECRET_KEY=sk_super_secret_value');
 
         self::assertSame('STRIPE_SECRET_KEY=***REDACTED:env_assignment***', $output);
@@ -196,11 +187,6 @@ final class RegexSecretScrubberTest extends TestCase
 
     public function test_runtime_pcre_failure_continues_to_remaining_patterns(): void
     {
-        // Two custom patterns — the FIRST hits the backtrack limit, the SECOND
-        // is well-behaved and would redact `SECONDARY-123` if reached.
-        //   `continue` → second pattern runs → SECONDARY-123 is redacted.
-        //   `break`    → second pattern skipped → SECONDARY-123 stays raw.
-        // Pins both the `continue` keyword AND the runtime null-result branch.
         $regexSecretScrubber = new RegexSecretScrubber(additionalPatterns: [
             '/^(a+)+$/',
             '/SECONDARY-\d+/',
@@ -243,9 +229,6 @@ final class RegexSecretScrubberTest extends TestCase
 
     private function secretFragmentOf(string $input): string
     {
-        // For env/inline assignment cases we'd otherwise need to extract just the value half;
-        // but every credential case here has its raw secret appear verbatim in the input AND
-        // we assert it does not appear in the scrubbed output.
         if (str_contains($input, '=')) {
             $parts = explode('=', $input, 2);
 

--- a/tests/Phpunit/Unit/Infrastructure/LLM/LLMResponseTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/LLMResponseTest.php
@@ -105,9 +105,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_it_treats_escaped_quote_as_part_of_string_during_extraction(): void
     {
-        // Without backslash-escape awareness, the `\"` would prematurely close the
-        // string, exposing the `]` to the bracket counter and truncating extraction
-        // at the wrong place. Pin the escape behavior.
         $content = 'prose: [{"title":"x \" ] y","other":"z"}] end';
         $llmResponse = LLMResponse::create($content, 10, 5, 'claude', 'end_turn');
 
@@ -118,10 +115,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_it_locks_extraction_length_to_closing_bracket_position(): void
     {
-        // A `+1` → `+2` mutation on the substring length would include one byte
-        // past the closing bracket. With a `{` immediately after the `]`, that
-        // extra byte makes the substring invalid JSON, so the second decode
-        // throws and the mutant is killed.
         $content = '[1,2]{garbage}';
         $llmResponse = LLMResponse::create($content, 10, 5, 'claude', 'end_turn');
 
@@ -132,13 +125,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_it_scans_for_opener_from_the_start_not_the_end_of_content(): void
     {
-        // PHP returns the last character for `$content[-1]`. A mutation that flips
-        // the opener-scan loop's initial index from `0` to `-1` would pick that
-        // last character as the opener when it happens to be `[` or `{`, yielding
-        // a different extracted substring than scanning forward from the start.
-        // Content has a valid `[1,2]` early AND ends with `{`, so the original
-        // recovers `[1,2]` while the mutant tries to extract from the trailing
-        // `{` and fails to find a matching close → null → JsonException rethrow.
         $content = '[1,2] {';
         $llmResponse = LLMResponse::create($content, 10, 5, 'claude', 'end_turn');
 
@@ -149,11 +135,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_it_extracts_json_object_when_braces_are_the_first_opener(): void
     {
-        // Pins the `{`-opener branch in `findFirstJsonOpener`: with no `[` earlier
-        // in the content, a ReturnRemoval on the `{` branch would skip past the
-        // opener, find no other opener later, and return null — collapsing back to
-        // a JsonException rethrow. The successful object extraction proves the
-        // branch returned its tuple.
         $content = 'prose {"key": "value"} suffix';
         $llmResponse = LLMResponse::create($content, 10, 5, 'claude', 'end_turn');
 
@@ -164,10 +145,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_it_recovers_trailing_empty_array_when_prose_mentions_php_array_access(): void
     {
-        // Reproduces the production log: the prose mentions `recommendation.contents[locale]`,
-        // which puts `[locale]` ahead of the real JSON. The first-opener heuristic would
-        // extract `[locale]`, fail to decode, and surface the JsonException — even though
-        // the actual JSON payload `[]` is right there at the end of the message.
         $content = "  The controller has a route condition restricting it to dev/test only. No exploitable issue.\n  \n"
             .'  The templates given are mostly safe - default escaping, translated strings, no `|raw` on user input.'
             .' The recommendation card displays `recommendation.contents[locale]` without escaping override -'
@@ -182,9 +159,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_it_recovers_trailing_vulnerability_list_when_prose_contains_undecodable_bracket_example(): void
     {
-        // Prose mentions PHP-style example syntax like `[array key]` whose bracketed
-        // content is not valid JSON. The first opener block fails to decode; the
-        // iterator must continue to the trailing real vulnerability list.
         $content = 'I noticed templates rendering `recommendation.contents[locale]` and'
             ." constructs like [array key access] in helpers. Final list of findings:\n"
             .'[{"type":"sql_injection","severity":"high","title":"Unsafe query",'
@@ -222,12 +196,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_recovery_is_skipped_when_first_character_is_an_object_opener_spanning_full_content(): void
     {
-        // Companion to the array-opener case. An `Identical` mutation flipping
-        // the `{`-opener check to `!==` makes the guard fail for object-shaped
-        // payloads — recovery would then walk into the embedded `[1]` sub-block
-        // and return it, masking the malformed JSON. The non-mutant identifies
-        // the whole content as a single balanced object, skips recovery, and
-        // rethrows the original `JsonException`.
         $llmResponse = LLMResponse::create('{xyz: [1]}', 10, 5, 'claude', 'end_turn');
 
         $this->expectException(JsonException::class);
@@ -236,16 +204,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_recovery_is_skipped_when_first_character_opens_a_block_spanning_full_content(): void
     {
-        // When the trimmed content is itself a single balanced block, the
-        // top-level `json_decode` already saw exactly that payload, so trying
-        // openers nested INSIDE it would silently accept shallower sub-blocks —
-        // defeating the depth limit and masking malformed payloads. An
-        // `IncrementInteger` mutation reading `$content[1]` instead of
-        // `$content[0]` would miss the leading `[`, fall through to a `false`
-        // return, and let recovery walk into the inner `[1,2]` block. Pin the
-        // index-0 lookup with a malformed list whose inner `[1,2]` decodes:
-        // original sees the full content as a balanced block, skips recovery,
-        // and rethrows `JsonException`. The mutant would recover `[1, 2]`.
         $llmResponse = LLMResponse::create('[xyz, [1,2]]', 10, 5, 'claude', 'end_turn');
 
         $this->expectException(JsonException::class);
@@ -254,13 +212,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_recovery_invokes_object_branch_only_on_brace_character(): void
     {
-        // An `Identical` mutation flipping the `{`-opener check to `!==` makes
-        // the elseif fire on EVERY non-brace character — and skip the actual
-        // `{` position via the `else continue`. With a stray `}` before the
-        // real `{}` block, the mutant scans `{`/`}` from the leading `}` and
-        // is then forced past the real `{` opener entirely; it never recovers,
-        // so the original `JsonException` is rethrown. The non-mutant correctly
-        // recovers `{}` → `[]`.
         $llmResponse = LLMResponse::create('}{}', 10, 5, 'claude', 'end_turn');
 
         $data = $llmResponse->parseJson();
@@ -270,14 +221,6 @@ final class LLMResponseTest extends TestCase
 
     public function test_recovery_iterator_starts_at_index_zero_not_minus_one(): void
     {
-        // PHP returns the last character for `$content[-1]`. A DecrementInteger
-        // mutation flipping the iterator's initial index from `0` to `-1` would
-        // pre-process the last character before reaching position 0 — when the
-        // content ends with `"`, the mutant flips `inString` on the trailing
-        // quote, then on the next iteration the leading `[` is treated as string
-        // content and skipped. The mutant fails to recover and the original
-        // `JsonException` is rethrown. The non-mutant starts cleanly at 0,
-        // decodes the leading `[1,2]` and returns the recovered array.
         $llmResponse = LLMResponse::create('[1,2]"', 10, 5, 'claude', 'end_turn');
 
         $data = $llmResponse->parseJson();

--- a/tests/Phpunit/Unit/Infrastructure/LLM/RateLimit/RetryAfterHeaderParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/RateLimit/RetryAfterHeaderParserTest.php
@@ -50,9 +50,6 @@ final class RetryAfterHeaderParserTest extends TestCase
 
     public function test_typed_exception_with_zero_retry_after_returns_null(): void
     {
-        // retry-after: 0 is a degenerate hint — the parser must treat it as
-        // "no useful hint" so the caller's exponential backoff kicks in
-        // instead of an immediate (potentially-stampeding) retry.
         $rateLimitExceededException = new RateLimitExceededException(retryAfter: 0);
 
         $retryAfterHeaderParser = new RetryAfterHeaderParser();
@@ -80,10 +77,6 @@ final class RetryAfterHeaderParserTest extends TestCase
 
     public function test_message_extraction_is_case_insensitive(): void
     {
-        // Real HTTP responses surface the header as `Retry-After:` (titlecase)
-        // while symfony/ai exception messages tend to be lowercase. The regex
-        // must match both — without the `i` flag, titlecase variants would
-        // silently fall through.
         $runtimeException = new RuntimeException('HTTP 429: Retry-After: 23');
 
         $retryAfterHeaderParser = new RetryAfterHeaderParser();

--- a/tests/Phpunit/Unit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiterTest.php
@@ -219,11 +219,6 @@ final class TokenBucketRateLimiterTest extends TestCase
             sleeper: $sleeper,
         );
 
-        // After waking from a pause, the acquire must continue the loop —
-        // run the capacity check, consume the quota, then return. If the
-        // pause-branch `break`s instead of `continue`s, the first acquire
-        // returns without incrementing requestsUsed, and the second acquire
-        // slips through under RPM=1 with no extra sleep.
         $tokenBucketRateLimiter->pauseUntil(new DateTimeImmutable('2026-01-01T12:00:30+00:00'));
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 0);
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 0);
@@ -460,10 +455,6 @@ final class TokenBucketRateLimiterTest extends TestCase
             sleeper: $sleeper,
         );
 
-        // Two acquires (5 + 10) must accumulate inputTokensUsed to 15 — a
-        // third acquire of 5 must block because (15 + 5) > 15. If acquire
-        // overwrites instead of accumulating, the bucket would read 10 and
-        // the third call would slip through.
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 5);
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 10);
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 5);
@@ -486,10 +477,6 @@ final class TokenBucketRateLimiterTest extends TestCase
             sleeper: $sleeper,
         );
 
-        // After acquire(5) + record(5, 0) the bucket must hold exactly 5
-        // input tokens. A subsequent acquire(6) must block ((5+6) > 10).
-        // If the reconcile operator flipped to subtraction, bucket would
-        // collapse to 0 and the 6-token call would slip through.
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 5);
         $tokenBucketRateLimiter->record(inputTokens: 5, outputTokens: 0);
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 6);
@@ -512,10 +499,6 @@ final class TokenBucketRateLimiterTest extends TestCase
             sleeper: $sleeper,
         );
 
-        // Estimate 5, record actual 0 → frees the full 5 tokens. Next
-        // acquire(5) must fit. If max(0, $inputTokens) clamp were
-        // max(1, $inputTokens), recorded input becomes 1 instead of 0,
-        // leaving inputTokensUsed at 1; (1 + 5) > 5 would block.
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 5);
         $tokenBucketRateLimiter->record(inputTokens: 0, outputTokens: 0);
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 5);
@@ -538,11 +521,6 @@ final class TokenBucketRateLimiterTest extends TestCase
             sleeper: $sleeper,
         );
 
-        // After acquire+record+record, pendingInputEstimate must be exactly
-        // 0 — so the third reconcile yields inputTokensUsed=10 (not 11).
-        // A boundary acquire(0) must then succeed; if record had left
-        // pendingInputEstimate at -1, the reconcile would over-add and
-        // (11 + 0) > 10 would block.
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 0);
         $tokenBucketRateLimiter->record(inputTokens: 5, outputTokens: 0);
         $tokenBucketRateLimiter->record(inputTokens: 5, outputTokens: 0);

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
@@ -19,22 +19,22 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ConsolePr
 
 final class ConsoleProgressReporterTest extends TestCase
 {
-    private BufferedOutput $output;
+    private BufferedOutput $bufferedOutput;
 
-    private ConsoleProgressReporter $reporter;
+    private ConsoleProgressReporter $consoleProgressReporter;
 
     public function test_it_renders_progress_bar_across_full_pipeline_lifecycle(): void
     {
-        $this->reporter->report('pipeline.started', ['stages' => ['ingestion', 'mapping', 'audit']]);
-        $this->reporter->report('stage.started', ['stage' => 'ingestion']);
-        $this->reporter->report('stage.completed');
-        $this->reporter->report('stage.started', ['stage' => 'mapping']);
-        $this->reporter->report('stage.completed');
-        $this->reporter->report('stage.started', ['stage' => 'audit']);
-        $this->reporter->report('stage.completed');
-        $this->reporter->report('pipeline.completed');
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['ingestion', 'mapping', 'audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'ingestion']);
+        $this->consoleProgressReporter->report('stage.completed');
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'mapping']);
+        $this->consoleProgressReporter->report('stage.completed');
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('stage.completed');
+        $this->consoleProgressReporter->report('pipeline.completed');
 
-        $rendered = $this->output->fetch();
+        $rendered = $this->bufferedOutput->fetch();
 
         self::assertStringContainsString('3/3', $rendered);
         self::assertStringContainsString('100%', $rendered);
@@ -42,67 +42,67 @@ final class ConsoleProgressReporterTest extends TestCase
 
     public function test_it_shows_stage_name_in_progress_bar_message(): void
     {
-        $this->reporter->report('pipeline.started', ['stages' => ['ingestion', 'mapping', 'audit']]);
-        $this->reporter->report('stage.started', ['stage' => 'mapping']);
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['ingestion', 'mapping', 'audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'mapping']);
 
-        self::assertStringContainsString('mapping', $this->output->fetch());
+        self::assertStringContainsString('mapping', $this->bufferedOutput->fetch());
     }
 
     public function test_it_writes_trailing_newline_on_pipeline_completed(): void
     {
-        $this->reporter->report('pipeline.started', ['stages' => ['ingestion']]);
-        $this->reporter->report('stage.completed');
-        $this->reporter->report('pipeline.completed');
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['ingestion']]);
+        $this->consoleProgressReporter->report('stage.completed');
+        $this->consoleProgressReporter->report('pipeline.completed');
 
-        self::assertStringEndsWith("\n", $this->output->fetch());
+        self::assertStringEndsWith("\n", $this->bufferedOutput->fetch());
     }
 
     public function test_it_ignores_unknown_events(): void
     {
-        $this->reporter->report('some.unknown.event', ['foo' => 'bar']);
+        $this->consoleProgressReporter->report('some.unknown.event', ['foo' => 'bar']);
 
-        self::assertSame('', $this->output->fetch());
+        self::assertSame('', $this->bufferedOutput->fetch());
     }
 
     public function test_stage_events_before_pipeline_started_are_no_ops(): void
     {
-        $this->reporter->report('stage.started', ['stage' => 'ingestion']);
-        $this->reporter->report('stage.completed');
-        $this->reporter->report('pipeline.completed');
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'ingestion']);
+        $this->consoleProgressReporter->report('stage.completed');
+        $this->consoleProgressReporter->report('pipeline.completed');
 
-        self::assertSame('', $this->output->fetch());
+        self::assertSame('', $this->bufferedOutput->fetch());
     }
 
     public function test_it_sizes_bar_to_stage_count(): void
     {
-        $this->reporter->report('pipeline.started', ['stages' => ['a', 'b']]);
-        $this->reporter->report('stage.completed');
-        $this->reporter->report('stage.completed');
-        $this->reporter->report('pipeline.completed');
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['a', 'b']]);
+        $this->consoleProgressReporter->report('stage.completed');
+        $this->consoleProgressReporter->report('stage.completed');
+        $this->consoleProgressReporter->report('pipeline.completed');
 
-        self::assertStringContainsString('2/2', $this->output->fetch());
+        self::assertStringContainsString('2/2', $this->bufferedOutput->fetch());
     }
 
     public function test_it_handles_missing_stages_context_gracefully(): void
     {
-        $this->reporter->report('pipeline.started', []);
-        $this->reporter->report('pipeline.completed');
+        $this->consoleProgressReporter->report('pipeline.started', []);
+        $this->consoleProgressReporter->report('pipeline.completed');
 
-        self::assertStringContainsString('0/0', $this->output->fetch());
+        self::assertStringContainsString('0/0', $this->bufferedOutput->fetch());
     }
 
     public function test_it_handles_missing_stage_name_gracefully(): void
     {
-        $this->reporter->report('pipeline.started', ['stages' => ['ingestion']]);
-        $this->reporter->report('stage.started', []);
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['ingestion']]);
+        $this->consoleProgressReporter->report('stage.started', []);
 
-        $rendered = $this->output->fetch();
+        $rendered = $this->bufferedOutput->fetch();
         self::assertNotEmpty($rendered);
     }
 
     protected function setUp(): void
     {
-        $this->output = new BufferedOutput();
-        $this->reporter = new ConsoleProgressReporter($this->output);
+        $this->bufferedOutput = new BufferedOutput();
+        $this->consoleProgressReporter = new ConsoleProgressReporter($this->bufferedOutput);
     }
 }

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Progress;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ConsoleProgressReporter;
+
+final class ConsoleProgressReporterTest extends TestCase
+{
+    private BufferedOutput $output;
+
+    private ConsoleProgressReporter $reporter;
+
+    public function test_it_renders_progress_bar_across_full_pipeline_lifecycle(): void
+    {
+        $this->reporter->report('pipeline.started', ['stages' => ['ingestion', 'mapping', 'audit']]);
+        $this->reporter->report('stage.started', ['stage' => 'ingestion']);
+        $this->reporter->report('stage.completed');
+        $this->reporter->report('stage.started', ['stage' => 'mapping']);
+        $this->reporter->report('stage.completed');
+        $this->reporter->report('stage.started', ['stage' => 'audit']);
+        $this->reporter->report('stage.completed');
+        $this->reporter->report('pipeline.completed');
+
+        $rendered = $this->output->fetch();
+
+        self::assertStringContainsString('3/3', $rendered);
+        self::assertStringContainsString('100%', $rendered);
+    }
+
+    public function test_it_shows_stage_name_in_progress_bar_message(): void
+    {
+        $this->reporter->report('pipeline.started', ['stages' => ['ingestion', 'mapping', 'audit']]);
+        $this->reporter->report('stage.started', ['stage' => 'mapping']);
+
+        self::assertStringContainsString('mapping', $this->output->fetch());
+    }
+
+    public function test_it_writes_trailing_newline_on_pipeline_completed(): void
+    {
+        $this->reporter->report('pipeline.started', ['stages' => ['ingestion']]);
+        $this->reporter->report('stage.completed');
+        $this->reporter->report('pipeline.completed');
+
+        self::assertStringEndsWith("\n", $this->output->fetch());
+    }
+
+    public function test_it_ignores_unknown_events(): void
+    {
+        $this->reporter->report('some.unknown.event', ['foo' => 'bar']);
+
+        self::assertSame('', $this->output->fetch());
+    }
+
+    public function test_stage_events_before_pipeline_started_are_no_ops(): void
+    {
+        $this->reporter->report('stage.started', ['stage' => 'ingestion']);
+        $this->reporter->report('stage.completed');
+        $this->reporter->report('pipeline.completed');
+
+        self::assertSame('', $this->output->fetch());
+    }
+
+    public function test_it_sizes_bar_to_stage_count(): void
+    {
+        $this->reporter->report('pipeline.started', ['stages' => ['a', 'b']]);
+        $this->reporter->report('stage.completed');
+        $this->reporter->report('stage.completed');
+        $this->reporter->report('pipeline.completed');
+
+        self::assertStringContainsString('2/2', $this->output->fetch());
+    }
+
+    public function test_it_handles_missing_stages_context_gracefully(): void
+    {
+        $this->reporter->report('pipeline.started', []);
+        $this->reporter->report('pipeline.completed');
+
+        self::assertStringContainsString('0/0', $this->output->fetch());
+    }
+
+    public function test_it_handles_missing_stage_name_gracefully(): void
+    {
+        $this->reporter->report('pipeline.started', ['stages' => ['ingestion']]);
+        $this->reporter->report('stage.started', []);
+
+        $rendered = $this->output->fetch();
+        self::assertNotEmpty($rendered);
+    }
+
+    protected function setUp(): void
+    {
+        $this->output = new BufferedOutput();
+        $this->reporter = new ConsoleProgressReporter($this->output);
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ProgressReporterHolderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ProgressReporterHolderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Progress;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;
+
+final class ProgressReporterHolderTest extends TestCase
+{
+    public function test_it_is_silent_by_default(): void
+    {
+        $holder = new ProgressReporterHolder();
+
+        $holder->report('pipeline.started', ['stages' => ['a']]);
+
+        self::assertTrue(true);
+    }
+
+    public function test_it_delegates_to_set_reporter(): void
+    {
+        $holder = new ProgressReporterHolder();
+
+        $reporter = $this->createMock(ProgressReporterInterface::class);
+        $reporter->expects(self::once())
+            ->method('report')
+            ->with('stage.completed', []);
+
+        $holder->setDelegate($reporter);
+        $holder->report('stage.completed');
+    }
+
+    public function test_it_swallows_reporter_exceptions(): void
+    {
+        $holder = new ProgressReporterHolder();
+
+        $reporter = $this->createStub(ProgressReporterInterface::class);
+        $reporter->method('report')->willThrowException(new \RuntimeException('boom'));
+
+        $holder->setDelegate($reporter);
+
+        $holder->report('pipeline.completed');
+
+        self::assertTrue(true);
+    }
+
+    public function test_it_forwards_context_to_delegate(): void
+    {
+        $holder = new ProgressReporterHolder();
+        $context = ['stage' => 'ingestion', 'audit_id' => 'abc'];
+
+        $reporter = $this->createMock(ProgressReporterInterface::class);
+        $reporter->expects(self::once())
+            ->method('report')
+            ->with('stage.started', $context);
+
+        $holder->setDelegate($reporter);
+        $holder->report('stage.started', $context);
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ProgressReporterHolderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ProgressReporterHolderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Progress;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;
 
@@ -21,43 +22,45 @@ final class ProgressReporterHolderTest extends TestCase
 {
     public function test_it_is_silent_by_default(): void
     {
-        $holder = new ProgressReporterHolder();
+        $progressReporterHolder = new ProgressReporterHolder();
+        $progressReporterHolder->report('pipeline.started', ['stages' => ['a']]);
 
-        $holder->report('pipeline.started', ['stages' => ['a']]);
-
-        self::assertTrue(true);
+        $reporter = $this->createMock(ProgressReporterInterface::class);
+        $reporter->expects(self::never())->method('report');
+        $progressReporterHolder->setDelegate($reporter);
     }
 
     public function test_it_delegates_to_set_reporter(): void
     {
-        $holder = new ProgressReporterHolder();
+        $progressReporterHolder = new ProgressReporterHolder();
 
         $reporter = $this->createMock(ProgressReporterInterface::class);
         $reporter->expects(self::once())
             ->method('report')
             ->with('stage.completed', []);
 
-        $holder->setDelegate($reporter);
-        $holder->report('stage.completed');
+        $progressReporterHolder->setDelegate($reporter);
+        $progressReporterHolder->report('stage.completed');
     }
 
     public function test_it_swallows_reporter_exceptions(): void
     {
-        $holder = new ProgressReporterHolder();
+        $progressReporterHolder = new ProgressReporterHolder();
 
-        $reporter = $this->createStub(ProgressReporterInterface::class);
-        $reporter->method('report')->willThrowException(new \RuntimeException('boom'));
+        $throwing = self::createStub(ProgressReporterInterface::class);
+        $throwing->method('report')->willThrowException(new RuntimeException('boom'));
+        $progressReporterHolder->setDelegate($throwing);
+        $progressReporterHolder->report('pipeline.completed');
 
-        $holder->setDelegate($reporter);
-
-        $holder->report('pipeline.completed');
-
-        self::assertTrue(true);
+        $working = $this->createMock(ProgressReporterInterface::class);
+        $working->expects(self::once())->method('report')->with('stage.started', []);
+        $progressReporterHolder->setDelegate($working);
+        $progressReporterHolder->report('stage.started');
     }
 
     public function test_it_forwards_context_to_delegate(): void
     {
-        $holder = new ProgressReporterHolder();
+        $progressReporterHolder = new ProgressReporterHolder();
         $context = ['stage' => 'ingestion', 'audit_id' => 'abc'];
 
         $reporter = $this->createMock(ProgressReporterInterface::class);
@@ -65,7 +68,7 @@ final class ProgressReporterHolderTest extends TestCase
             ->method('report')
             ->with('stage.started', $context);
 
-        $holder->setDelegate($reporter);
-        $holder->report('stage.started', $context);
+        $progressReporterHolder->setDelegate($reporter);
+        $progressReporterHolder->report('stage.started', $context);
     }
 }

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
@@ -174,11 +174,6 @@ final class ReviewerPromptBuilderTest extends TestCase
 
     public function test_system_prompt_emits_sections_in_documented_order(): void
     {
-        // Locks the concat chain in buildSystemPrompt(): persona → severity rubric
-        // → FP playbook → output statement → JSON schema → decision rules. Any
-        // ConcatOperandRemoval makes one section disappear (strpos returns false,
-        // assertNotFalse fails); any Concat swap puts sections out of order (the
-        // assertLessThan fails).
         $prompt = $this->reviewerPromptBuilder->buildSystemPrompt();
 
         $personaPos = strpos($prompt, 'You are a senior AppSec engineer');
@@ -204,9 +199,6 @@ final class ReviewerPromptBuilderTest extends TestCase
 
     public function test_batch_system_prompt_emits_sections_in_documented_order(): void
     {
-        // Same ordering guarantee for the batch variant — it has an extra
-        // "batch preamble" right after the core persona and an ordering
-        // instruction right before the decision rules.
         $prompt = $this->reviewerPromptBuilder->buildBatchSystemPrompt();
 
         $personaPos = strpos($prompt, 'You are a senior AppSec engineer');

--- a/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
@@ -365,9 +365,6 @@ final class ReportRendererTest extends TestCase
 
     public function test_render_sarif_rule_is_not_overwritten_when_same_type_appears_twice(): void
     {
-        // ??= mutated to = would overwrite the rule each time. With identical types the rule body is the same,
-        // but the count of entries remains 1 either way. To detect the mutation we capture the rule body
-        // at first occurrence and again after the second, ensuring no extra mutations sneak in.
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
         $vuln2 = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::CRITICAL, 'src/Bar.php', 10);
         $decoded = $this->decodeSarif($this->makeReport($vulnerability, $vuln2));

--- a/tests/Phpunit/Unit/Infrastructure/Tool/GrepToolTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Tool/GrepToolTest.php
@@ -138,9 +138,6 @@ final class GrepToolTest extends TestCase
 
     public function test_execute_caps_results_at_max_matches_and_stops_scanning_remaining_files(): void
     {
-        // Build two files. First file has MAX_MATCHES + 5 matches; second file has unique markers we
-        // want to verify are NOT scanned. break 2 must exit both loops; break 1 would let the outer
-        // loop reach the second file.
         $contentA = '';
         for ($i = 0; $i < self::MAX_MATCHES + 5; ++$i) {
             $contentA .= "foo line\n";


### PR DESCRIPTION
## Summary

- `audit:run` now renders a live **console progress bar** while the pipeline  runs
- `audit:run --dry-run` no longer shows `RISK LEVEL: SAFE / No validated  vulnerabilities found / Audit complete` — output that implied a real audit  had run and found nothing

## Type of change

- [x] Refactor / internal improvement

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)
