### PR TITLE
fix(agent): prevent non-array attacker entries from leaking into cache and logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.3.3] — 2026-05-26 — Mesh
+
+### Changed
+
+- `AttackerPromptBuilder` prompt bumped to version 3: the attacker is now
+  explicitly forbidden from emitting bare strings, numbers, booleans, or `null`
+  as JSON array elements, and is told to return `[]` rather than
+  `["no findings"]` or any prose substitute. Audits against vulnerability-free
+  projects previously logged a handful of `warning`-level
+  `Skipping non-array vulnerability entry from LLM` records per run because the
+  model occasionally interleaved prose entries with the expected vulnerability
+  dicts. Bumping the cache-key fold prevents stale v2 payloads — which may
+  already contain stray strings — from being replayed and re-triggering the
+  warning on a cache hit.
+- `VulnerabilityFactory` warning payload now carries an `entry_preview` field —
+  the first 120 bytes of the skipped value when it is a string, `null` otherwise
+  — so operators can see what the model emitted instead of a vulnerability dict
+  without having to enable debug logging.
+
+### Fixed
+
+- `AttackerAgent::analyzeChunk()` now filters non-array entries out of the raw
+  LLM payload before handing it to `AttackerCacheInterface::store()` and re-keys
+  the survivors as a list. Previously, any stray string, number, or `null` from
+  a chatty model was persisted to the filesystem cache as a gapped numeric-keyed
+  array, and the same warning re-fired on every subsequent cache hit. Only the
+  cache write path is affected; `VulnerabilityFactory::fromList()` still
+  receives the full unfiltered payload so the diagnostic warning continues to
+  surface model drift.
+
 ## [1.3.2] — 2026-05-26 — Sieve
 
 ### Fixed

--- a/src/Audit/Application/Agent/AttackerAgent.php
+++ b/src/Audit/Application/Agent/AttackerAgent.php
@@ -127,11 +127,13 @@ final readonly class AttackerAgent implements AttackerAgentInterface
                 return [];
             }
 
-            /** @var list<array<string, mixed>> $rawData */
+            /** @var list<mixed> $rawData */
             $rawData = $response->parseJson();
 
             if (!$bypassCache) {
-                $this->attackerCache->store($chunk, $rawData);
+                /** @var list<array<string, mixed>> $cacheablePayload */
+                $cacheablePayload = array_values(array_filter($rawData, 'is_array'));
+                $this->attackerCache->store($chunk, $cacheablePayload);
             }
 
             $this->recordChunkCoverage($chunk, 'analyzed', $coverageRecorder);

--- a/src/Audit/Application/Agent/VulnerabilityFactory.php
+++ b/src/Audit/Application/Agent/VulnerabilityFactory.php
@@ -22,6 +22,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class VulnerabilityFactory
 {
+    private const int ENTRY_PREVIEW_BYTES = 120;
+
     public function __construct(
         private LoggerInterface $logger,
     ) {}
@@ -82,6 +84,7 @@ final readonly class VulnerabilityFactory
             if (!\is_array($raw)) {
                 $this->logger->warning('Skipping non-array vulnerability entry from LLM', [
                     'entry_type' => get_debug_type($raw),
+                    'entry_preview' => \is_string($raw) ? substr($raw, 0, self::ENTRY_PREVIEW_BYTES) : null,
                 ]);
 
                 continue;

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -26,7 +26,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 2;
+    public const int PROMPT_VERSION = 3;
 
     /**
      * Skill-block emission order — by attack-surface priority, NOT alphabetical.
@@ -300,6 +300,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             - Consider the FULL call chain, not just single function calls
             - Cross-reference controllers, voters, services, and entities together
             - Return ONLY the JSON array, no prose, no markdown fences
+            - Every element of the JSON array MUST be a vulnerability object of the exact shape above. NEVER emit a bare string, number, boolean, or null as an array element. When no vulnerabilities are found, return `[]` — never `["no findings"]`, `["safe"]`, or any prose substitute.
 
             Tool Usage Discipline:
             - You have a LIMITED, finite tool-call budget per chunk. Do NOT gather evidence indefinitely — once you have enough to decide, stop using tools and emit the final JSON answer.

--- a/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
@@ -568,6 +568,45 @@ final class AttackerAgentTest extends TestCase
         $attackerAgent->analyze($files, SymfonyMapping::create(), new NullCoverageRecorder());
     }
 
+    public function test_it_filters_non_array_entries_out_of_cached_payload_as_a_list(): void
+    {
+        $files = [$this->makeFile('src/Controller/UserController.php')];
+
+        $firstFinding = [
+            'type' => 'broken_access_control',
+            'severity' => 'high',
+            'title' => 'First',
+            'description' => 'x',
+            'file_path' => 'src/Controller/UserController.php',
+            'line_start' => 1,
+            'line_end' => 2,
+            'vulnerable_code' => 'x',
+            'attack_vector' => 'x',
+            'proof' => 'x',
+            'remediation' => 'x',
+            'confidence' => 0.85,
+        ];
+        $secondFinding = ['type' => 'sql_injection'] + $firstFinding;
+        $secondFinding['title'] = 'Second';
+
+        $mixedPayload = [$firstFinding, 'stray prose entry', $secondFinding];
+
+        $cache = $this->createMock(AttackerCacheInterface::class);
+        $cache->method('get')->willReturn(null);
+        $cache->expects(self::once())
+            ->method('store')
+            ->with(self::isArray(), [$firstFinding, $secondFinding]);
+
+        $llmClient = self::createStub(LLMClientInterface::class);
+        $llmClient
+            ->method('complete')
+            ->willReturn(LLMResponse::create((string) json_encode($mixedPayload), 10, 10, 'claude', 'end_turn'));
+
+        $attackerAgent = $this->makeAttackerAgent($llmClient, $cache);
+
+        $attackerAgent->analyze($files, SymfonyMapping::create(), new NullCoverageRecorder());
+    }
+
     public function test_it_does_not_store_in_cache_when_llm_returns_empty_response(): void
     {
         $files = [$this->makeFile('src/Controller/UserController.php')];

--- a/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
@@ -102,13 +102,48 @@ final class VulnerabilityFactoryTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())
             ->method('warning')
-            ->with('Skipping non-array vulnerability entry from LLM', ['entry_type' => 'string']);
+            ->with('Skipping non-array vulnerability entry from LLM', [
+                'entry_type' => 'string',
+                'entry_preview' => 'not an array',
+            ]);
 
         $vulnerabilityFactory = new VulnerabilityFactory($logger);
 
         $result = $vulnerabilityFactory->fromList(['not an array']);
 
         self::assertEmpty($result);
+    }
+
+    public function test_it_truncates_long_string_preview_in_warning(): void
+    {
+        $longString = str_repeat('A', 200);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with('Skipping non-array vulnerability entry from LLM', [
+                'entry_type' => 'string',
+                'entry_preview' => str_repeat('A', 120),
+            ]);
+
+        $vulnerabilityFactory = new VulnerabilityFactory($logger);
+
+        $vulnerabilityFactory->fromList([$longString]);
+    }
+
+    public function test_it_omits_preview_for_non_string_entries(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with('Skipping non-array vulnerability entry from LLM', [
+                'entry_type' => 'int',
+                'entry_preview' => null,
+            ]);
+
+        $vulnerabilityFactory = new VulnerabilityFactory($logger);
+
+        $vulnerabilityFactory->fromList([42]);
     }
 
     public function test_it_uses_integer_line_numbers_correctly(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -513,7 +513,16 @@ final class AttackerPromptBuilderTest extends TestCase
 
     public function test_prompt_version_is_bumped_when_tool_usage_discipline_section_is_added(): void
     {
-        self::assertSame(2, AttackerPromptBuilder::PROMPT_VERSION);
+        self::assertSame(3, AttackerPromptBuilder::PROMPT_VERSION);
+    }
+
+    public function test_base_prompt_forbids_non_object_array_elements(): void
+    {
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString('Every element of the JSON array MUST be a vulnerability object', $prompt);
+        self::assertStringContainsString('NEVER emit a bare string, number, boolean, or null as an array element', $prompt);
+        self::assertStringContainsString('return `[]`', $prompt);
     }
 
     public function test_base_prompt_instructs_model_to_converge_within_tool_call_budget(): void


### PR DESCRIPTION
## Summary

- AttackerPromptBuilder v3 explicitly forbids bare strings, numbers, booleans, or null as JSON array elements and instructs the model to return [] instead of prose substitutes for empty results. Bumping PROMPT_VERSION invalidates v2-era cached responses that may already contain stray strings.
- AttackerAgent::analyzeChunk filters non-array entries via array_values(array_filter(..., 'is_array')) before AttackerCacheInterface::store, preventing warning replay on cache hit and ensuring the cached payload remains a list rather than a gapped numeric-keyed array.
- VulnerabilityFactory warning payload gains an entry_preview field carrying the first 120 bytes of the skipped value when it is a string (null otherwise) so operators can diagnose LLM drift without enabling debug logging.

<!-- Closes #xxx -->

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)
