### PR TITLE
ci: allow `prompt` scope in commitlint config

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -44,6 +44,7 @@ export default {
                 'tool',
                 'cache',
                 'report',
+                'prompt',
                 'scan',
                 'rate-limit',
             ],


### PR DESCRIPTION
The merged commit feat(prompt): ... (#26) failed the Commit Lint job on
main because `prompt` was missing from scope-enum, despite a legitimate
src/Audit/Infrastructure/Prompt/ directory existing.

https://claude.ai/code/session_01CTGbFt3rgMEMrCyQr8GaMk