### PR TITLE
feat: parse files into domain graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
-## [1.5.0] — 2026-05-28 — Bloodhound II
+## [1.5.0] — 2026-05-28 — Cartographer
 
 A visibility, hardening, and coverage release. The auditor now reports how much
 LLM output it had to drop on the floor, warns operators on stderr when sensitive
@@ -79,7 +79,7 @@ Domain port signature changed.
 
 ### Changed
 
-- `AttackerPromptBuilder::PROMPT_VERSION` bumped to **7** and
+- `AttackerPromptBuilder::PROMPT_VERSION` bumped to **5** and
   `RegexStaticPreScanner::CACHE_VERSION` bumped to **2** so cached attacker
   responses invalidate automatically against the new prompt and pattern.
 - `VulnerabilityFactory` now takes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 ## [1.5.0] — 2026-05-28 — Bloodhound II
 
 A visibility, hardening, and coverage release. The auditor now reports how much
-LLM output it had to drop on the floor, warns operators on stderr when
-sensitive content will be sent to the cloud unscrubbed, looks for
-over-permissive serializer groups on entities, and parses controller routes
-and access-control attributes into a graph fed to the attacker prompt. Every
-change is backward compatible — no existing key, default, exit code,
-JSON/SARIF schema field, or Domain port signature changed.
+LLM output it had to drop on the floor, warns operators on stderr when sensitive
+content will be sent to the cloud unscrubbed, looks for over-permissive
+serializer groups on entities, and parses controller routes and access-control
+attributes into a graph fed to the attacker prompt. Every change is backward
+compatible — no existing key, default, exit code, JSON/SARIF schema field, or
+Domain port signature changed.
 
 ### Added
 
@@ -37,8 +37,8 @@ JSON/SARIF schema field, or Domain port signature changed.
   output (empty file paths, 100 KB descriptions) that previously slipped through
   `Vulnerability::create`'s coarser guards.
 - **Secret-scrubbing pre-flight warning.** `audit:run` now emits a one-shot
-  warning on **stderr** after the header when `scan.secret_scrubbing.enabled`
-  is set to `false`, explaining that file contents will be sent verbatim to the
+  warning on **stderr** after the header when `scan.secret_scrubbing.enabled` is
+  set to `false`, explaining that file contents will be sent verbatim to the
   configured LLM provider. Routing to stderr means the warning always surfaces
   (including when `--format=json|sarif` writes to stdout) without polluting the
   parseable machine-readable payload. The default (`true`) is unchanged.
@@ -50,8 +50,8 @@ JSON/SARIF schema field, or Domain port signature changed.
   (`roles`, `isAdmin`, `passwordHash`, `apiToken`) landing in write-side groups
   (`*:write`) and sensitive fields leaking via read-side groups (`*:read`,
   `public`).
-- **Full route → controller → voter → form semantic graph.** Three new
-  Domain ports (`ControllerAccessControlParserInterface`,
+- **Full route → controller → voter → form semantic graph.** Three new Domain
+  ports (`ControllerAccessControlParserInterface`,
   `VoterCapabilityParserInterface`, `FormBindingParserInterface`) with AST-based
   default implementations (backed by `nikic/php-parser`):
   - `PhpParserControllerAccessControlParser` walks every controller and emits
@@ -69,31 +69,31 @@ JSON/SARIF schema field, or Domain port signature changed.
   `formBindings()`, and `formBindingsForController()` accessors. `MappingStage`
   populates the graph and surfaces `mapping.routes`,
   `mapping.routes_without_access_check`, `mapping.voter_capabilities`, and
-  `mapping.form_bindings` metadata on `AuditContext`. The attacker prompt
-  now ships three new context blocks — `Route Access-Control Map`,
-  `Voter Coverage`, and `Form Bindings` — so the LLM can cross-reference an
-  `#[IsGranted('ATTR', $subject)]` against the voters that actually accept
-  that attribute on that subject (a `missing_voter` finding when nothing
-  matches), and cross-reference `createForm()` call sites against the form
-  types involved (mass-assignment / CSRF surface).
+  `mapping.form_bindings` metadata on `AuditContext`. The attacker prompt now
+  ships three new context blocks — `Route Access-Control Map`, `Voter Coverage`,
+  and `Form Bindings` — so the LLM can cross-reference an
+  `#[IsGranted('ATTR', $subject)]` against the voters that actually accept that
+  attribute on that subject (a `missing_voter` finding when nothing matches),
+  and cross-reference `createForm()` call sites against the form types involved
+  (mass-assignment / CSRF surface).
 
 ### Changed
 
 - `AttackerPromptBuilder::PROMPT_VERSION` bumped to **7** and
   `RegexStaticPreScanner::CACHE_VERSION` bumped to **2** so cached attacker
   responses invalidate automatically against the new prompt and pattern.
-- `VulnerabilityFactory` now takes a `Symfony\Component\Validator\Validator\ValidatorInterface`
-  as a constructor argument (autowired via a private inline factory in
-  `config/services.php`). The factory is `@internal`, so this is a non-BC change
-  for end users; downstream custom-agent code that constructs the factory
-  manually must pass a `ValidatorInterface` (typically
-  `Validation::createValidator()`).
+- `VulnerabilityFactory` now takes a
+  `Symfony\Component\Validator\Validator\ValidatorInterface` as a constructor
+  argument (autowired via a private inline factory in `config/services.php`).
+  The factory is `@internal`, so this is a non-BC change for end users;
+  downstream custom-agent code that constructs the factory manually must pass a
+  `ValidatorInterface` (typically `Validation::createValidator()`).
 - `MappingStage` now takes three optional parser arguments
   (`ControllerAccessControlParserInterface`, `VoterCapabilityParserInterface`,
-  `FormBindingParserInterface`); each defaults to a no-op parser, preserving
-  the previous shape. The DI wiring binds the real parsers in production.
-- `nikic/php-parser ^5.3` is now a runtime dependency (previously transitive
-  via `phpunit/php-code-coverage`); used by the three AST parsers.
+  `FormBindingParserInterface`); each defaults to a no-op parser, preserving the
+  previous shape. The DI wiring binds the real parsers in production.
+- `nikic/php-parser ^5.3` is now a runtime dependency (previously transitive via
+  `phpunit/php-code-coverage`); used by the three AST parsers.
 
 ## [1.4.0] — 2026-05-27 — Bloodhound
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,57 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-05-28 — Bloodhound II
+
+A visibility, hardening, and coverage release. The auditor now reports how much
+LLM output it had to drop on the floor, warns operators when sensitive content
+will be sent to the cloud unscrubbed, and looks for over-permissive serializer
+groups on entities. Every change is backward compatible — no existing key,
+default, exit code, JSON/SARIF schema field, or Domain port signature changed.
+
+### Added
+
+- **Visible hydration drops.** `VulnerabilityFactory::fromList()` now returns a
+  `VulnerabilityHydrationResult` value object (vulnerabilities + drop counts
+  bucketed by `VulnerabilityDropReason`: `non_array_entry`, `validation_failed`,
+  `hydration_failed`). Each drop is logged with a structured `reason` code, and
+  per-audit totals appear on the `Attacker agent complete` info log line under
+  `total_dropped_entries` / `dropped_by_reason` — so silent loss of an LLM-
+  proposed vulnerability is no longer invisible to operators.
+- **`symfony/validator` constraints on hydrated findings.** The factory now
+  validates raw LLM payloads against `Assert\Collection` constraints (non-blank
+  `title` / `description` / `file_path`, sane length bounds on all free-text
+  fields) and drops violators under the new `validation_failed` reason, with the
+  structured violation messages in the log payload. Catches pathological LLM
+  output (empty file paths, 100 KB descriptions) that previously slipped through
+  `Vulnerability::create`'s coarser guards.
+- **Secret-scrubbing pre-flight warning.** `audit:run` now emits a one-shot
+  warning after the header when `scan.secret_scrubbing.enabled` is set to
+  `false`, explaining that file contents will be sent verbatim to the configured
+  LLM provider. The warning is suppressed for machine-readable output
+  (`--format=json|sarif` to stdout) so CI pipelines keep parseable output. The
+  default (`true`) is unchanged.
+- **`over_permissive_serializer_group` coverage.** New
+  `VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP` (category
+  Symfony-Specific, OWASP A05:2021) plus a `RegexStaticPreScanner` marker for
+  the PHP-attribute and annotation forms of `#[Groups(...)]` / `@Groups({...})`
+  on entities. The attacker entity skill block now flags privileged fields
+  (`roles`, `isAdmin`, `passwordHash`, `apiToken`) landing in write-side groups
+  (`*:write`) and sensitive fields leaking via read-side groups (`*:read`,
+  `public`).
+
+### Changed
+
+- `AttackerPromptBuilder::PROMPT_VERSION` bumped to **5** and
+  `RegexStaticPreScanner::CACHE_VERSION` bumped to **2** so cached attacker
+  responses invalidate automatically against the new prompt and pattern.
+- `VulnerabilityFactory` now takes a `Symfony\Component\Validator\Validator\ValidatorInterface`
+  as a constructor argument (autowired via a private inline factory in
+  `config/services.php`). The factory is `@internal`, so this is a non-BC change
+  for end users; downstream custom-agent code that constructs the factory
+  manually must pass a `ValidatorInterface` (typically
+  `Validation::createValidator()`).
+
 ## [1.4.0] — 2026-05-27 — Bloodhound
 
 A detection-and-cost release. The auditor now covers the modern Symfony 7.x/8.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 ## [1.5.0] — 2026-05-28 — Bloodhound II
 
 A visibility, hardening, and coverage release. The auditor now reports how much
-LLM output it had to drop on the floor, warns operators when sensitive content
-will be sent to the cloud unscrubbed, and looks for over-permissive serializer
-groups on entities. Every change is backward compatible — no existing key,
-default, exit code, JSON/SARIF schema field, or Domain port signature changed.
+LLM output it had to drop on the floor, warns operators on stderr when
+sensitive content will be sent to the cloud unscrubbed, looks for
+over-permissive serializer groups on entities, and parses controller routes
+and access-control attributes into a graph fed to the attacker prompt. Every
+change is backward compatible — no existing key, default, exit code,
+JSON/SARIF schema field, or Domain port signature changed.
 
 ### Added
 
@@ -35,11 +37,11 @@ default, exit code, JSON/SARIF schema field, or Domain port signature changed.
   output (empty file paths, 100 KB descriptions) that previously slipped through
   `Vulnerability::create`'s coarser guards.
 - **Secret-scrubbing pre-flight warning.** `audit:run` now emits a one-shot
-  warning after the header when `scan.secret_scrubbing.enabled` is set to
-  `false`, explaining that file contents will be sent verbatim to the configured
-  LLM provider. The warning is suppressed for machine-readable output
-  (`--format=json|sarif` to stdout) so CI pipelines keep parseable output. The
-  default (`true`) is unchanged.
+  warning on **stderr** after the header when `scan.secret_scrubbing.enabled`
+  is set to `false`, explaining that file contents will be sent verbatim to the
+  configured LLM provider. Routing to stderr means the warning always surfaces
+  (including when `--format=json|sarif` writes to stdout) without polluting the
+  parseable machine-readable payload. The default (`true`) is unchanged.
 - **`over_permissive_serializer_group` coverage.** New
   `VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP` (category
   Symfony-Specific, OWASP A05:2021) plus a `RegexStaticPreScanner` marker for
@@ -48,10 +50,23 @@ default, exit code, JSON/SARIF schema field, or Domain port signature changed.
   (`roles`, `isAdmin`, `passwordHash`, `apiToken`) landing in write-side groups
   (`*:write`) and sensitive fields leaking via read-side groups (`*:read`,
   `public`).
+- **Route → controller access-control graph (Phase 1).** A new
+  `ControllerAccessControlParserInterface` port (default implementation
+  `PhpParserControllerAccessControlParser` using `nikic/php-parser`) walks
+  every controller's AST and emits one `RouteAccessControl` value object per
+  public action, capturing the `#[Route(path:, methods:)]` attribute, both
+  class- and method-level `#[IsGranted(...)]`, and `denyAccessUnlessGranted()`
+  call sites. `SymfonyMapping` gains `routeAccessControls()` and
+  `controllersWithoutAccessCheck()` accessors. `MappingStage` populates the
+  graph and surfaces `mapping.routes` / `mapping.routes_without_access_check`
+  metadata on `AuditContext`. The attacker prompt now ships a `Route
+  Access-Control Map` block listing every action with its enforcement
+  surface — actions tagged with the LACKS marker are direct candidates for
+  `broken_access_control` and `missing_voter` findings.
 
 ### Changed
 
-- `AttackerPromptBuilder::PROMPT_VERSION` bumped to **5** and
+- `AttackerPromptBuilder::PROMPT_VERSION` bumped to **6** and
   `RegexStaticPreScanner::CACHE_VERSION` bumped to **2** so cached attacker
   responses invalidate automatically against the new prompt and pattern.
 - `VulnerabilityFactory` now takes a `Symfony\Component\Validator\Validator\ValidatorInterface`
@@ -60,6 +75,11 @@ default, exit code, JSON/SARIF schema field, or Domain port signature changed.
   for end users; downstream custom-agent code that constructs the factory
   manually must pass a `ValidatorInterface` (typically
   `Validation::createValidator()`).
+- `MappingStage` now takes an optional `ControllerAccessControlParserInterface`
+  constructor argument (defaults to a no-op parser to preserve the previous
+  shape). The DI wiring binds the real parser in production.
+- `nikic/php-parser ^5.3` is now a runtime dependency (previously transitive
+  via `phpunit/php-code-coverage`); used by the new controller AST parser.
 
 ## [1.4.0] — 2026-05-27 — Bloodhound
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,23 +50,36 @@ JSON/SARIF schema field, or Domain port signature changed.
   (`roles`, `isAdmin`, `passwordHash`, `apiToken`) landing in write-side groups
   (`*:write`) and sensitive fields leaking via read-side groups (`*:read`,
   `public`).
-- **Route → controller access-control graph (Phase 1).** A new
-  `ControllerAccessControlParserInterface` port (default implementation
-  `PhpParserControllerAccessControlParser` using `nikic/php-parser`) walks
-  every controller's AST and emits one `RouteAccessControl` value object per
-  public action, capturing the `#[Route(path:, methods:)]` attribute, both
-  class- and method-level `#[IsGranted(...)]`, and `denyAccessUnlessGranted()`
-  call sites. `SymfonyMapping` gains `routeAccessControls()` and
-  `controllersWithoutAccessCheck()` accessors. `MappingStage` populates the
-  graph and surfaces `mapping.routes` / `mapping.routes_without_access_check`
-  metadata on `AuditContext`. The attacker prompt now ships a `Route
-  Access-Control Map` block listing every action with its enforcement
-  surface — actions tagged with the LACKS marker are direct candidates for
-  `broken_access_control` and `missing_voter` findings.
+- **Full route → controller → voter → form semantic graph.** Three new
+  Domain ports (`ControllerAccessControlParserInterface`,
+  `VoterCapabilityParserInterface`, `FormBindingParserInterface`) with AST-based
+  default implementations (backed by `nikic/php-parser`):
+  - `PhpParserControllerAccessControlParser` walks every controller and emits
+    one `RouteAccessControl` per public action, capturing the
+    `#[Route(path:, methods:)]` attribute, both class- and method-level
+    `#[IsGranted(...)]`, and `denyAccessUnlessGranted()` call sites.
+  - `PhpParserVoterCapabilityParser` walks every voter file and emits a
+    `VoterCapability` describing the attribute strings and `instanceof` subject
+    types referenced inside its `supports()` body.
+  - `PhpParserFormBindingParser` walks every controller and emits one
+    `FormBinding` per `$this->createForm(SomeFormType::class)` call site.
+
+  `SymfonyMapping` gains `routeAccessControls()`,
+  `controllersWithoutAccessCheck()`, `voterCapabilities()`, `votersFor()`,
+  `formBindings()`, and `formBindingsForController()` accessors. `MappingStage`
+  populates the graph and surfaces `mapping.routes`,
+  `mapping.routes_without_access_check`, `mapping.voter_capabilities`, and
+  `mapping.form_bindings` metadata on `AuditContext`. The attacker prompt
+  now ships three new context blocks — `Route Access-Control Map`,
+  `Voter Coverage`, and `Form Bindings` — so the LLM can cross-reference an
+  `#[IsGranted('ATTR', $subject)]` against the voters that actually accept
+  that attribute on that subject (a `missing_voter` finding when nothing
+  matches), and cross-reference `createForm()` call sites against the form
+  types involved (mass-assignment / CSRF surface).
 
 ### Changed
 
-- `AttackerPromptBuilder::PROMPT_VERSION` bumped to **6** and
+- `AttackerPromptBuilder::PROMPT_VERSION` bumped to **7** and
   `RegexStaticPreScanner::CACHE_VERSION` bumped to **2** so cached attacker
   responses invalidate automatically against the new prompt and pattern.
 - `VulnerabilityFactory` now takes a `Symfony\Component\Validator\Validator\ValidatorInterface`
@@ -75,11 +88,12 @@ JSON/SARIF schema field, or Domain port signature changed.
   for end users; downstream custom-agent code that constructs the factory
   manually must pass a `ValidatorInterface` (typically
   `Validation::createValidator()`).
-- `MappingStage` now takes an optional `ControllerAccessControlParserInterface`
-  constructor argument (defaults to a no-op parser to preserve the previous
-  shape). The DI wiring binds the real parser in production.
+- `MappingStage` now takes three optional parser arguments
+  (`ControllerAccessControlParserInterface`, `VoterCapabilityParserInterface`,
+  `FormBindingParserInterface`); each defaults to a no-op parser, preserving
+  the previous shape. The DI wiring binds the real parsers in production.
 - `nikic/php-parser ^5.3` is now a runtime dependency (previously transitive
-  via `phpunit/php-code-coverage`); used by the new controller AST parser.
+  via `phpunit/php-code-coverage`); used by the three AST parsers.
 
 ## [1.4.0] — 2026-05-27 — Bloodhound
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,9 @@ Commit messages are validated separately in CI via
 src/
   Audit/
     Domain/          # Pure PHP — no framework, no I/O
-      Model/         # Value objects and enums (Vulnerability, AuditReport, ProjectFile, ProjectFileType, RouteAccessControl, VulnerabilityHydrationResult, VulnerabilityDropReason, …)
+      Model/         # Value objects and enums (Vulnerability, AuditReport, ProjectFile, ProjectFileType, RouteAccessControl, VoterCapability, FormBinding, VulnerabilityHydrationResult, VulnerabilityDropReason, …)
       Pipeline/      # PipelineInterface, StageInterface, CoverageRecorderInterface (ports)
-      Port/          # Cross-layer ports (LLMClientInterface, BatchCapableLLMClientInterface, LLMResponse, *PromptBuilderInterface, ProjectFileScannerInterface, AttackerCacheInterface, AdvisoryDatabaseInterface, SecretScrubberInterface, TokenEstimatorInterface, PricingProviderInterface, RateLimiterInterface, StaticPreScannerInterface, CodeSlicerInterface, ControllerAccessControlParserInterface, GitChangedFilesResolverInterface)
+      Port/          # Cross-layer ports (LLMClientInterface, BatchCapableLLMClientInterface, LLMResponse, *PromptBuilderInterface, ProjectFileScannerInterface, AttackerCacheInterface, AdvisoryDatabaseInterface, SecretScrubberInterface, TokenEstimatorInterface, PricingProviderInterface, RateLimiterInterface, StaticPreScannerInterface, CodeSlicerInterface, ControllerAccessControlParserInterface, VoterCapabilityParserInterface, FormBindingParserInterface, GitChangedFilesResolverInterface)
         Tool/        # ToolInterface, ToolDefinition, ToolRegistry, ToolRegistryFactoryInterface
     Application/     # Orchestration — no I/O, depends only on Domain
       UseCase/       # RunAuditUseCase, EstimateAuditCostUseCase (entry points)
@@ -73,7 +73,7 @@ src/
     Infrastructure/  # I/O adapters
       LLM/           # SymfonyAiLLMClient, RetryPolicy, TransientFailureClassifier, CharacterBasedTokenEstimator, Delay/, RateLimit/{NullRateLimiter, TokenBucketRateLimiter, RetryAfterHeaderParser}
       FileSystem/    # ProjectFileScanner, RegexSecretScrubber, NullSecretScrubber
-      Scan/          # RegexStaticPreScanner, NullStaticPreScanner, RegexCodeSlicer, NullCodeSlicer, PhpParserControllerAccessControlParser, NullControllerAccessControlParser
+      Scan/          # RegexStaticPreScanner, NullStaticPreScanner, RegexCodeSlicer, NullCodeSlicer, PhpParserControllerAccessControlParser, NullControllerAccessControlParser, PhpParserVoterCapabilityParser, NullVoterCapabilityParser, PhpParserFormBindingParser, NullFormBindingParser
       Diff/          # ProcessGitChangedFilesResolver (git diff for --since)
       Prompt/        # AttackerPromptBuilder, ReviewerPromptBuilder
       Cache/         # FilesystemAttackerCache, NullAttackerCache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Commit messages are validated separately in CI via
 src/
   Audit/
     Domain/          # Pure PHP — no framework, no I/O
-      Model/         # Value objects and enums (Vulnerability, AuditReport, ProjectFile, ProjectFileType, …)
+      Model/         # Value objects and enums (Vulnerability, AuditReport, ProjectFile, ProjectFileType, VulnerabilityHydrationResult, VulnerabilityDropReason, …)
       Pipeline/      # PipelineInterface, StageInterface, CoverageRecorderInterface (ports)
       Port/          # Cross-layer ports (LLMClientInterface, BatchCapableLLMClientInterface, LLMResponse, *PromptBuilderInterface, ProjectFileScannerInterface, AttackerCacheInterface, AdvisoryDatabaseInterface, SecretScrubberInterface, TokenEstimatorInterface, PricingProviderInterface, RateLimiterInterface, StaticPreScannerInterface, CodeSlicerInterface, GitChangedFilesResolverInterface)
         Tool/        # ToolInterface, ToolDefinition, ToolRegistry, ToolRegistryFactoryInterface

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,9 @@ Commit messages are validated separately in CI via
 src/
   Audit/
     Domain/          # Pure PHP — no framework, no I/O
-      Model/         # Value objects and enums (Vulnerability, AuditReport, ProjectFile, ProjectFileType, VulnerabilityHydrationResult, VulnerabilityDropReason, …)
+      Model/         # Value objects and enums (Vulnerability, AuditReport, ProjectFile, ProjectFileType, RouteAccessControl, VulnerabilityHydrationResult, VulnerabilityDropReason, …)
       Pipeline/      # PipelineInterface, StageInterface, CoverageRecorderInterface (ports)
-      Port/          # Cross-layer ports (LLMClientInterface, BatchCapableLLMClientInterface, LLMResponse, *PromptBuilderInterface, ProjectFileScannerInterface, AttackerCacheInterface, AdvisoryDatabaseInterface, SecretScrubberInterface, TokenEstimatorInterface, PricingProviderInterface, RateLimiterInterface, StaticPreScannerInterface, CodeSlicerInterface, GitChangedFilesResolverInterface)
+      Port/          # Cross-layer ports (LLMClientInterface, BatchCapableLLMClientInterface, LLMResponse, *PromptBuilderInterface, ProjectFileScannerInterface, AttackerCacheInterface, AdvisoryDatabaseInterface, SecretScrubberInterface, TokenEstimatorInterface, PricingProviderInterface, RateLimiterInterface, StaticPreScannerInterface, CodeSlicerInterface, ControllerAccessControlParserInterface, GitChangedFilesResolverInterface)
         Tool/        # ToolInterface, ToolDefinition, ToolRegistry, ToolRegistryFactoryInterface
     Application/     # Orchestration — no I/O, depends only on Domain
       UseCase/       # RunAuditUseCase, EstimateAuditCostUseCase (entry points)
@@ -73,7 +73,7 @@ src/
     Infrastructure/  # I/O adapters
       LLM/           # SymfonyAiLLMClient, RetryPolicy, TransientFailureClassifier, CharacterBasedTokenEstimator, Delay/, RateLimit/{NullRateLimiter, TokenBucketRateLimiter, RetryAfterHeaderParser}
       FileSystem/    # ProjectFileScanner, RegexSecretScrubber, NullSecretScrubber
-      Scan/          # RegexStaticPreScanner, NullStaticPreScanner, RegexCodeSlicer, NullCodeSlicer
+      Scan/          # RegexStaticPreScanner, NullStaticPreScanner, RegexCodeSlicer, NullCodeSlicer, PhpParserControllerAccessControlParser, NullControllerAccessControlParser
       Diff/          # ProcessGitChangedFilesResolver (git diff for --since)
       Prompt/        # AttackerPromptBuilder, ReviewerPromptBuilder
       Cache/         # FilesystemAttackerCache, NullAttackerCache

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "require": {
         "php": ">=8.3",
         "composer-runtime-api": "^2.0",
+        "nikic/php-parser": "^5.3",
         "psr/clock": "^1.0",
         "psr/log": "^3.0",
         "symfony/ai-bundle": "^0.9",

--- a/config/services.php
+++ b/config/services.php
@@ -44,6 +44,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AdvisoryDatabaseInter
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerCacheInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerPromptBuilderInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CodeSlicerInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\FormBindingParserInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\GitChangedFilesResolverInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\PricingProviderInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
@@ -53,6 +55,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\SecretScrubberInterfa
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\StaticPreScannerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\TokenEstimatorInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistryFactoryInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParserInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditAdvisoryDatabase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditRunnerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\InMemoryAdvisoryDatabase;
@@ -78,13 +81,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\ReviewerPro
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullCodeSlicer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullStaticPreScanner;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\RegexCodeSlicer;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\FormBindingParserInterface;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParserInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserControllerAccessControlParser;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserFormBindingParser;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserVoterCapabilityParser;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\RegexCodeSlicer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\RegexStaticPreScanner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool\SymfonyToolRegistryFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;

--- a/config/services.php
+++ b/config/services.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgentInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestrator;
@@ -155,7 +157,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ]);
     $defaultsConfigurator->alias(ProjectFileScannerInterface::class, ProjectFileScanner::class);
 
-    $defaultsConfigurator->set(VulnerabilityFactory::class);
+    $defaultsConfigurator->set(VulnerabilityFactory::class)
+        ->args([
+            service('logger')->ignoreOnInvalid(),
+            inline_service(ValidatorInterface::class)->factory([Validation::class, 'createValidator']),
+        ]);
     $defaultsConfigurator->set(AttackerPromptBuilder::class);
     $defaultsConfigurator->alias(AttackerPromptBuilderInterface::class, AttackerPromptBuilder::class);
 

--- a/config/services.php
+++ b/config/services.php
@@ -80,7 +80,11 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullCodeSlice
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullStaticPreScanner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\RegexCodeSlicer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\FormBindingParserInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParserInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserControllerAccessControlParser;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserFormBindingParser;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserVoterCapabilityParser;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\RegexStaticPreScanner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool\SymfonyToolRegistryFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
@@ -194,8 +198,19 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $defaultsConfigurator->set(PhpParserControllerAccessControlParser::class);
     $defaultsConfigurator->alias(ControllerAccessControlParserInterface::class, PhpParserControllerAccessControlParser::class);
 
+    $defaultsConfigurator->set(PhpParserVoterCapabilityParser::class);
+    $defaultsConfigurator->alias(VoterCapabilityParserInterface::class, PhpParserVoterCapabilityParser::class);
+
+    $defaultsConfigurator->set(PhpParserFormBindingParser::class);
+    $defaultsConfigurator->alias(FormBindingParserInterface::class, PhpParserFormBindingParser::class);
+
     $defaultsConfigurator->set(MappingStage::class)
-        ->args([service('logger'), service(ControllerAccessControlParserInterface::class)]);
+        ->args([
+            service('logger'),
+            service(ControllerAccessControlParserInterface::class),
+            service(VoterCapabilityParserInterface::class),
+            service(FormBindingParserInterface::class),
+        ]);
 
     $defaultsConfigurator->set(AuditOrchestrator::class)
         ->args([

--- a/config/services.php
+++ b/config/services.php
@@ -346,6 +346,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(AuditPresenterInterface::class),
             service(EstimateAuditCostUseCase::class),
             service(ProgressReporterHolder::class),
+            param('symfony_security_auditor.scan.secret_scrubbing.enabled'),
         ])
         ->tag('console.command');
 };

--- a/config/services.php
+++ b/config/services.php
@@ -79,6 +79,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRende
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullCodeSlicer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullStaticPreScanner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\RegexCodeSlicer;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserControllerAccessControlParser;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\RegexStaticPreScanner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool\SymfonyToolRegistryFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
@@ -189,8 +191,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(GitChangedFilesResolverInterface::class),
         ]);
 
+    $defaultsConfigurator->set(PhpParserControllerAccessControlParser::class);
+    $defaultsConfigurator->alias(ControllerAccessControlParserInterface::class, PhpParserControllerAccessControlParser::class);
+
     $defaultsConfigurator->set(MappingStage::class)
-        ->args([service('logger')]);
+        ->args([service('logger'), service(ControllerAccessControlParserInterface::class)]);
 
     $defaultsConfigurator->set(AuditOrchestrator::class)
         ->args([

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -260,9 +260,8 @@ security surface rather than file contents alone. Notable helpers:
 - `controllersWithoutVoters()` surfaces controllers that lack `#[IsGranted]` or
   `denyAccessUnlessGranted` calls (filename-heuristic).
 - `routeAccessControls()` returns the route → controller graph: one
-  `RouteAccessControl` per public action with its parsed `#[Route]`,
-  class- and method-level `#[IsGranted]`, and `denyAccessUnlessGranted()`
-  call sites.
+  `RouteAccessControl` per public action with its parsed `#[Route]`, class- and
+  method-level `#[IsGranted]`, and `denyAccessUnlessGranted()` call sites.
 - `controllersWithoutAccessCheck()` filters the graph to actions that carry a
   route but no enforcement.
 
@@ -274,9 +273,8 @@ One entry per public controller action emitted by
 Captures `filePath`, `methodName`, `routePath`, `routeMethods`, plus three
 boolean / list signals — `methodLevelIsGranted`, `methodHasDenyAccess`,
 `classHasIsGranted` — combined by `hasAccessCheck()` and `lacksAccessCheck()`.
-The attacker prompt renders the full graph as a `Route Access-Control Map`
-block so the LLM can spot missing enforcement without re-deriving it from
-source.
+The attacker prompt renders the full graph as a `Route Access-Control Map` block
+so the LLM can spot missing enforcement without re-deriving it from source.
 
 ### `VoterCapability` — immutable per-voter `supports()` summary
 
@@ -284,10 +282,10 @@ One entry per voter file emitted by `VoterCapabilityParserInterface` (default
 impl `PhpParserVoterCapabilityParser`). Captures `filePath`, `className`,
 `supportedAttributes` (string literals seen inside `supports()`) and
 `supportedSubjects` (right-hand class names of `instanceof` checks). Helpers
-`coversAttribute(string)` and `coversSubject(string)` answer
-"is there a voter that handles this access decision?" so the prompt's
-`Voter Coverage` block lets the LLM flag `#[IsGranted('ATTR', $subject)]`
-calls that no voter actually backs.
+`coversAttribute(string)` and `coversSubject(string)` answer "is there a voter
+that handles this access decision?" so the prompt's `Voter Coverage` block lets
+the LLM flag `#[IsGranted('ATTR', $subject)]` calls that no voter actually
+backs.
 
 ### `FormBinding` — immutable controller → form-type binding
 
@@ -295,8 +293,8 @@ One entry per `$this->createForm(SomeFormType::class)` call site emitted by
 `FormBindingParserInterface` (default impl `PhpParserFormBindingParser`).
 Captures `controllerFilePath`, `controllerMethod`, and `formTypeClass`. The
 attacker prompt renders the list as a `Form Bindings` block so the LLM can
-cross-reference call sites against the form types involved for mass-assignment
-/ CSRF analysis without re-deriving the binding from source.
+cross-reference call sites against the form types involved for mass-assignment /
+CSRF analysis without re-deriving the binding from source.
 
 ### Pipeline ports (`Domain/Pipeline/`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -376,10 +376,20 @@ any error: returns the vulnerability with `reviewerValidated = false`.
 ### `VulnerabilityFactory`
 
 Parses raw `array<string, mixed>` from LLM JSON output into `Vulnerability`
-instances. Invalid or missing fields are handled with null-coalescing casts.
-Invalid enum values cause a caught `\Throwable` — `fromArray()` returns `null`.
-`fromList()` silently drops nulls, returning only successfully hydrated
-instances.
+instances. Each entry is first checked against `symfony/validator` constraints
+(non-blank `title` / `description` / `file_path`, sane length bounds on every
+free-text field); on violation the entry is dropped under
+`VulnerabilityDropReason::VALIDATION_FAILED`. Surviving entries are hydrated;
+invalid or missing fields are handled with null-coalescing casts; invalid enum
+values cause a caught `\Throwable` and the entry is dropped under
+`VulnerabilityDropReason::HYDRATION_FAILED`. Non-array list entries are dropped
+under `VulnerabilityDropReason::NON_ARRAY_ENTRY`.
+
+`fromArray()` still returns `?Vulnerability`. `fromList()` returns a
+`VulnerabilityHydrationResult` value object exposing both the hydrated
+vulnerabilities and per-reason drop counts. `AttackerAgent::analyze` aggregates
+the per-chunk drop counts and surfaces them on its `Attacker agent complete`
+info log as `total_dropped_entries` / `dropped_by_reason`.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,6 +278,26 @@ The attacker prompt renders the full graph as a `Route Access-Control Map`
 block so the LLM can spot missing enforcement without re-deriving it from
 source.
 
+### `VoterCapability` — immutable per-voter `supports()` summary
+
+One entry per voter file emitted by `VoterCapabilityParserInterface` (default
+impl `PhpParserVoterCapabilityParser`). Captures `filePath`, `className`,
+`supportedAttributes` (string literals seen inside `supports()`) and
+`supportedSubjects` (right-hand class names of `instanceof` checks). Helpers
+`coversAttribute(string)` and `coversSubject(string)` answer
+"is there a voter that handles this access decision?" so the prompt's
+`Voter Coverage` block lets the LLM flag `#[IsGranted('ATTR', $subject)]`
+calls that no voter actually backs.
+
+### `FormBinding` — immutable controller → form-type binding
+
+One entry per `$this->createForm(SomeFormType::class)` call site emitted by
+`FormBindingParserInterface` (default impl `PhpParserFormBindingParser`).
+Captures `controllerFilePath`, `controllerMethod`, and `formTypeClass`. The
+attacker prompt renders the list as a `Form Bindings` block so the LLM can
+cross-reference call sites against the form types involved for mass-assignment
+/ CSRF analysis without re-deriving the binding from source.
+
 ### Pipeline ports (`Domain/Pipeline/`)
 
 - `PipelineInterface::process(AuditContext): void`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -255,9 +255,28 @@ the static pre-scanner buckets, and the attacker skill-block ordering.
 
 Groups `ProjectFile` instances by role and holds `routeAccessMap` and
 `firewallRules`. Passed to `AttackerAgent` so it can reason about the full
-security surface rather than file contents alone. Notable helper:
-`controllersWithoutVoters()` surfaces controllers that lack `#[IsGranted]` or
-`denyAccessUnlessGranted` calls.
+security surface rather than file contents alone. Notable helpers:
+
+- `controllersWithoutVoters()` surfaces controllers that lack `#[IsGranted]` or
+  `denyAccessUnlessGranted` calls (filename-heuristic).
+- `routeAccessControls()` returns the route → controller graph: one
+  `RouteAccessControl` per public action with its parsed `#[Route]`,
+  class- and method-level `#[IsGranted]`, and `denyAccessUnlessGranted()`
+  call sites.
+- `controllersWithoutAccessCheck()` filters the graph to actions that carry a
+  route but no enforcement.
+
+### `RouteAccessControl` — immutable per-action access-control summary
+
+One entry per public controller action emitted by
+`ControllerAccessControlParserInterface` (default impl
+`PhpParserControllerAccessControlParser`, AST-based via `nikic/php-parser`).
+Captures `filePath`, `methodName`, `routePath`, `routeMethods`, plus three
+boolean / list signals — `methodLevelIsGranted`, `methodHasDenyAccess`,
+`classHasIsGranted` — combined by `hasAccessCheck()` and `lacksAccessCheck()`.
+The attacker prompt renders the full graph as a `Route Access-Control Map`
+block so the LLM can spot missing enforcement without re-deriving it from
+source.
 
 ### Pipeline ports (`Domain/Pipeline/`)
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -301,7 +301,7 @@ final class RuleBasedAttackerAgent implements AttackerAgentInterface
             return [];
         }
 
-        return $this->factory->fromList($response->parseJson());
+        return $this->factory->fromList($response->parseJson())->vulnerabilities();
     }
 
     private function systemPrompt(): string
@@ -399,13 +399,21 @@ convert raw LLM arrays into domain objects.
 
 ```php
 // $rawList is the decoded JSON array from the LLM.
-$vulnerabilities = $this->factory->fromList($rawList); // list<Vulnerability>
+$result = $this->factory->fromList($rawList); // VulnerabilityHydrationResult
+
+$vulnerabilities = $result->vulnerabilities(); // list<Vulnerability>
+$result->totalDropped();                       // int — entries the factory dropped
+$result->droppedBy(VulnerabilityDropReason::HYDRATION_FAILED); // per-reason count
 ```
 
 `fromList()` calls `fromArray()` per item and drops any entry that fails
 validation (unknown `type`/`severity` enum value, empty `title`,
-`line_end < line_start`, `confidence` outside `[0.0, 1.0]`). Failures are logged
-at `warning` level via the injected `LoggerInterface`.
+`line_end < line_start`, `confidence` outside `[0.0, 1.0]`). Each drop is logged
+at `warning` level with a structured `reason` code
+(`VulnerabilityDropReason::NON_ARRAY_ENTRY` for non-array entries,
+`VulnerabilityDropReason::HYDRATION_FAILED` for invalid shapes) and aggregated
+in the returned `VulnerabilityHydrationResult` so callers can surface drop
+counts in their reports or metrics.
 
 ---
 

--- a/src/Audit/Application/Agent/AttackerAgent.php
+++ b/src/Audit/Application/Agent/AttackerAgent.php
@@ -22,6 +22,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\LLMProviderExcep
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AgentRole;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityHydrationResult;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\CoverageRecorderInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerCacheInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerPromptBuilderInterface;
@@ -113,22 +114,30 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
         $chunks = $this->chunkFiles($effectiveFiles);
         $allVulnerabilities = [];
+        $totalDropsByReason = [];
 
         foreach ($chunks as $index => $chunk) {
             $this->logger->debug(\sprintf('Analyzing chunk %d/%d', $index + 1, \count($chunks)));
 
-            $vulnerabilities = $this->analyzeChunk($chunk, $attackerAnalysisRequest, $coverageRecorder, $toolRegistry, $riskMarkerIndex);
-            $allVulnerabilities = [...$allVulnerabilities, ...$vulnerabilities];
+            $chunkResult = $this->analyzeChunk($chunk, $attackerAnalysisRequest, $coverageRecorder, $toolRegistry, $riskMarkerIndex);
+            $allVulnerabilities = [...$allVulnerabilities, ...$chunkResult->vulnerabilities()];
+
+            foreach ($chunkResult->dropsByReason() as $reason => $count) {
+                $totalDropsByReason[$reason] = ($totalDropsByReason[$reason] ?? 0) + $count;
+            }
 
             $this->logger->debug('Chunk analysis complete', [
                 'chunk' => $index + 1,
-                'found' => \count($vulnerabilities),
+                'found' => \count($chunkResult->vulnerabilities()),
+                'dropped' => $chunkResult->totalDropped(),
                 'total_so_far' => \count($allVulnerabilities),
             ]);
         }
 
         $this->logger->info('Attacker agent complete', [
             'total_vulnerabilities' => \count($allVulnerabilities),
+            'total_dropped_entries' => array_sum($totalDropsByReason),
+            'dropped_by_reason' => $totalDropsByReason,
         ]);
 
         return $allVulnerabilities;
@@ -136,10 +145,8 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
     /**
      * @param list<ProjectFile> $chunk
-     *
-     * @return list<Vulnerability>
      */
-    private function analyzeChunk(array $chunk, AttackerAnalysisRequest $attackerAnalysisRequest, CoverageRecorderInterface $coverageRecorder, ?ToolRegistry $toolRegistry, RiskMarkerIndex $riskMarkerIndex): array
+    private function analyzeChunk(array $chunk, AttackerAnalysisRequest $attackerAnalysisRequest, CoverageRecorderInterface $coverageRecorder, ?ToolRegistry $toolRegistry, RiskMarkerIndex $riskMarkerIndex): VulnerabilityHydrationResult
     {
         $hasPreviousFindings = [] !== $attackerAnalysisRequest->previousFindings;
         $chunkMarkers = $riskMarkerIndex->forChunk($chunk);
@@ -153,7 +160,7 @@ final readonly class AttackerAgent implements AttackerAgentInterface
                 $this->logger->info('Attacker chunk served from cache', ['files' => \count($chunk)]);
                 $this->recordChunkCoverage($chunk, 'cached', $coverageRecorder);
 
-                return $this->vulnerabilityFactory->fromList(array_values($cached))->vulnerabilities();
+                return $this->vulnerabilityFactory->fromList(array_values($cached));
             }
         }
 
@@ -181,7 +188,7 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
                 $this->recordChunkCoverage($chunk, 'analyzed', $coverageRecorder);
 
-                return [];
+                return VulnerabilityHydrationResult::empty();
             }
 
             /** @var list<mixed> $rawData */
@@ -195,7 +202,7 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
             $this->recordChunkCoverage($chunk, 'analyzed', $coverageRecorder);
 
-            return $this->vulnerabilityFactory->fromList($rawData)->vulnerabilities();
+            return $this->vulnerabilityFactory->fromList($rawData);
         } catch (BudgetExceededException $budgetExceededException) {
             // Budget exhaustion is a deliberate abort, not an LLM failure;
             // let it bubble up so RunAuditUseCase can wrap it with a partial report.
@@ -213,14 +220,14 @@ final readonly class AttackerAgent implements AttackerAgentInterface
             ]);
             $this->recordChunkCoverage($chunk, 'errored', $coverageRecorder);
 
-            return [];
+            return VulnerabilityHydrationResult::empty();
         } catch (Throwable $exception) {
             $this->logger->error('Attacker agent LLM call failed', [
                 'error' => $exception->getMessage(),
             ]);
             $this->recordChunkCoverage($chunk, 'errored', $coverageRecorder);
 
-            return [];
+            return VulnerabilityHydrationResult::empty();
         }
     }
 

--- a/src/Audit/Application/Agent/AttackerAgent.php
+++ b/src/Audit/Application/Agent/AttackerAgent.php
@@ -153,7 +153,7 @@ final readonly class AttackerAgent implements AttackerAgentInterface
                 $this->logger->info('Attacker chunk served from cache', ['files' => \count($chunk)]);
                 $this->recordChunkCoverage($chunk, 'cached', $coverageRecorder);
 
-                return $this->vulnerabilityFactory->fromList(array_values($cached));
+                return $this->vulnerabilityFactory->fromList(array_values($cached))->vulnerabilities();
             }
         }
 
@@ -195,7 +195,7 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
             $this->recordChunkCoverage($chunk, 'analyzed', $coverageRecorder);
 
-            return $this->vulnerabilityFactory->fromList($rawData);
+            return $this->vulnerabilityFactory->fromList($rawData)->vulnerabilities();
         } catch (BudgetExceededException $budgetExceededException) {
             // Budget exhaustion is a deliberate abort, not an LLM failure;
             // let it bubble up so RunAuditUseCase can wrap it with a partial report.

--- a/src/Audit/Application/Agent/VulnerabilityFactory.php
+++ b/src/Audit/Application/Agent/VulnerabilityFactory.php
@@ -159,13 +159,13 @@ final readonly class VulnerabilityFactory
     {
         $collection = new Assert\Collection(
             fields: [
-                'title' => new Assert\Optional([new Assert\Length(max: self::TITLE_MAX_LENGTH)]),
-                'description' => new Assert\Optional([new Assert\NotBlank(), new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
-                'file_path' => new Assert\Optional([new Assert\NotBlank(), new Assert\Length(max: self::FILE_PATH_MAX_LENGTH)]),
-                'vulnerable_code' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
-                'attack_vector' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
-                'proof' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
-                'remediation' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
+                'title' => [new Assert\Length(max: self::TITLE_MAX_LENGTH)],
+                'description' => [new Assert\NotBlank(), new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)],
+                'file_path' => [new Assert\NotBlank(), new Assert\Length(max: self::FILE_PATH_MAX_LENGTH)],
+                'vulnerable_code' => [new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)],
+                'attack_vector' => [new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)],
+                'proof' => [new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)],
+                'remediation' => [new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)],
             ],
             allowExtraFields: true,
             allowMissingFields: true,

--- a/src/Audit/Application/Agent/VulnerabilityFactory.php
+++ b/src/Audit/Application/Agent/VulnerabilityFactory.php
@@ -16,6 +16,8 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityDropReason;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityHydrationResult;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 
@@ -63,6 +65,7 @@ final readonly class VulnerabilityFactory
             );
         } catch (Throwable $throwable) {
             $this->logger->warning('Failed to create vulnerability from LLM data', [
+                'reason' => VulnerabilityDropReason::HYDRATION_FAILED->value,
                 'data' => $data,
                 'error' => $throwable->getMessage(),
             ]);
@@ -73,19 +76,21 @@ final readonly class VulnerabilityFactory
 
     /**
      * @param list<mixed> $rawList
-     *
-     * @return list<Vulnerability>
      */
-    public function fromList(array $rawList): array
+    public function fromList(array $rawList): VulnerabilityHydrationResult
     {
         $vulnerabilities = [];
+        $dropsByReason = [];
 
         foreach ($rawList as $raw) {
             if (!\is_array($raw)) {
                 $this->logger->warning('Skipping non-array vulnerability entry from LLM', [
+                    'reason' => VulnerabilityDropReason::NON_ARRAY_ENTRY->value,
                     'entry_type' => get_debug_type($raw),
                     'entry_preview' => \is_string($raw) ? substr($raw, 0, self::ENTRY_PREVIEW_BYTES) : null,
                 ]);
+
+                $dropsByReason[VulnerabilityDropReason::NON_ARRAY_ENTRY->value] = ($dropsByReason[VulnerabilityDropReason::NON_ARRAY_ENTRY->value] ?? 0) + 1;
 
                 continue;
             }
@@ -94,9 +99,13 @@ final readonly class VulnerabilityFactory
 
             if ($vulnerability instanceof Vulnerability) {
                 $vulnerabilities[] = $vulnerability;
+
+                continue;
             }
+
+            $dropsByReason[VulnerabilityDropReason::HYDRATION_FAILED->value] = ($dropsByReason[VulnerabilityDropReason::HYDRATION_FAILED->value] ?? 0) + 1;
         }
 
-        return $vulnerabilities;
+        return new VulnerabilityHydrationResult($vulnerabilities, $dropsByReason);
     }
 }

--- a/src/Audit/Application/Agent/VulnerabilityFactory.php
+++ b/src/Audit/Application/Agent/VulnerabilityFactory.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityDropReason;
@@ -26,14 +28,88 @@ final readonly class VulnerabilityFactory
 {
     private const int ENTRY_PREVIEW_BYTES = 120;
 
+    private const int TITLE_MAX_LENGTH = 500;
+
+    private const int FILE_PATH_MAX_LENGTH = 500;
+
+    private const int LONG_TEXT_MAX_LENGTH = 5000;
+
     public function __construct(
         private LoggerInterface $logger,
+        private ValidatorInterface $validator,
     ) {}
 
     /**
      * @param array<array-key, mixed> $data
      */
     public function fromArray(array $data): ?Vulnerability
+    {
+        $violations = $this->validateRawData($data);
+
+        if ([] !== $violations) {
+            $this->logger->warning('Dropping vulnerability entry that failed validation', [
+                'reason' => VulnerabilityDropReason::VALIDATION_FAILED->value,
+                'violations' => $violations,
+            ]);
+
+            return null;
+        }
+
+        return $this->hydrate($data);
+    }
+
+    /**
+     * @param list<mixed> $rawList
+     */
+    public function fromList(array $rawList): VulnerabilityHydrationResult
+    {
+        $vulnerabilities = [];
+        $dropsByReason = [];
+
+        foreach ($rawList as $raw) {
+            if (!\is_array($raw)) {
+                $this->logger->warning('Skipping non-array vulnerability entry from LLM', [
+                    'reason' => VulnerabilityDropReason::NON_ARRAY_ENTRY->value,
+                    'entry_type' => get_debug_type($raw),
+                    'entry_preview' => \is_string($raw) ? substr($raw, 0, self::ENTRY_PREVIEW_BYTES) : null,
+                ]);
+
+                $dropsByReason[VulnerabilityDropReason::NON_ARRAY_ENTRY->value] = ($dropsByReason[VulnerabilityDropReason::NON_ARRAY_ENTRY->value] ?? 0) + 1;
+
+                continue;
+            }
+
+            $violations = $this->validateRawData($raw);
+
+            if ([] !== $violations) {
+                $this->logger->warning('Dropping vulnerability entry that failed validation', [
+                    'reason' => VulnerabilityDropReason::VALIDATION_FAILED->value,
+                    'violations' => $violations,
+                ]);
+
+                $dropsByReason[VulnerabilityDropReason::VALIDATION_FAILED->value] = ($dropsByReason[VulnerabilityDropReason::VALIDATION_FAILED->value] ?? 0) + 1;
+
+                continue;
+            }
+
+            $vulnerability = $this->hydrate($raw);
+
+            if ($vulnerability instanceof Vulnerability) {
+                $vulnerabilities[] = $vulnerability;
+
+                continue;
+            }
+
+            $dropsByReason[VulnerabilityDropReason::HYDRATION_FAILED->value] = ($dropsByReason[VulnerabilityDropReason::HYDRATION_FAILED->value] ?? 0) + 1;
+        }
+
+        return new VulnerabilityHydrationResult($vulnerabilities, $dropsByReason);
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    private function hydrate(array $data): ?Vulnerability
     {
         try {
             $rawType = $data['type'] ?? null;
@@ -75,37 +151,33 @@ final readonly class VulnerabilityFactory
     }
 
     /**
-     * @param list<mixed> $rawList
+     * @param array<array-key, mixed> $data
+     *
+     * @return list<string> human-readable violation messages, empty when valid
      */
-    public function fromList(array $rawList): VulnerabilityHydrationResult
+    private function validateRawData(array $data): array
     {
-        $vulnerabilities = [];
-        $dropsByReason = [];
+        $collection = new Assert\Collection(
+            fields: [
+                'title' => new Assert\Optional([new Assert\NotBlank(), new Assert\Length(max: self::TITLE_MAX_LENGTH)]),
+                'description' => new Assert\Optional([new Assert\NotBlank(), new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
+                'file_path' => new Assert\Optional([new Assert\NotBlank(), new Assert\Length(max: self::FILE_PATH_MAX_LENGTH)]),
+                'vulnerable_code' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
+                'attack_vector' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
+                'proof' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
+                'remediation' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
+            ],
+            allowExtraFields: true,
+            allowMissingFields: true,
+        );
 
-        foreach ($rawList as $raw) {
-            if (!\is_array($raw)) {
-                $this->logger->warning('Skipping non-array vulnerability entry from LLM', [
-                    'reason' => VulnerabilityDropReason::NON_ARRAY_ENTRY->value,
-                    'entry_type' => get_debug_type($raw),
-                    'entry_preview' => \is_string($raw) ? substr($raw, 0, self::ENTRY_PREVIEW_BYTES) : null,
-                ]);
+        $constraintViolationList = $this->validator->validate($data, $collection);
 
-                $dropsByReason[VulnerabilityDropReason::NON_ARRAY_ENTRY->value] = ($dropsByReason[VulnerabilityDropReason::NON_ARRAY_ENTRY->value] ?? 0) + 1;
-
-                continue;
-            }
-
-            $vulnerability = $this->fromArray($raw);
-
-            if ($vulnerability instanceof Vulnerability) {
-                $vulnerabilities[] = $vulnerability;
-
-                continue;
-            }
-
-            $dropsByReason[VulnerabilityDropReason::HYDRATION_FAILED->value] = ($dropsByReason[VulnerabilityDropReason::HYDRATION_FAILED->value] ?? 0) + 1;
+        $messages = [];
+        foreach ($constraintViolationList as $violation) {
+            $messages[] = \sprintf('%s: %s', $violation->getPropertyPath(), (string) $violation->getMessage());
         }
 
-        return new VulnerabilityHydrationResult($vulnerabilities, $dropsByReason);
+        return $messages;
     }
 }

--- a/src/Audit/Application/Agent/VulnerabilityFactory.php
+++ b/src/Audit/Application/Agent/VulnerabilityFactory.php
@@ -159,7 +159,7 @@ final readonly class VulnerabilityFactory
     {
         $collection = new Assert\Collection(
             fields: [
-                'title' => new Assert\Optional([new Assert\NotBlank(), new Assert\Length(max: self::TITLE_MAX_LENGTH)]),
+                'title' => new Assert\Optional([new Assert\Length(max: self::TITLE_MAX_LENGTH)]),
                 'description' => new Assert\Optional([new Assert\NotBlank(), new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),
                 'file_path' => new Assert\Optional([new Assert\NotBlank(), new Assert\Length(max: self::FILE_PATH_MAX_LENGTH)]),
                 'vulnerable_code' => new Assert\Optional([new Assert\Length(max: self::LONG_TEXT_MAX_LENGTH)]),

--- a/src/Audit/Application/Pipeline/Stage/MappingStage.php
+++ b/src/Audit/Application/Pipeline/Stage/MappingStage.php
@@ -16,12 +16,18 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\BuiltInStageName;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\StageInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\FormBindingParserInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParserInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullControllerAccessControlParser;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullFormBindingParser;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullVoterCapabilityParser;
 
 use function Symfony\Component\String\u;
 
@@ -30,11 +36,19 @@ final readonly class MappingStage implements StageInterface
 {
     private ControllerAccessControlParserInterface $controllerAccessControlParser;
 
+    private VoterCapabilityParserInterface $voterCapabilityParser;
+
+    private FormBindingParserInterface $formBindingParser;
+
     public function __construct(
         private LoggerInterface $logger,
         ?ControllerAccessControlParserInterface $controllerAccessControlParser = null,
+        ?VoterCapabilityParserInterface $voterCapabilityParser = null,
+        ?FormBindingParserInterface $formBindingParser = null,
     ) {
         $this->controllerAccessControlParser = $controllerAccessControlParser ?? new NullControllerAccessControlParser();
+        $this->voterCapabilityParser = $voterCapabilityParser ?? new NullVoterCapabilityParser();
+        $this->formBindingParser = $formBindingParser ?? new NullFormBindingParser();
     }
 
     public function name(): string
@@ -63,6 +77,8 @@ final readonly class MappingStage implements StageInterface
 
         [$routeAccessMap, $firewallRules] = $this->extractSecurityConfig($files);
         $routeAccessControls = $this->parseControllerAccessControls($controllers);
+        $voterCapabilities = $this->parseVoterCapabilities($voters);
+        $formBindings = $this->parseFormBindings($controllers);
 
         $symfonyMapping = SymfonyMapping::create(
             controllers: $controllers,
@@ -75,6 +91,8 @@ final readonly class MappingStage implements StageInterface
             routeAccessMap: $routeAccessMap,
             firewallRules: $firewallRules,
             routeAccessControls: $routeAccessControls,
+            voterCapabilities: $voterCapabilities,
+            formBindings: $formBindings,
         );
 
         $auditContext->setMapping($symfonyMapping);
@@ -84,11 +102,15 @@ final readonly class MappingStage implements StageInterface
         $auditContext->setMeta('mapping.no_voter_controllers', \count($symfonyMapping->controllersWithoutVoters()));
         $auditContext->setMeta('mapping.routes', \count($routeAccessControls));
         $auditContext->setMeta('mapping.routes_without_access_check', \count($symfonyMapping->controllersWithoutAccessCheck()));
+        $auditContext->setMeta('mapping.voter_capabilities', \count($voterCapabilities));
+        $auditContext->setMeta('mapping.form_bindings', \count($formBindings));
 
         $this->logger->info('Mapping complete', [
             'summary' => $symfonyMapping->toSummary(),
             'unprotected_controllers' => \count($symfonyMapping->controllersWithoutVoters()),
             'routes_without_access_check' => \count($symfonyMapping->controllersWithoutAccessCheck()),
+            'voter_capabilities' => \count($voterCapabilities),
+            'form_bindings' => \count($formBindings),
         ]);
     }
 
@@ -103,6 +125,41 @@ final readonly class MappingStage implements StageInterface
 
         foreach ($controllers as $controller) {
             $entries = [...$entries, ...$this->controllerAccessControlParser->parse($controller)];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param list<ProjectFile> $voters
+     *
+     * @return list<VoterCapability>
+     */
+    private function parseVoterCapabilities(array $voters): array
+    {
+        $entries = [];
+
+        foreach ($voters as $voter) {
+            $capability = $this->voterCapabilityParser->parse($voter);
+            if ($capability instanceof VoterCapability) {
+                $entries[] = $capability;
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param list<ProjectFile> $controllers
+     *
+     * @return list<FormBinding>
+     */
+    private function parseFormBindings(array $controllers): array
+    {
+        $entries = [];
+
+        foreach ($controllers as $controller) {
+            $entries = [...$entries, ...$this->formBindingParser->parse($controller)];
         }
 
         return $entries;

--- a/src/Audit/Application/Pipeline/Stage/MappingStage.php
+++ b/src/Audit/Application/Pipeline/Stage/MappingStage.php
@@ -17,17 +17,25 @@ use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\BuiltInStageName;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\StageInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullControllerAccessControlParser;
 
 use function Symfony\Component\String\u;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class MappingStage implements StageInterface
 {
+    private ControllerAccessControlParserInterface $controllerAccessControlParser;
+
     public function __construct(
         private LoggerInterface $logger,
-    ) {}
+        ?ControllerAccessControlParserInterface $controllerAccessControlParser = null,
+    ) {
+        $this->controllerAccessControlParser = $controllerAccessControlParser ?? new NullControllerAccessControlParser();
+    }
 
     public function name(): string
     {
@@ -54,6 +62,7 @@ final readonly class MappingStage implements StageInterface
         $templates = array_values(array_filter($files, static fn (ProjectFile $projectFile): bool => $projectFile->isTemplate()));
 
         [$routeAccessMap, $firewallRules] = $this->extractSecurityConfig($files);
+        $routeAccessControls = $this->parseControllerAccessControls($controllers);
 
         $symfonyMapping = SymfonyMapping::create(
             controllers: $controllers,
@@ -65,6 +74,7 @@ final readonly class MappingStage implements StageInterface
             templates: $templates,
             routeAccessMap: $routeAccessMap,
             firewallRules: $firewallRules,
+            routeAccessControls: $routeAccessControls,
         );
 
         $auditContext->setMapping($symfonyMapping);
@@ -72,11 +82,30 @@ final readonly class MappingStage implements StageInterface
         $auditContext->setMeta('mapping.entities', \count($entities));
         $auditContext->setMeta('mapping.voters', \count($voters));
         $auditContext->setMeta('mapping.no_voter_controllers', \count($symfonyMapping->controllersWithoutVoters()));
+        $auditContext->setMeta('mapping.routes', \count($routeAccessControls));
+        $auditContext->setMeta('mapping.routes_without_access_check', \count($symfonyMapping->controllersWithoutAccessCheck()));
 
         $this->logger->info('Mapping complete', [
             'summary' => $symfonyMapping->toSummary(),
             'unprotected_controllers' => \count($symfonyMapping->controllersWithoutVoters()),
+            'routes_without_access_check' => \count($symfonyMapping->controllersWithoutAccessCheck()),
         ]);
+    }
+
+    /**
+     * @param list<ProjectFile> $controllers
+     *
+     * @return list<RouteAccessControl>
+     */
+    private function parseControllerAccessControls(array $controllers): array
+    {
+        $entries = [];
+
+        foreach ($controllers as $controller) {
+            $entries = [...$entries, ...$this->controllerAccessControlParser->parse($controller)];
+        }
+
+        return $entries;
     }
 
     /**

--- a/src/Audit/Domain/Model/FormBinding.php
+++ b/src/Audit/Domain/Model/FormBinding.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
+
+final readonly class FormBinding
+{
+    public function __construct(
+        private string $controllerFilePath,
+        private string $controllerMethod,
+        private string $formTypeClass,
+    ) {}
+
+    public function controllerFilePath(): string
+    {
+        return $this->controllerFilePath;
+    }
+
+    public function controllerMethod(): string
+    {
+        return $this->controllerMethod;
+    }
+
+    public function formTypeClass(): string
+    {
+        return $this->formTypeClass;
+    }
+}

--- a/src/Audit/Domain/Model/RouteAccessControl.php
+++ b/src/Audit/Domain/Model/RouteAccessControl.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
+
+final readonly class RouteAccessControl
+{
+    /**
+     * @param list<string> $routeMethods         HTTP methods declared on the route, empty list when not specified
+     * @param list<string> $methodLevelIsGranted attribute names referenced by `#[IsGranted(...)]` on the action method
+     */
+    public function __construct(
+        private string $filePath,
+        private string $methodName,
+        private ?string $routePath,
+        private array $routeMethods,
+        private bool $hasRouteAttribute,
+        private array $methodLevelIsGranted,
+        private bool $methodHasDenyAccess,
+        private bool $classHasIsGranted,
+    ) {}
+
+    public function filePath(): string
+    {
+        return $this->filePath;
+    }
+
+    public function methodName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function routePath(): ?string
+    {
+        return $this->routePath;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function routeMethods(): array
+    {
+        return $this->routeMethods;
+    }
+
+    public function hasRouteAttribute(): bool
+    {
+        return $this->hasRouteAttribute;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function methodLevelIsGranted(): array
+    {
+        return $this->methodLevelIsGranted;
+    }
+
+    public function methodHasDenyAccess(): bool
+    {
+        return $this->methodHasDenyAccess;
+    }
+
+    public function classHasIsGranted(): bool
+    {
+        return $this->classHasIsGranted;
+    }
+
+    public function hasAccessCheck(): bool
+    {
+        return $this->classHasIsGranted
+            || [] !== $this->methodLevelIsGranted
+            || $this->methodHasDenyAccess;
+    }
+
+    public function lacksAccessCheck(): bool
+    {
+        return $this->hasRouteAttribute && !$this->hasAccessCheck();
+    }
+}

--- a/src/Audit/Domain/Model/SymfonyMapping.php
+++ b/src/Audit/Domain/Model/SymfonyMapping.php
@@ -16,18 +16,18 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
 final readonly class SymfonyMapping
 {
     /**
-     * @param list<ProjectFile>         $controllers
-     * @param list<ProjectFile>         $entities
-     * @param list<ProjectFile>         $voters
-     * @param list<ProjectFile>         $repositories
-     * @param list<ProjectFile>         $forms
-     * @param list<ProjectFile>         $services
-     * @param list<ProjectFile>         $templates
+     * @param list<ProjectFile>           $controllers
+     * @param list<ProjectFile>           $entities
+     * @param list<ProjectFile>           $voters
+     * @param list<ProjectFile>           $repositories
+     * @param list<ProjectFile>           $forms
+     * @param list<ProjectFile>           $services
+     * @param list<ProjectFile>           $templates
      * @param array<string, list<string>> $routeAccessMap
-     * @param list<string>              $firewallRules
-     * @param list<RouteAccessControl>  $routeAccessControls
-     * @param list<VoterCapability>     $voterCapabilities
-     * @param list<FormBinding>         $formBindings
+     * @param list<string>                $firewallRules
+     * @param list<RouteAccessControl>    $routeAccessControls
+     * @param list<VoterCapability>       $voterCapabilities
+     * @param list<FormBinding>           $formBindings
      */
     private function __construct(
         private array $controllers,
@@ -45,18 +45,18 @@ final readonly class SymfonyMapping
     ) {}
 
     /**
-     * @param list<ProjectFile>         $controllers
-     * @param list<ProjectFile>         $entities
-     * @param list<ProjectFile>         $voters
-     * @param list<ProjectFile>         $repositories
-     * @param list<ProjectFile>         $forms
-     * @param list<ProjectFile>         $services
-     * @param list<ProjectFile>         $templates
+     * @param list<ProjectFile>           $controllers
+     * @param list<ProjectFile>           $entities
+     * @param list<ProjectFile>           $voters
+     * @param list<ProjectFile>           $repositories
+     * @param list<ProjectFile>           $forms
+     * @param list<ProjectFile>           $services
+     * @param list<ProjectFile>           $templates
      * @param array<string, list<string>> $routeAccessMap
-     * @param list<string>              $firewallRules
-     * @param list<RouteAccessControl>  $routeAccessControls
-     * @param list<VoterCapability>     $voterCapabilities
-     * @param list<FormBinding>         $formBindings
+     * @param list<string>                $firewallRules
+     * @param list<RouteAccessControl>    $routeAccessControls
+     * @param list<VoterCapability>       $voterCapabilities
+     * @param list<FormBinding>           $formBindings
      */
     public static function create(
         array $controllers = [],

--- a/src/Audit/Domain/Model/SymfonyMapping.php
+++ b/src/Audit/Domain/Model/SymfonyMapping.php
@@ -16,15 +16,16 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
 final readonly class SymfonyMapping
 {
     /**
-     * @param list<ProjectFile>           $controllers
-     * @param list<ProjectFile>           $entities
-     * @param list<ProjectFile>           $voters
-     * @param list<ProjectFile>           $repositories
-     * @param list<ProjectFile>           $forms
-     * @param list<ProjectFile>           $services
-     * @param list<ProjectFile>           $templates
+     * @param list<ProjectFile>         $controllers
+     * @param list<ProjectFile>         $entities
+     * @param list<ProjectFile>         $voters
+     * @param list<ProjectFile>         $repositories
+     * @param list<ProjectFile>         $forms
+     * @param list<ProjectFile>         $services
+     * @param list<ProjectFile>         $templates
      * @param array<string, list<string>> $routeAccessMap
-     * @param list<string>                $firewallRules
+     * @param list<string>              $firewallRules
+     * @param list<RouteAccessControl>  $routeAccessControls
      */
     private function __construct(
         private array $controllers,
@@ -36,18 +37,20 @@ final readonly class SymfonyMapping
         private array $templates,
         private array $routeAccessMap,
         private array $firewallRules,
+        private array $routeAccessControls,
     ) {}
 
     /**
-     * @param list<ProjectFile>           $controllers
-     * @param list<ProjectFile>           $entities
-     * @param list<ProjectFile>           $voters
-     * @param list<ProjectFile>           $repositories
-     * @param list<ProjectFile>           $forms
-     * @param list<ProjectFile>           $services
-     * @param list<ProjectFile>           $templates
+     * @param list<ProjectFile>         $controllers
+     * @param list<ProjectFile>         $entities
+     * @param list<ProjectFile>         $voters
+     * @param list<ProjectFile>         $repositories
+     * @param list<ProjectFile>         $forms
+     * @param list<ProjectFile>         $services
+     * @param list<ProjectFile>         $templates
      * @param array<string, list<string>> $routeAccessMap
-     * @param list<string>                $firewallRules
+     * @param list<string>              $firewallRules
+     * @param list<RouteAccessControl>  $routeAccessControls
      */
     public static function create(
         array $controllers = [],
@@ -59,6 +62,7 @@ final readonly class SymfonyMapping
         array $templates = [],
         array $routeAccessMap = [],
         array $firewallRules = [],
+        array $routeAccessControls = [],
     ): self {
         return new self(
             controllers: $controllers,
@@ -70,6 +74,7 @@ final readonly class SymfonyMapping
             templates: $templates,
             routeAccessMap: $routeAccessMap,
             firewallRules: $firewallRules,
+            routeAccessControls: $routeAccessControls,
         );
     }
 
@@ -125,6 +130,21 @@ final readonly class SymfonyMapping
     public function firewallRules(): array
     {
         return $this->firewallRules;
+    }
+
+    /** @return list<RouteAccessControl> */
+    public function routeAccessControls(): array
+    {
+        return $this->routeAccessControls;
+    }
+
+    /** @return list<RouteAccessControl> */
+    public function controllersWithoutAccessCheck(): array
+    {
+        return array_values(array_filter(
+            $this->routeAccessControls,
+            static fn (RouteAccessControl $routeAccessControl): bool => $routeAccessControl->lacksAccessCheck(),
+        ));
     }
 
     public function totalFiles(): int

--- a/src/Audit/Domain/Model/SymfonyMapping.php
+++ b/src/Audit/Domain/Model/SymfonyMapping.php
@@ -26,6 +26,8 @@ final readonly class SymfonyMapping
      * @param array<string, list<string>> $routeAccessMap
      * @param list<string>              $firewallRules
      * @param list<RouteAccessControl>  $routeAccessControls
+     * @param list<VoterCapability>     $voterCapabilities
+     * @param list<FormBinding>         $formBindings
      */
     private function __construct(
         private array $controllers,
@@ -38,6 +40,8 @@ final readonly class SymfonyMapping
         private array $routeAccessMap,
         private array $firewallRules,
         private array $routeAccessControls,
+        private array $voterCapabilities,
+        private array $formBindings,
     ) {}
 
     /**
@@ -51,6 +55,8 @@ final readonly class SymfonyMapping
      * @param array<string, list<string>> $routeAccessMap
      * @param list<string>              $firewallRules
      * @param list<RouteAccessControl>  $routeAccessControls
+     * @param list<VoterCapability>     $voterCapabilities
+     * @param list<FormBinding>         $formBindings
      */
     public static function create(
         array $controllers = [],
@@ -63,6 +69,8 @@ final readonly class SymfonyMapping
         array $routeAccessMap = [],
         array $firewallRules = [],
         array $routeAccessControls = [],
+        array $voterCapabilities = [],
+        array $formBindings = [],
     ): self {
         return new self(
             controllers: $controllers,
@@ -75,6 +83,8 @@ final readonly class SymfonyMapping
             routeAccessMap: $routeAccessMap,
             firewallRules: $firewallRules,
             routeAccessControls: $routeAccessControls,
+            voterCapabilities: $voterCapabilities,
+            formBindings: $formBindings,
         );
     }
 
@@ -144,6 +154,36 @@ final readonly class SymfonyMapping
         return array_values(array_filter(
             $this->routeAccessControls,
             static fn (RouteAccessControl $routeAccessControl): bool => $routeAccessControl->lacksAccessCheck(),
+        ));
+    }
+
+    /** @return list<VoterCapability> */
+    public function voterCapabilities(): array
+    {
+        return $this->voterCapabilities;
+    }
+
+    /** @return list<VoterCapability> */
+    public function votersFor(string $attribute, string $subject): array
+    {
+        return array_values(array_filter(
+            $this->voterCapabilities,
+            static fn (VoterCapability $voterCapability): bool => $voterCapability->coversAttribute($attribute) && $voterCapability->coversSubject($subject),
+        ));
+    }
+
+    /** @return list<FormBinding> */
+    public function formBindings(): array
+    {
+        return $this->formBindings;
+    }
+
+    /** @return list<FormBinding> */
+    public function formBindingsForController(string $controllerFilePath): array
+    {
+        return array_values(array_filter(
+            $this->formBindings,
+            static fn (FormBinding $formBinding): bool => $formBinding->controllerFilePath() === $controllerFilePath,
         ));
     }
 

--- a/src/Audit/Domain/Model/VoterCapability.php
+++ b/src/Audit/Domain/Model/VoterCapability.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
+
+final readonly class VoterCapability
+{
+    /**
+     * @param list<string> $supportedAttributes attribute names the voter's `supports()` accepts (e.g. `EDIT`, `DELETE`)
+     * @param list<string> $supportedSubjects   fully-qualified or short class names of subjects the voter's `supports()` accepts (e.g. `App\Entity\User`)
+     */
+    public function __construct(
+        private string $filePath,
+        private string $className,
+        private array $supportedAttributes,
+        private array $supportedSubjects,
+    ) {}
+
+    public function filePath(): string
+    {
+        return $this->filePath;
+    }
+
+    public function className(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function supportedAttributes(): array
+    {
+        return $this->supportedAttributes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function supportedSubjects(): array
+    {
+        return $this->supportedSubjects;
+    }
+
+    public function coversAttribute(string $attribute): bool
+    {
+        return \in_array($attribute, $this->supportedAttributes, true);
+    }
+
+    public function coversSubject(string $subject): bool
+    {
+        foreach ($this->supportedSubjects as $supportedSubject) {
+            if ($supportedSubject === $subject) {
+                return true;
+            }
+
+            $parts = explode('\\', $supportedSubject);
+            if (end($parts) === $subject) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Audit/Domain/Model/VulnerabilityDropReason.php
+++ b/src/Audit/Domain/Model/VulnerabilityDropReason.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
+
+enum VulnerabilityDropReason: string
+{
+    case NON_ARRAY_ENTRY = 'non_array_entry';
+    case HYDRATION_FAILED = 'hydration_failed';
+}

--- a/src/Audit/Domain/Model/VulnerabilityDropReason.php
+++ b/src/Audit/Domain/Model/VulnerabilityDropReason.php
@@ -16,5 +16,6 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
 enum VulnerabilityDropReason: string
 {
     case NON_ARRAY_ENTRY = 'non_array_entry';
+    case VALIDATION_FAILED = 'validation_failed';
     case HYDRATION_FAILED = 'hydration_failed';
 }

--- a/src/Audit/Domain/Model/VulnerabilityHydrationResult.php
+++ b/src/Audit/Domain/Model/VulnerabilityHydrationResult.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
+
+final readonly class VulnerabilityHydrationResult
+{
+    /**
+     * @param list<Vulnerability>  $vulnerabilities
+     * @param array<string, int>   $dropsByReason
+     */
+    public function __construct(
+        private array $vulnerabilities,
+        private array $dropsByReason,
+    ) {}
+
+    public static function empty(): self
+    {
+        return new self([], []);
+    }
+
+    /**
+     * @return list<Vulnerability>
+     */
+    public function vulnerabilities(): array
+    {
+        return $this->vulnerabilities;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function dropsByReason(): array
+    {
+        return $this->dropsByReason;
+    }
+
+    public function droppedBy(VulnerabilityDropReason $vulnerabilityDropReason): int
+    {
+        return $this->dropsByReason[$vulnerabilityDropReason->value] ?? 0;
+    }
+
+    public function totalDropped(): int
+    {
+        return array_sum($this->dropsByReason);
+    }
+
+    public function hasDrops(): bool
+    {
+        return $this->totalDropped() > 0;
+    }
+}

--- a/src/Audit/Domain/Model/VulnerabilityHydrationResult.php
+++ b/src/Audit/Domain/Model/VulnerabilityHydrationResult.php
@@ -16,8 +16,8 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
 final readonly class VulnerabilityHydrationResult
 {
     /**
-     * @param list<Vulnerability>  $vulnerabilities
-     * @param array<string, int>   $dropsByReason
+     * @param list<Vulnerability> $vulnerabilities
+     * @param array<string, int>  $dropsByReason
      */
     public function __construct(
         private array $vulnerabilities,

--- a/src/Audit/Domain/Model/VulnerabilityType.php
+++ b/src/Audit/Domain/Model/VulnerabilityType.php
@@ -45,6 +45,7 @@ enum VulnerabilityType: string
     case EXPOSED_INTERNAL_SERVICE = 'exposed_internal_service';
     case MISCONFIGURED_FIREWALL = 'misconfigured_firewall';
     case INSECURE_REDIRECT = 'insecure_redirect';
+    case OVER_PERMISSIVE_SERIALIZER_GROUP = 'over_permissive_serializer_group';
 
     // Data Exposure
     case SENSITIVE_DATA_EXPOSURE = 'sensitive_data_exposure';
@@ -101,6 +102,7 @@ enum VulnerabilityType: string
             self::EXPOSED_INTERNAL_SERVICE,
             self::MISCONFIGURED_FIREWALL,
             self::INSECURE_REDIRECT,
+            self::OVER_PERMISSIVE_SERIALIZER_GROUP,
             self::MESSENGER_HANDLER_UNSAFE => 'Symfony-Specific',
 
             self::SENSITIVE_DATA_EXPOSURE,
@@ -155,6 +157,7 @@ enum VulnerabilityType: string
             self::INSECURE_REDIRECT,
             self::OPEN_REDIRECT,
             self::XXE,
+            self::OVER_PERMISSIVE_SERIALIZER_GROUP,
             self::CACHE_POISONING => 'OWASP A05:2021 - Security Misconfiguration',
 
             self::INSECURE_DESERIALIZATION,

--- a/src/Audit/Domain/Port/ControllerAccessControlParserInterface.php
+++ b/src/Audit/Domain/Port/ControllerAccessControlParserInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
+
+/**
+ * Extracts route/access-control metadata from a single controller file. Implementations
+ * must degrade silently (return an empty list) when the file cannot be parsed — a
+ * single broken controller must not abort the mapping stage.
+ */
+interface ControllerAccessControlParserInterface
+{
+    /**
+     * @return list<RouteAccessControl> one entry per public action method discovered in the file
+     */
+    public function parse(ProjectFile $projectFile): array;
+}

--- a/src/Audit/Domain/Port/FormBindingParserInterface.php
+++ b/src/Audit/Domain/Port/FormBindingParserInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+
+/**
+ * Extracts FormType bindings — `$this->createForm(SomeFormType::class, ...)`
+ * call sites — from a controller file. One `FormBinding` is emitted per call
+ * site so the same controller method may produce multiple entries when it
+ * builds several forms. Implementations must degrade silently (return empty
+ * list) when the file cannot be parsed.
+ */
+interface FormBindingParserInterface
+{
+    /**
+     * @return list<FormBinding>
+     */
+    public function parse(ProjectFile $projectFile): array;
+}

--- a/src/Audit/Domain/Port/VoterCapabilityParserInterface.php
+++ b/src/Audit/Domain/Port/VoterCapabilityParserInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
+
+/**
+ * Extracts the attribute and subject vocabulary from a single voter file by
+ * scanning the body of its `supports()` method. Implementations must degrade
+ * silently (return null or no entries) when the file cannot be parsed.
+ */
+interface VoterCapabilityParserInterface
+{
+    public function parse(ProjectFile $projectFile): ?VoterCapability;
+}

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -27,7 +27,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 5;
+    public const int PROMPT_VERSION = 6;
 
     /**
      * Skill-block emission order — by attack-surface priority, NOT alphabetical.
@@ -313,6 +313,8 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             $symfonyMapping->controllersWithoutVoters(),
         ));
 
+        $accessControlMap = $this->renderRouteAccessControlMap($symfonyMapping);
+
         return <<<PROMPT
             ## Project Mapping Summary
             {$summary}
@@ -320,6 +322,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             ## Controllers WITHOUT Security Annotations (High Priority)
             {$noVoterList}
 
+            {$accessControlMap}
             ## Source Code
             Analyze these files for exploitable vulnerabilities. Each line is prefixed with its line number (`NNN | code`) — use those exact numbers when populating `line_start` and `line_end`; do NOT count manually or guess.
 
@@ -327,6 +330,39 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
 
             Return a JSON array of all vulnerabilities found.
             PROMPT;
+    }
+
+    private function renderRouteAccessControlMap(SymfonyMapping $symfonyMapping): string
+    {
+        $routeAccessControls = $symfonyMapping->routeAccessControls();
+        if ([] === $routeAccessControls) {
+            return '';
+        }
+
+        $lines = ['## Route Access-Control Map'];
+        $lines[] = 'Each line describes a controller action: HTTP method(s), route path, source location, and the access-control surface (class- and method-level `#[IsGranted]`, `denyAccessUnlessGranted()` body calls). Lines marked at the end with the LACKS marker carry a route but no enforcement — treat them as primary candidates for `broken_access_control` and `missing_voter` findings unless a parent firewall covers them.';
+
+        foreach ($routeAccessControls as $routeAccessControl) {
+            $methods = [] === $routeAccessControl->routeMethods() ? 'ANY' : implode(',', $routeAccessControl->routeMethods());
+            $path = $routeAccessControl->routePath() ?? '(unresolved)';
+            $checks = [];
+            if ($routeAccessControl->classHasIsGranted()) {
+                $checks[] = 'class:#[IsGranted]';
+            }
+
+            if ([] !== $routeAccessControl->methodLevelIsGranted()) {
+                $checks[] = 'method:#[IsGranted('.implode(',', $routeAccessControl->methodLevelIsGranted()).')]';
+            }
+
+            if ($routeAccessControl->methodHasDenyAccess()) {
+                $checks[] = 'body:denyAccessUnlessGranted()';
+            }
+
+            $checkLabel = [] === $checks ? 'LACKS_ACCESS_CHECK' : implode(' + ', $checks);
+            $lines[] = \sprintf('- %s %s — %s::%s — %s', $methods, $path, $routeAccessControl->filePath(), $routeAccessControl->methodName(), $checkLabel);
+        }
+
+        return implode("\n", $lines)."\n\n";
     }
 
     private function basePrompt(): string

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -27,7 +27,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 7;
+    public const int PROMPT_VERSION = 5;
 
     /**
      * Skill-block emission order — by attack-surface priority, NOT alphabetical.

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -27,7 +27,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 4;
+    public const int PROMPT_VERSION = 5;
 
     /**
      * Skill-block emission order — by attack-surface priority, NOT alphabetical.
@@ -186,9 +186,13 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             - Custom Doctrine types using `convertToPHPValue` with `unserialize` or `eval`-equivalent.
             - DQL/QueryBuilder usage with string concatenation of request input — even inside the entity class.
             - Boolean / enum coercion via Doctrine type juggling that lets attacker promote a role string.
+            - Serializer groups: `#[Groups([...])]` (or `@Groups({...})`) that places a privileged field (`roles`, `isAdmin`, `passwordHash`, `apiToken`, `internal*`) into a write-side group (e.g. `user:write`, `*:write`, `admin:*`) — denormalization will set it from request payload. Report as `over_permissive_serializer_group`.
+            - Read-side groups (`*:read`, `public`) leaking sensitive fields (`passwordHash`, `tokens`, internal ids) when the entity is serialized in API responses — also `over_permissive_serializer_group`.
             Do NOT flag:
             - Public setters on non-sensitive fields (titles, descriptions) where the form `mapped: false` or constraints validate input.
             - `#[ORM\Column]` with `nullable: true` — nullability is a schema concern, not a security one.
+            - Read-only groups on safe fields (display name, public bio) — non-sensitive read groups are by design.
+            - Fields annotated `#[Ignore]` / `#[SerializedName]` redirecting to a public alias — those are explicit safe overrides.
             </skills>
             SKILL,
         ProjectFileType::REPOSITORY->value => <<<'SKILL'
@@ -373,7 +377,8 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             exposed_internal_service, misconfigured_firewall, insecure_redirect, sensitive_data_exposure,
             log_injection, path_traversal, ssrf, xxe, open_redirect, weak_cryptography, insecure_random,
             hardcoded_secret, missing_signature_verification, messenger_handler_unsafe, missing_rate_limiting,
-            cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass
+            cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass,
+            over_permissive_serializer_group
 
             Severity rubric (calibrate every finding against this scale — do NOT inflate severity for emphasis):
             - critical: unauthenticated RCE, full authentication bypass, mass data exfiltration without auth, hardcoded production secret in a committed file.

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -27,7 +27,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 6;
+    public const int PROMPT_VERSION = 7;
 
     /**
      * Skill-block emission order — by attack-surface priority, NOT alphabetical.
@@ -314,6 +314,8 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
         ));
 
         $accessControlMap = $this->renderRouteAccessControlMap($symfonyMapping);
+        $voterCoverage = $this->renderVoterCoverage($symfonyMapping);
+        $formBindings = $this->renderFormBindings($symfonyMapping);
 
         return <<<PROMPT
             ## Project Mapping Summary
@@ -322,14 +324,47 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             ## Controllers WITHOUT Security Annotations (High Priority)
             {$noVoterList}
 
-            {$accessControlMap}
-            ## Source Code
+            {$accessControlMap}{$voterCoverage}{$formBindings}## Source Code
             Analyze these files for exploitable vulnerabilities. Each line is prefixed with its line number (`NNN | code`) — use those exact numbers when populating `line_start` and `line_end`; do NOT count manually or guess.
 
             {$context}
 
             Return a JSON array of all vulnerabilities found.
             PROMPT;
+    }
+
+    private function renderVoterCoverage(SymfonyMapping $symfonyMapping): string
+    {
+        $voterCapabilities = $symfonyMapping->voterCapabilities();
+        if ([] === $voterCapabilities) {
+            return '';
+        }
+
+        $lines = ['## Voter Coverage'];
+        $lines[] = 'Each line summarises a `Voter::supports()` body: the attributes it accepts and the subject types it gates. Use this to spot `#[IsGranted(\'ATTR\', $subject)]` calls referencing an attribute or subject type that no voter actually covers — that is a `missing_voter` finding.';
+        foreach ($voterCapabilities as $voterCapability) {
+            $attributes = [] === $voterCapability->supportedAttributes() ? '(none)' : implode(',', $voterCapability->supportedAttributes());
+            $subjects = [] === $voterCapability->supportedSubjects() ? '(none)' : implode(',', $voterCapability->supportedSubjects());
+            $lines[] = \sprintf('- %s — attributes: [%s] — subjects: [%s] — %s', $voterCapability->className(), $attributes, $subjects, $voterCapability->filePath());
+        }
+
+        return implode("\n", $lines)."\n\n";
+    }
+
+    private function renderFormBindings(SymfonyMapping $symfonyMapping): string
+    {
+        $formBindings = $symfonyMapping->formBindings();
+        if ([] === $formBindings) {
+            return '';
+        }
+
+        $lines = ['## Form Bindings'];
+        $lines[] = 'Each line records a `$this->createForm(FormType::class)` call site. Cross-reference with the form type to spot mass-assignment vectors (`allow_extra_fields: true`, unbounded `EntityType` choices, missing CSRF on state-changing actions).';
+        foreach ($formBindings as $formBinding) {
+            $lines[] = \sprintf('- %s::%s — %s', $formBinding->controllerFilePath(), $formBinding->controllerMethod(), $formBinding->formTypeClass());
+        }
+
+        return implode("\n", $lines)."\n\n";
     }
 
     private function renderRouteAccessControlMap(SymfonyMapping $symfonyMapping): string

--- a/src/Audit/Infrastructure/Scan/NullControllerAccessControlParser.php
+++ b/src/Audit/Infrastructure/Scan/NullControllerAccessControlParser.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class NullControllerAccessControlParser implements ControllerAccessControlParserInterface
+{
+    public function parse(ProjectFile $projectFile): array
+    {
+        return [];
+    }
+}

--- a/src/Audit/Infrastructure/Scan/NullFormBindingParser.php
+++ b/src/Audit/Infrastructure/Scan/NullFormBindingParser.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\FormBindingParserInterface;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class NullFormBindingParser implements FormBindingParserInterface
+{
+    public function parse(ProjectFile $projectFile): array
+    {
+        return [];
+    }
+}

--- a/src/Audit/Infrastructure/Scan/NullVoterCapabilityParser.php
+++ b/src/Audit/Infrastructure/Scan/NullVoterCapabilityParser.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParserInterface;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class NullVoterCapabilityParser implements VoterCapabilityParserInterface
+{
+    public function parse(ProjectFile $projectFile): ?VoterCapability
+    {
+        return null;
+    }
+}

--- a/src/Audit/Infrastructure/Scan/PhpParserControllerAccessControlParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserControllerAccessControlParser.php
@@ -21,8 +21,6 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
@@ -56,10 +54,6 @@ final readonly class PhpParserControllerAccessControlParser implements Controlle
             if (null === $ast) {
                 return [];
             }
-
-            $nodeTraverser = new NodeTraverser();
-            $nodeTraverser->addVisitor(new NameResolver());
-            $ast = $nodeTraverser->traverse($ast);
         } catch (Throwable) {
             return [];
         }

--- a/src/Audit/Infrastructure/Scan/PhpParserControllerAccessControlParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserControllerAccessControlParser.php
@@ -110,14 +110,13 @@ final readonly class PhpParserControllerAccessControlParser implements Controlle
 
                 $path = null;
                 $methods = [];
-                $positionalIndex = 0;
+                $firstPositionalConsumed = false;
                 foreach ($attribute->args as $arg) {
                     $argName = $arg->name?->toString();
-                    if (null === $argName && 0 === $positionalIndex) {
+                    if (null === $argName && !$firstPositionalConsumed) {
                         $argName = 'path';
+                        $firstPositionalConsumed = true;
                     }
-
-                    ++$positionalIndex;
 
                     if ('path' === $argName && $arg->value instanceof String_) {
                         $path = $arg->value->value;

--- a/src/Audit/Infrastructure/Scan/PhpParserControllerAccessControlParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserControllerAccessControlParser.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use Throwable;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Walks a controller's AST to extract one RouteAccessControl per public action
+ * method. Recognises `#[Route(path:, methods:)]` on methods, `#[IsGranted(...)]`
+ * on both class and method level (matched by short name to survive aliased
+ * imports), and `denyAccessUnlessGranted()` calls in method bodies. Returns
+ * [] for any non-controller file or any parse error — the mapping stage must
+ * never abort because of a single broken file.
+ */
+final readonly class PhpParserControllerAccessControlParser implements ControllerAccessControlParserInterface
+{
+    public function parse(ProjectFile $projectFile): array
+    {
+        if (ProjectFileType::CONTROLLER !== $projectFile->fileType()) {
+            return [];
+        }
+
+        try {
+            $parserFactory = new ParserFactory();
+            $parser = $parserFactory->createForNewestSupportedVersion();
+            $ast = $parser->parse($projectFile->content());
+
+            if (null === $ast) {
+                return [];
+            }
+
+            $nodeTraverser = new NodeTraverser();
+            $nodeTraverser->addVisitor(new NameResolver());
+            $ast = $nodeTraverser->traverse($ast);
+        } catch (Throwable) {
+            return [];
+        }
+
+        $nodeFinder = new NodeFinder();
+        $classes = $nodeFinder->findInstanceOf($ast, Class_::class);
+
+        $entries = [];
+        foreach ($classes as $class) {
+            $classHasIsGranted = $this->hasIsGrantedAttribute($class->attrGroups);
+
+            foreach ($class->getMethods() as $methodNode) {
+                if (!$methodNode->isPublic()) {
+                    continue;
+                }
+
+                $entries[] = $this->buildEntry($projectFile->relativePath(), $methodNode, $classHasIsGranted, $nodeFinder);
+            }
+        }
+
+        return $entries;
+    }
+
+    private function buildEntry(string $filePath, ClassMethod $classMethod, bool $classHasIsGranted, NodeFinder $nodeFinder): RouteAccessControl
+    {
+        $routeData = $this->extractRouteAttribute($classMethod->attrGroups);
+        $methodLevelIsGranted = $this->extractIsGrantedValues($classMethod->attrGroups);
+        $methodHasDenyAccess = $this->methodInvokesDenyAccess($classMethod, $nodeFinder);
+
+        return new RouteAccessControl(
+            filePath: $filePath,
+            methodName: $classMethod->name->toString(),
+            routePath: $routeData['path'],
+            routeMethods: $routeData['methods'],
+            hasRouteAttribute: $routeData['present'],
+            methodLevelIsGranted: $methodLevelIsGranted,
+            methodHasDenyAccess: $methodHasDenyAccess,
+            classHasIsGranted: $classHasIsGranted,
+        );
+    }
+
+    /**
+     * @param array<AttributeGroup> $attributeGroups
+     *
+     * @return array{present: bool, path: ?string, methods: list<string>}
+     */
+    private function extractRouteAttribute(array $attributeGroups): array
+    {
+        foreach ($attributeGroups as $attributeGroup) {
+            foreach ($attributeGroup->attrs as $attribute) {
+                if (!$this->attributeShortNameMatches($attribute->name->toString(), 'Route')) {
+                    continue;
+                }
+
+                $path = null;
+                $methods = [];
+                $positionalIndex = 0;
+                foreach ($attribute->args as $arg) {
+                    $argName = $arg->name?->toString();
+                    if (null === $argName && 0 === $positionalIndex) {
+                        $argName = 'path';
+                    }
+
+                    ++$positionalIndex;
+
+                    if ('path' === $argName && $arg->value instanceof String_) {
+                        $path = $arg->value->value;
+                    }
+
+                    if ('methods' === $argName && $arg->value instanceof Array_) {
+                        $methods = $this->stringValuesFromArray($arg->value);
+                    }
+                }
+
+                return ['present' => true, 'path' => $path, 'methods' => $methods];
+            }
+        }
+
+        return ['present' => false, 'path' => null, 'methods' => []];
+    }
+
+    /**
+     * @param array<AttributeGroup> $attributeGroups
+     *
+     * @return list<string>
+     */
+    private function extractIsGrantedValues(array $attributeGroups): array
+    {
+        $values = [];
+        foreach ($attributeGroups as $attributeGroup) {
+            foreach ($attributeGroup->attrs as $attribute) {
+                if (!$this->attributeShortNameMatches($attribute->name->toString(), 'IsGranted')) {
+                    continue;
+                }
+
+                foreach ($attribute->args as $arg) {
+                    if ($arg->value instanceof String_) {
+                        $values[] = $arg->value->value;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array<AttributeGroup> $attributeGroups
+     */
+    private function hasIsGrantedAttribute(array $attributeGroups): bool
+    {
+        return [] !== $this->extractIsGrantedValues($attributeGroups);
+    }
+
+    private function methodInvokesDenyAccess(ClassMethod $classMethod, NodeFinder $nodeFinder): bool
+    {
+        $stmts = $classMethod->stmts;
+        if (null === $stmts) {
+            return false;
+        }
+
+        $methodCalls = $nodeFinder->findInstanceOf($stmts, MethodCall::class);
+        foreach ($methodCalls as $methodCall) {
+            if ($methodCall->name instanceof Identifier && 'denyAccessUnlessGranted' === $methodCall->name->toString()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function attributeShortNameMatches(string $fullyQualifiedName, string $expectedShortName): bool
+    {
+        $parts = explode('\\', $fullyQualifiedName);
+
+        return end($parts) === $expectedShortName;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringValuesFromArray(Array_ $array): array
+    {
+        $values = [];
+        foreach ($array->items as $item) {
+            if ($item->value instanceof String_) {
+                $values[] = $item->value->value;
+            }
+        }
+
+        return $values;
+    }
+}

--- a/src/Audit/Infrastructure/Scan/PhpParserFormBindingParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserFormBindingParser.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Name;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use Throwable;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\FormBindingParserInterface;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Walks each public controller method body looking for
+ * `$this->createForm(SomeFormType::class)` call sites. Only literal
+ * `FooType::class` arguments are recorded — dynamic class names (variables,
+ * method calls returning class strings) are intentionally ignored because the
+ * binding cannot be resolved statically.
+ */
+final readonly class PhpParserFormBindingParser implements FormBindingParserInterface
+{
+    public function parse(ProjectFile $projectFile): array
+    {
+        if (ProjectFileType::CONTROLLER !== $projectFile->fileType()) {
+            return [];
+        }
+
+        try {
+            $parserFactory = new ParserFactory();
+            $parser = $parserFactory->createForNewestSupportedVersion();
+            $ast = $parser->parse($projectFile->content());
+
+            if (null === $ast) {
+                return [];
+            }
+
+            $nodeTraverser = new NodeTraverser();
+            $nodeTraverser->addVisitor(new NameResolver());
+            $ast = $nodeTraverser->traverse($ast);
+        } catch (Throwable) {
+            return [];
+        }
+
+        $nodeFinder = new NodeFinder();
+        $classes = $nodeFinder->findInstanceOf($ast, Class_::class);
+
+        $bindings = [];
+        foreach ($classes as $class) {
+            foreach ($class->getMethods() as $methodNode) {
+                if (!$methodNode->isPublic()) {
+                    continue;
+                }
+
+                $bindings = [...$bindings, ...$this->bindingsForMethod($projectFile->relativePath(), $methodNode, $nodeFinder)];
+            }
+        }
+
+        return $bindings;
+    }
+
+    /**
+     * @return list<FormBinding>
+     */
+    private function bindingsForMethod(string $filePath, ClassMethod $classMethod, NodeFinder $nodeFinder): array
+    {
+        $body = $classMethod->stmts;
+        if (null === $body) {
+            return [];
+        }
+
+        $bindings = [];
+        $methodCalls = $nodeFinder->findInstanceOf($body, MethodCall::class);
+        foreach ($methodCalls as $methodCall) {
+            if (!$this->isThisCreateFormCall($methodCall)) {
+                continue;
+            }
+
+            $formClass = $this->resolveFirstArgumentClassName($methodCall);
+            if (null === $formClass) {
+                continue;
+            }
+
+            $bindings[] = new FormBinding($filePath, $classMethod->name->toString(), $formClass);
+        }
+
+        return $bindings;
+    }
+
+    private function isThisCreateFormCall(MethodCall $methodCall): bool
+    {
+        if (!$methodCall->name instanceof Identifier) {
+            return false;
+        }
+
+        if ('createForm' !== $methodCall->name->toString()) {
+            return false;
+        }
+
+        return $methodCall->var instanceof Variable && 'this' === $methodCall->var->name;
+    }
+
+    private function resolveFirstArgumentClassName(MethodCall $methodCall): ?string
+    {
+        $firstArgument = $methodCall->args[0] ?? null;
+        if (!$firstArgument instanceof Arg) {
+            return null;
+        }
+
+        $value = $firstArgument->value;
+        if (!$value instanceof ClassConstFetch) {
+            return null;
+        }
+
+        if (!$value->name instanceof Identifier) {
+            return null;
+        }
+
+        if ('class' !== $value->name->toString()) {
+            return null;
+        }
+
+        if (!$value->class instanceof Name) {
+            return null;
+        }
+
+        return $value->class->toString();
+    }
+}

--- a/src/Audit/Infrastructure/Scan/PhpParserFormBindingParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserFormBindingParser.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
 
 use PhpParser\Node\Arg;
-use PhpParser\Node\Name;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;

--- a/src/Audit/Infrastructure/Scan/PhpParserVoterCapabilityParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserVoterCapabilityParser.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+use PhpParser\Node\Name;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use Throwable;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParserInterface;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Walks a voter file's AST and approximates its `supports()` vocabulary by
+ * collecting every string literal (attribute names) and every `instanceof X`
+ * right-hand class name (subject types) inside the method body. The result is
+ * heuristic — random string literals inside `supports()` will be reported as
+ * attributes — but for the attacker prompt's "Voter Coverage" block it gives
+ * the LLM a useful, deterministic summary of who handles what.
+ */
+final readonly class PhpParserVoterCapabilityParser implements VoterCapabilityParserInterface
+{
+    public function parse(ProjectFile $projectFile): ?VoterCapability
+    {
+        if (ProjectFileType::VOTER !== $projectFile->fileType()) {
+            return null;
+        }
+
+        try {
+            $parserFactory = new ParserFactory();
+            $parser = $parserFactory->createForNewestSupportedVersion();
+            $ast = $parser->parse($projectFile->content());
+
+            if (null === $ast) {
+                return null;
+            }
+
+            $nodeTraverser = new NodeTraverser();
+            $nodeTraverser->addVisitor(new NameResolver());
+            $ast = $nodeTraverser->traverse($ast);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $nodeFinder = new NodeFinder();
+        $class = $nodeFinder->findFirstInstanceOf($ast, Class_::class);
+        if (!$class instanceof Class_) {
+            return null;
+        }
+
+        $supportsMethod = $this->findSupportsMethod($class);
+        if (!$supportsMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $body = $supportsMethod->stmts;
+        if (null === $body) {
+            return null;
+        }
+
+        $attributes = $this->collectStringLiterals($body, $nodeFinder);
+        $subjects = $this->collectInstanceofClassNames($body, $nodeFinder);
+
+        return new VoterCapability(
+            filePath: $projectFile->relativePath(),
+            className: $this->resolveClassName($class),
+            supportedAttributes: $attributes,
+            supportedSubjects: $subjects,
+        );
+    }
+
+    private function findSupportsMethod(Class_ $class): ?ClassMethod
+    {
+        foreach ($class->getMethods() as $classMethod) {
+            if ('supports' === $classMethod->name->toString()) {
+                return $classMethod;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<Node> $body
+     *
+     * @return list<string>
+     */
+    private function collectStringLiterals(array $body, NodeFinder $nodeFinder): array
+    {
+        $values = [];
+        $seen = [];
+        $stringNodes = $nodeFinder->findInstanceOf($body, String_::class);
+        foreach ($stringNodes as $stringNode) {
+            $value = $stringNode->value;
+            if ('' === $value) {
+                continue;
+            }
+
+            if (isset($seen[$value])) {
+                continue;
+            }
+
+            $seen[$value] = true;
+            $values[] = $value;
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array<Node> $body
+     *
+     * @return list<string>
+     */
+    private function collectInstanceofClassNames(array $body, NodeFinder $nodeFinder): array
+    {
+        $names = [];
+        $seen = [];
+        $instanceofNodes = $nodeFinder->findInstanceOf($body, Instanceof_::class);
+        foreach ($instanceofNodes as $instanceofNode) {
+            $classExpression = $instanceofNode->class;
+            if (!$classExpression instanceof Name) {
+                continue;
+            }
+
+            $resolved = $classExpression->toString();
+            if (isset($seen[$resolved])) {
+                continue;
+            }
+
+            $seen[$resolved] = true;
+            $names[] = $resolved;
+        }
+
+        return $names;
+    }
+
+    private function resolveClassName(Class_ $class): string
+    {
+        $namespaceName = $class->namespacedName;
+        if ($namespaceName instanceof Name) {
+            return $namespaceName->toString();
+        }
+
+        $shortName = $class->name?->toString();
+
+        return null === $shortName ? '' : $shortName;
+    }
+}

--- a/src/Audit/Infrastructure/Scan/PhpParserVoterCapabilityParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserVoterCapabilityParser.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
 
-use PhpParser\Node\Name;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;

--- a/src/Audit/Infrastructure/Scan/PhpParserVoterCapabilityParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserVoterCapabilityParser.php
@@ -109,7 +109,6 @@ final readonly class PhpParserVoterCapabilityParser implements VoterCapabilityPa
     private function collectStringLiterals(array $body, NodeFinder $nodeFinder): array
     {
         $values = [];
-        $seen = [];
         $stringNodes = $nodeFinder->findInstanceOf($body, String_::class);
         foreach ($stringNodes as $stringNode) {
             $value = $stringNode->value;
@@ -117,11 +116,10 @@ final readonly class PhpParserVoterCapabilityParser implements VoterCapabilityPa
                 continue;
             }
 
-            if (isset($seen[$value])) {
+            if (\in_array($value, $values, true)) {
                 continue;
             }
 
-            $seen[$value] = true;
             $values[] = $value;
         }
 
@@ -136,7 +134,6 @@ final readonly class PhpParserVoterCapabilityParser implements VoterCapabilityPa
     private function collectInstanceofClassNames(array $body, NodeFinder $nodeFinder): array
     {
         $names = [];
-        $seen = [];
         $instanceofNodes = $nodeFinder->findInstanceOf($body, Instanceof_::class);
         foreach ($instanceofNodes as $instanceofNode) {
             $classExpression = $instanceofNode->class;
@@ -145,11 +142,10 @@ final readonly class PhpParserVoterCapabilityParser implements VoterCapabilityPa
             }
 
             $resolved = $classExpression->toString();
-            if (isset($seen[$resolved])) {
+            if (\in_array($resolved, $names, true)) {
                 continue;
             }
 
-            $seen[$resolved] = true;
             $names[] = $resolved;
         }
 

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -32,7 +32,7 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      * alter scan output for existing chunk content. Folded into the attacker
      * cache key so stale entries are invalidated.
      */
-    public const int CACHE_VERSION = 1;
+    public const int CACHE_VERSION = 2;
 
     /**
      * @param array<string, array<string, array{regex: string, description: string}>> $customPatterns extra patterns merged into the static dictionary keyed by file-type bucket
@@ -143,6 +143,10 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
             'sensitive_setter' => [
                 'regex' => '/public\s+function\s+set(?:Roles?|IsAdmin|PasswordHash|Password|Admin|Superuser)\b/i',
                 'description' => 'Public setter on sensitive field — verify it is not bound by a form',
+            ],
+            'serializer_groups_attribute' => [
+                'regex' => '/#\[\s*Groups\s*\(|@Groups\s*\(/',
+                'description' => 'Serializer #[Groups] attribute — verify write groups do not expose privileged fields (roles, isAdmin, passwordHash) to mass assignment',
             ],
         ],
         ProjectFileType::TEMPLATE->value => [

--- a/src/Command/AuditCommand.php
+++ b/src/Command/AuditCommand.php
@@ -74,9 +74,7 @@ final readonly class AuditCommand
 
         $this->auditPresenter->header($symfonyStyle, $projectPath);
 
-        if (!$auditCommandInput->isMachineReadableToStdout()) {
-            $this->auditPresenter->preflightWarnings($symfonyStyle, $this->secretScrubbingEnabled);
-        }
+        $this->auditPresenter->preflightWarnings($symfonyStyle, $this->secretScrubbingEnabled);
 
         $scanPaths = $auditCommandInput->scanPaths();
 

--- a/src/Command/AuditCommand.php
+++ b/src/Command/AuditCommand.php
@@ -63,6 +63,7 @@ final readonly class AuditCommand
         private AuditPresenterInterface $auditPresenter,
         private EstimateAuditCostUseCase $estimateAuditCostUseCase,
         private ProgressReporterHolder $progressReporterHolder,
+        private bool $secretScrubbingEnabled,
     ) {}
 
     public function __invoke(
@@ -72,6 +73,10 @@ final readonly class AuditCommand
         $projectPath = $auditCommandInput->resolvedProjectPath();
 
         $this->auditPresenter->header($symfonyStyle, $projectPath);
+
+        if (!$auditCommandInput->isMachineReadableToStdout()) {
+            $this->auditPresenter->preflightWarnings($symfonyStyle, $this->secretScrubbingEnabled);
+        }
 
         $scanPaths = $auditCommandInput->scanPaths();
 

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -38,11 +38,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
             return;
         }
 
-        $symfonyStyle->getErrorStyle()->warning(
-            'Secret scrubbing is disabled. File contents will be sent verbatim to the configured LLM provider. '
-            .'If that provider runs in the cloud, credentials in committed configs or .env.dist files may be exposed. '
-            .'Re-enable scan.secret_scrubbing.enabled (the default) or confirm you are using a local provider.',
-        );
+        $symfonyStyle->getErrorStyle()->warning('Secret scrubbing is disabled. File contents will be sent verbatim to the configured LLM provider. If that provider runs in the cloud, credentials in committed configs or .env.dist files may be exposed. Re-enable scan.secret_scrubbing.enabled (the default) or confirm you are using a local provider.');
     }
 
     public function runningSection(SymfonyStyle $symfonyStyle): void

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -32,6 +32,19 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         ]);
     }
 
+    public function preflightWarnings(SymfonyStyle $symfonyStyle, bool $secretScrubbingEnabled): void
+    {
+        if ($secretScrubbingEnabled) {
+            return;
+        }
+
+        $symfonyStyle->warning(
+            'Secret scrubbing is disabled. File contents will be sent verbatim to the configured LLM provider. '
+            .'If that provider runs in the cloud, credentials in committed configs or .env.dist files may be exposed. '
+            .'Re-enable scan.secret_scrubbing.enabled (the default) or confirm you are using a local provider.',
+        );
+    }
+
     public function runningSection(SymfonyStyle $symfonyStyle): void
     {
         $symfonyStyle->section('Running audit pipeline...');

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -38,7 +38,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
             return;
         }
 
-        $symfonyStyle->warning(
+        $symfonyStyle->getErrorStyle()->warning(
             'Secret scrubbing is disabled. File contents will be sent verbatim to the configured LLM provider. '
             .'If that provider runs in the cloud, credentials in committed configs or .env.dist files may be exposed. '
             .'Re-enable scan.secret_scrubbing.enabled (the default) or confirm you are using a local provider.',

--- a/src/Command/AuditPresenterInterface.php
+++ b/src/Command/AuditPresenterInterface.php
@@ -22,6 +22,8 @@ interface AuditPresenterInterface
 {
     public function header(SymfonyStyle $symfonyStyle, string $projectPath): void;
 
+    public function preflightWarnings(SymfonyStyle $symfonyStyle, bool $secretScrubbingEnabled): void;
+
     public function runningSection(SymfonyStyle $symfonyStyle): void;
 
     public function estimatingSection(SymfonyStyle $symfonyStyle): void;

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -92,16 +92,20 @@ final class AuditCommandEndToEndTest extends TestCase
         self::assertStringNotContainsString('Secret scrubbing is disabled', $commandTester->getDisplay());
     }
 
-    public function test_command_suppresses_scrubbing_warning_when_output_is_machine_readable(): void
+    public function test_command_still_emits_scrubbing_warning_for_machine_readable_output_on_stderr(): void
     {
         $this->createProjectDir();
 
         $commandTester = $this->makeCommandTester('[]', '{}', secretScrubbingEnabled: false);
-        $commandTester->execute([
-            'project-path' => $this->fixtureDir,
-            '--format' => 'json',
-        ]);
+        $commandTester->execute(
+            [
+                'project-path' => $this->fixtureDir,
+                '--format' => 'json',
+            ],
+            ['capture_stderr_separately' => true],
+        );
 
+        self::assertStringContainsString('Secret scrubbing is disabled', $commandTester->getErrorOutput());
         self::assertStringNotContainsString('Secret scrubbing is disabled', $commandTester->getDisplay());
     }
 

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -71,6 +71,39 @@ final class AuditCommandEndToEndTest extends TestCase
         self::assertStringContainsString('SAFE', $commandTester->getDisplay());
     }
 
+    public function test_command_emits_secret_scrubbing_warning_when_scrubbing_disabled(): void
+    {
+        $this->createProjectDir();
+
+        $commandTester = $this->makeCommandTester('[]', '{}', secretScrubbingEnabled: false);
+        $commandTester->execute(['project-path' => $this->fixtureDir]);
+
+        self::assertStringContainsString('Secret scrubbing is disabled', $commandTester->getDisplay());
+    }
+
+    public function test_command_is_silent_about_scrubbing_when_enabled(): void
+    {
+        $this->createProjectDir();
+
+        $commandTester = $this->makeCommandTester('[]', '{}', secretScrubbingEnabled: true);
+        $commandTester->execute(['project-path' => $this->fixtureDir]);
+
+        self::assertStringNotContainsString('Secret scrubbing is disabled', $commandTester->getDisplay());
+    }
+
+    public function test_command_suppresses_scrubbing_warning_when_output_is_machine_readable(): void
+    {
+        $this->createProjectDir();
+
+        $commandTester = $this->makeCommandTester('[]', '{}', secretScrubbingEnabled: false);
+        $commandTester->execute([
+            'project-path' => $this->fixtureDir,
+            '--format' => 'json',
+        ]);
+
+        self::assertStringNotContainsString('Secret scrubbing is disabled', $commandTester->getDisplay());
+    }
+
     public function test_command_exits_failure_for_nonexistent_project_path(): void
     {
         $commandTester = $this->makeCommandTester('[]', '{}');
@@ -296,7 +329,7 @@ final class AuditCommandEndToEndTest extends TestCase
         );
     }
 
-    private function makeCommandTester(string $attackerResponse, string $reviewerResponse): CommandTester
+    private function makeCommandTester(string $attackerResponse, string $reviewerResponse, bool $secretScrubbingEnabled = true): CommandTester
     {
         $attackerLLM = self::createStub(LLMClientInterface::class);
         $attackerLLM->method('complete')->willReturn(
@@ -308,10 +341,10 @@ final class AuditCommandEndToEndTest extends TestCase
             LLMResponse::create($reviewerResponse, 0, 0, 'stub', 'end_turn'),
         );
 
-        return $this->makeCommandTesterWithLLM($attackerLLM, $reviewerLLM);
+        return $this->makeCommandTesterWithLLM($attackerLLM, $reviewerLLM, $secretScrubbingEnabled);
     }
 
-    private function makeCommandTesterWithLLM(LLMClientInterface $attackerLLM, LLMClientInterface $reviewerLLM): CommandTester
+    private function makeCommandTesterWithLLM(LLMClientInterface $attackerLLM, LLMClientInterface $reviewerLLM, bool $secretScrubbingEnabled = true): CommandTester
     {
         $auditOrchestrator = new AuditOrchestrator(
             new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger()), new NullAttackerCache(), new NullLogger()),
@@ -346,6 +379,7 @@ final class AuditCommandEndToEndTest extends TestCase
             new AuditPresenter(),
             $estimateAuditCostUseCase,
             $progressReporterHolder,
+            secretScrubbingEnabled: $secretScrubbingEnabled,
         );
 
         return new CommandTester($auditCommand);

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -19,6 +19,7 @@ use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Validator\Validation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestrator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
@@ -347,7 +348,7 @@ final class AuditCommandEndToEndTest extends TestCase
     private function makeCommandTesterWithLLM(LLMClientInterface $attackerLLM, LLMClientInterface $reviewerLLM, bool $secretScrubbingEnabled = true): CommandTester
     {
         $auditOrchestrator = new AuditOrchestrator(
-            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger()), new NullAttackerCache(), new NullLogger()),
+            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger()),
             new ReviewerAgent($reviewerLLM, new ReviewerPromptBuilder(), new NullLogger()),
             new NullLogger(),
         );

--- a/tests/Phpunit/EndToEnd/FullAuditEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/FullAuditEndToEndTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\EndToEnd;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Validator\Validation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestrator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
@@ -206,7 +207,7 @@ final class FullAuditEndToEndTest extends TestCase
     private function makeUseCase(LLMClientInterface $attackerLLM, LLMClientInterface $reviewerLLM): RunAuditUseCase
     {
         $auditOrchestrator = new AuditOrchestrator(
-            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger()), new NullAttackerCache(), new NullLogger()),
+            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger()),
             new ReviewerAgent($reviewerLLM, new ReviewerPromptBuilder(), new NullLogger()),
             new NullLogger(),
         );

--- a/tests/Phpunit/Integration/Pipeline/AuditPipelineIntegrationTest.php
+++ b/tests/Phpunit/Integration/Pipeline/AuditPipelineIntegrationTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Pipeline;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Validator\Validation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestrator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
@@ -144,7 +145,7 @@ final class AuditPipelineIntegrationTest extends TestCase
         );
 
         $auditOrchestrator = new AuditOrchestrator(
-            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger()), new NullAttackerCache(), new NullLogger()),
+            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger()),
             new ReviewerAgent($reviewerLLM, new ReviewerPromptBuilder(), new NullLogger()),
             new NullLogger(),
         );

--- a/tests/Phpunit/Integration/UseCase/RunAuditUseCaseIntegrationTest.php
+++ b/tests/Phpunit/Integration/UseCase/RunAuditUseCaseIntegrationTest.php
@@ -16,6 +16,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\UseCase;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\Validator\Validation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestrator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
@@ -153,7 +154,7 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         $reviewerLLM->method('complete')->willReturn(LLMResponse::create('{}', 0, 0, 'gpt-4o', 'end_turn'));
 
         $auditOrchestrator = new AuditOrchestrator(
-            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger()), new NullAttackerCache(), new NullLogger()),
+            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger()),
             new ReviewerAgent($reviewerLLM, new ReviewerPromptBuilder(), new NullLogger()),
             new NullLogger(),
         );
@@ -230,7 +231,7 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
 
         // batchSize > 1 routes through reviewBatch instead of reviewSingle.
         $auditOrchestrator = new AuditOrchestrator(
-            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger()), new NullAttackerCache(), new NullLogger()),
+            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger()),
             new ReviewerAgent($reviewerLLM, new ReviewerPromptBuilder(), new NullLogger(), batchSize: 5),
             new NullLogger(),
         );
@@ -335,7 +336,7 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         LoggerInterface $logger,
     ): RunAuditUseCase {
         $auditOrchestrator = new AuditOrchestrator(
-            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger()), new NullAttackerCache(), new NullLogger()),
+            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger()),
             new ReviewerAgent($reviewerLLM, new ReviewerPromptBuilder(), new NullLogger()),
             new NullLogger(),
         );
@@ -368,7 +369,7 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         );
 
         $auditOrchestrator = new AuditOrchestrator(
-            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger()), new NullAttackerCache(), new NullLogger()),
+            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger()),
             new ReviewerAgent($reviewerLLM, new ReviewerPromptBuilder(), new NullLogger()),
             new NullLogger(),
         );

--- a/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
@@ -33,6 +33,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskMarker;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityDropReason;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\CoverageRecorderInterface;
@@ -552,6 +553,39 @@ final class AttackerAgentTest extends TestCase
 
         self::assertSame(['Attacker agent starting analysis', ['files' => 2, 'files_filtered_lean' => 0, 'markers' => 0, 'tools_enabled' => false, 'cache_bypassed' => false, 'previous_findings' => 0]], $infoLogs[0]);
         self::assertSame(['Attacker agent complete', ['total_vulnerabilities' => 0, 'total_dropped_entries' => 0, 'dropped_by_reason' => []]], $infoLogs[1]);
+    }
+
+    public function test_it_aggregates_drop_counts_across_chunks_in_complete_log(): void
+    {
+        $infoLogs = [];
+        $logger = self::createStub(LoggerInterface::class);
+        $logger->method('info')->willReturnCallback(
+            static function (string $msg, array $ctx = []) use (&$infoLogs): void {
+                $infoLogs[] = [$msg, $ctx];
+            },
+        );
+        $logger->method('debug');
+        $logger->method('warning');
+
+        $files = [];
+        for ($i = 1; $i <= 15; ++$i) {
+            $files[] = $this->makeFile(\sprintf('src/Service/Service%d.php', $i));
+        }
+
+        $llmClient = self::createStub(LLMClientInterface::class);
+        $llmClient
+            ->method('complete')
+            ->willReturn(LLMResponse::create('["not-an-array-entry", "another-bad-one"]', 10, 10, 'claude', 'end_turn'));
+
+        $attackerAgent = $this->makeAttackerAgent($llmClient, null, $logger);
+
+        $this->callAnalyze($attackerAgent, $files, SymfonyMapping::create(), new NullCoverageRecorder());
+
+        $completeLog = $infoLogs[\count($infoLogs) - 1];
+        self::assertSame('Attacker agent complete', $completeLog[0]);
+        self::assertSame(0, $completeLog[1]['total_vulnerabilities']);
+        self::assertSame(4, $completeLog[1]['total_dropped_entries']);
+        self::assertSame([VulnerabilityDropReason::NON_ARRAY_ENTRY->value => 4], $completeLog[1]['dropped_by_reason']);
     }
 
     public function test_it_logs_debug_chunk_complete_with_exact_context(): void

--- a/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
@@ -20,6 +20,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use Symfony\Component\ErrorHandler\BufferingLogger;
+use Symfony\Component\Validator\Validation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgentInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAnalysisRequest;
@@ -168,7 +169,7 @@ final class AttackerAgentTest extends TestCase
         $attackerAgent = new AttackerAgent(
             llmClient: $llmClient,
             attackerPromptBuilder: new AttackerPromptBuilder(),
-            vulnerabilityFactory: new VulnerabilityFactory(new NullLogger()),
+            vulnerabilityFactory: new VulnerabilityFactory(new NullLogger(), Validation::createValidator()),
             attackerCache: new NullAttackerCache(),
             logger: new NullLogger(),
             codeSlicer: $codeSlicer,
@@ -550,7 +551,7 @@ final class AttackerAgentTest extends TestCase
         $this->callAnalyze($attackerAgent, $files, SymfonyMapping::create(), new NullCoverageRecorder());
 
         self::assertSame(['Attacker agent starting analysis', ['files' => 2, 'files_filtered_lean' => 0, 'markers' => 0, 'tools_enabled' => false, 'cache_bypassed' => false, 'previous_findings' => 0]], $infoLogs[0]);
-        self::assertSame(['Attacker agent complete', ['total_vulnerabilities' => 0]], $infoLogs[1]);
+        self::assertSame(['Attacker agent complete', ['total_vulnerabilities' => 0, 'total_dropped_entries' => 0, 'dropped_by_reason' => []]], $infoLogs[1]);
     }
 
     public function test_it_logs_debug_chunk_complete_with_exact_context(): void
@@ -578,7 +579,7 @@ final class AttackerAgentTest extends TestCase
         self::assertCount(2, $debugLogs);
         self::assertSame('Analyzing chunk 1/1', $debugLogs[0][0]);
         self::assertSame('Chunk analysis complete', $debugLogs[1][0]);
-        self::assertSame(['chunk' => 1, 'found' => 0, 'total_so_far' => 0], $debugLogs[1][1]);
+        self::assertSame(['chunk' => 1, 'found' => 0, 'dropped' => 0, 'total_so_far' => 0], $debugLogs[1][1]);
     }
 
     public function test_it_logs_debug_analyzing_chunk_with_one_based_index_for_multiple_chunks(): void
@@ -1582,7 +1583,7 @@ final class AttackerAgentTest extends TestCase
         return new AttackerAgent(
             llmClient: $llmClient,
             attackerPromptBuilder: new AttackerPromptBuilder(),
-            vulnerabilityFactory: new VulnerabilityFactory(new NullLogger()),
+            vulnerabilityFactory: new VulnerabilityFactory(new NullLogger(), Validation::createValidator()),
             attackerCache: $attackerCache ?? new NullAttackerCache(),
             logger: $logger ?? new NullLogger(),
             toolRegistryFactory: $toolRegistryFactory,

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
+use Symfony\Component\Validator\Validation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestrator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
@@ -693,7 +694,7 @@ final class AuditOrchestratorTest extends TestCase
             attackerAgent: new AttackerAgent(
                 llmClient: $attackerLlm,
                 attackerPromptBuilder: new AttackerPromptBuilder(),
-                vulnerabilityFactory: new VulnerabilityFactory(new NullLogger()),
+                vulnerabilityFactory: new VulnerabilityFactory(new NullLogger(), Validation::createValidator()),
                 attackerCache: new NullAttackerCache(),
                 logger: new NullLogger(),
             ),

--- a/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
@@ -225,6 +225,78 @@ final class VulnerabilityFactoryTest extends TestCase
         self::assertNull($result);
     }
 
+    public function test_from_list_validation_drop_emits_logger_warning_with_reason_and_violations(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Dropping vulnerability entry that failed validation',
+                self::callback(static function (array $context): bool {
+                    if (VulnerabilityDropReason::VALIDATION_FAILED->value !== ($context['reason'] ?? null)) {
+                        return false;
+                    }
+
+                    if (!\is_array($context['violations'] ?? null)) {
+                        return false;
+                    }
+
+                    return [] !== $context['violations'];
+                }),
+            );
+
+        $vulnerabilityFactory = new VulnerabilityFactory($logger, Validation::createValidator());
+
+        $vulnerabilityHydrationResult = $vulnerabilityFactory->fromList([$this->validData(['file_path' => ''])]);
+
+        self::assertSame([], $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
+    }
+
+    public function test_validation_drop_emits_one_violation_message_per_failed_constraint(): void
+    {
+        $violationsByCall = [];
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Dropping vulnerability entry that failed validation',
+                self::callback(static function (array $context) use (&$violationsByCall): bool {
+                    $violationsByCall[] = $context['violations'] ?? null;
+
+                    return true;
+                }),
+            );
+
+        $vulnerabilityFactory = new VulnerabilityFactory($logger, Validation::createValidator());
+
+        $vulnerabilityFactory->fromArray($this->validData([
+            'file_path' => '',
+            'description' => '',
+            'attack_vector' => str_repeat('A', 5001),
+        ]));
+
+        self::assertCount(1, $violationsByCall);
+        self::assertIsArray($violationsByCall[0]);
+        self::assertCount(3, $violationsByCall[0]);
+    }
+
+    public function test_validation_accepts_payload_with_missing_optional_fields(): void
+    {
+        $vulnerability = $this->vulnerabilityFactory->fromArray([
+            'type' => 'sql_injection',
+            'severity' => 'high',
+            'title' => 'SQL Injection',
+            'description' => 'Raw query with user input',
+            'file_path' => 'src/Repository/UserRepository.php',
+            'line_start' => 42,
+            'line_end' => 45,
+        ]);
+
+        self::assertNotNull($vulnerability);
+        self::assertSame('SQL Injection', $vulnerability->title());
+    }
+
     public function test_it_drops_entries_with_blank_description_under_validation_failed_reason(): void
     {
         $list = [

--- a/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
@@ -16,6 +16,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\Validator\Validation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityDropReason;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityHydrationResult;
@@ -119,6 +120,45 @@ final class VulnerabilityFactoryTest extends TestCase
         self::assertSame(3, $vulnerabilityHydrationResult->totalDropped());
     }
 
+    public function test_it_drops_entries_with_blank_file_path_under_validation_failed_reason(): void
+    {
+        $list = [
+            $this->validData(['file_path' => '']),
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertCount(1, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
+    }
+
+    public function test_it_drops_entries_with_overly_long_title_under_validation_failed_reason(): void
+    {
+        $list = [
+            $this->validData(['title' => str_repeat('A', 501)]),
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertCount(1, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
+    }
+
+    public function test_it_drops_entries_with_blank_description_under_validation_failed_reason(): void
+    {
+        $list = [
+            $this->validData(['description' => '']),
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertCount(1, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
+    }
+
     public function test_it_counts_hydration_failures_under_hydration_failed_reason(): void
     {
         $list = [
@@ -145,7 +185,7 @@ final class VulnerabilityFactoryTest extends TestCase
                 'entry_preview' => 'not an array',
             ]);
 
-        $vulnerabilityFactory = new VulnerabilityFactory($logger);
+        $vulnerabilityFactory = new VulnerabilityFactory($logger, Validation::createValidator());
 
         $vulnerabilityHydrationResult = $vulnerabilityFactory->fromList(['not an array']);
 
@@ -165,7 +205,7 @@ final class VulnerabilityFactoryTest extends TestCase
                 'entry_preview' => str_repeat('A', 120),
             ]);
 
-        $vulnerabilityFactory = new VulnerabilityFactory($logger);
+        $vulnerabilityFactory = new VulnerabilityFactory($logger, Validation::createValidator());
 
         $vulnerabilityFactory->fromList([$longString]);
     }
@@ -181,7 +221,7 @@ final class VulnerabilityFactoryTest extends TestCase
                 'entry_preview' => null,
             ]);
 
-        $vulnerabilityFactory = new VulnerabilityFactory($logger);
+        $vulnerabilityFactory = new VulnerabilityFactory($logger, Validation::createValidator());
 
         $vulnerabilityFactory->fromList([42]);
     }
@@ -237,7 +277,7 @@ final class VulnerabilityFactoryTest extends TestCase
                 'error' => '"invalid_type" is not a valid backing value for enum VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType',
             ]);
 
-        $vulnerabilityFactory = new VulnerabilityFactory($logger);
+        $vulnerabilityFactory = new VulnerabilityFactory($logger, Validation::createValidator());
 
         $result = $vulnerabilityFactory->fromArray($invalidData);
 
@@ -255,7 +295,7 @@ final class VulnerabilityFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->vulnerabilityFactory = new VulnerabilityFactory(new NullLogger());
+        $this->vulnerabilityFactory = new VulnerabilityFactory(new NullLogger(), Validation::createValidator());
     }
 
     /**

--- a/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
@@ -146,6 +146,85 @@ final class VulnerabilityFactoryTest extends TestCase
         self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
     }
 
+    public function test_it_drops_entries_with_overly_long_vulnerable_code_under_validation_failed_reason(): void
+    {
+        $list = [
+            $this->validData(['vulnerable_code' => str_repeat('A', 5001)]),
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertCount(1, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
+    }
+
+    public function test_it_drops_entries_with_overly_long_attack_vector_under_validation_failed_reason(): void
+    {
+        $list = [
+            $this->validData(['attack_vector' => str_repeat('A', 5001)]),
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertCount(1, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
+    }
+
+    public function test_it_drops_entries_with_overly_long_proof_under_validation_failed_reason(): void
+    {
+        $list = [
+            $this->validData(['proof' => str_repeat('A', 5001)]),
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertCount(1, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
+    }
+
+    public function test_it_drops_entries_with_overly_long_remediation_under_validation_failed_reason(): void
+    {
+        $list = [
+            $this->validData(['remediation' => str_repeat('A', 5001)]),
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertCount(1, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(1, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::VALIDATION_FAILED));
+    }
+
+    public function test_validation_drop_emits_logger_warning_with_reason_and_violations(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Dropping vulnerability entry that failed validation',
+                self::callback(static function (array $context): bool {
+                    if (VulnerabilityDropReason::VALIDATION_FAILED->value !== ($context['reason'] ?? null)) {
+                        return false;
+                    }
+
+                    if (!\is_array($context['violations'] ?? null)) {
+                        return false;
+                    }
+
+                    return [] !== $context['violations'];
+                }),
+            );
+
+        $vulnerabilityFactory = new VulnerabilityFactory($logger, Validation::createValidator());
+
+        $result = $vulnerabilityFactory->fromArray($this->validData(['file_path' => '']));
+
+        self::assertNull($result);
+    }
+
     public function test_it_drops_entries_with_blank_description_under_validation_failed_reason(): void
     {
         $list = [

--- a/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityFactory;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityDropReason;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityHydrationResult;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 
@@ -68,16 +70,20 @@ final class VulnerabilityFactoryTest extends TestCase
             $this->validData(['title' => 'Second valid', 'file_path' => 'src/Other.php']),
         ];
 
-        $vulnerabilities = $this->vulnerabilityFactory->fromList($list);
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
 
-        self::assertCount(2, $vulnerabilities);
-        self::assertSame('SQL Injection', $vulnerabilities[0]->title());
-        self::assertSame('Second valid', $vulnerabilities[1]->title());
+        self::assertCount(2, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame('SQL Injection', $vulnerabilityHydrationResult->vulnerabilities()[0]->title());
+        self::assertSame('Second valid', $vulnerabilityHydrationResult->vulnerabilities()[1]->title());
     }
 
-    public function test_it_returns_empty_array_for_empty_list(): void
+    public function test_it_returns_empty_result_for_empty_list(): void
     {
-        self::assertEmpty($this->vulnerabilityFactory->fromList([]));
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList([]);
+
+        self::assertInstanceOf(VulnerabilityHydrationResult::class, $vulnerabilityHydrationResult);
+        self::assertSame([], $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertFalse($vulnerabilityHydrationResult->hasDrops());
     }
 
     public function test_it_drops_non_array_entries_from_list(): void
@@ -90,28 +96,60 @@ final class VulnerabilityFactoryTest extends TestCase
             $this->validData(['title' => 'Second valid', 'file_path' => 'src/Other.php']),
         ];
 
-        $vulnerabilities = $this->vulnerabilityFactory->fromList($list);
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
 
-        self::assertCount(2, $vulnerabilities);
-        self::assertSame('SQL Injection', $vulnerabilities[0]->title());
-        self::assertSame('Second valid', $vulnerabilities[1]->title());
+        self::assertCount(2, $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame('SQL Injection', $vulnerabilityHydrationResult->vulnerabilities()[0]->title());
+        self::assertSame('Second valid', $vulnerabilityHydrationResult->vulnerabilities()[1]->title());
     }
 
-    public function test_it_logs_warning_when_list_entry_is_not_an_array(): void
+    public function test_it_counts_non_array_entries_under_non_array_reason(): void
+    {
+        $list = [
+            'not an array',
+            42,
+            null,
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertSame(3, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::NON_ARRAY_ENTRY));
+        self::assertSame(0, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::HYDRATION_FAILED));
+        self::assertSame(3, $vulnerabilityHydrationResult->totalDropped());
+    }
+
+    public function test_it_counts_hydration_failures_under_hydration_failed_reason(): void
+    {
+        $list = [
+            $this->validData(['type' => 'invalid_type']),
+            $this->validData(['severity' => 'invalid_severity']),
+            $this->validData(),
+        ];
+
+        $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($list);
+
+        self::assertSame(0, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::NON_ARRAY_ENTRY));
+        self::assertSame(2, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::HYDRATION_FAILED));
+        self::assertSame(2, $vulnerabilityHydrationResult->totalDropped());
+    }
+
+    public function test_it_logs_warning_with_reason_code_when_list_entry_is_not_an_array(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())
             ->method('warning')
             ->with('Skipping non-array vulnerability entry from LLM', [
+                'reason' => VulnerabilityDropReason::NON_ARRAY_ENTRY->value,
                 'entry_type' => 'string',
                 'entry_preview' => 'not an array',
             ]);
 
         $vulnerabilityFactory = new VulnerabilityFactory($logger);
 
-        $result = $vulnerabilityFactory->fromList(['not an array']);
+        $vulnerabilityHydrationResult = $vulnerabilityFactory->fromList(['not an array']);
 
-        self::assertEmpty($result);
+        self::assertSame([], $vulnerabilityHydrationResult->vulnerabilities());
     }
 
     public function test_it_truncates_long_string_preview_in_warning(): void
@@ -122,6 +160,7 @@ final class VulnerabilityFactoryTest extends TestCase
         $logger->expects(self::once())
             ->method('warning')
             ->with('Skipping non-array vulnerability entry from LLM', [
+                'reason' => VulnerabilityDropReason::NON_ARRAY_ENTRY->value,
                 'entry_type' => 'string',
                 'entry_preview' => str_repeat('A', 120),
             ]);
@@ -137,6 +176,7 @@ final class VulnerabilityFactoryTest extends TestCase
         $logger->expects(self::once())
             ->method('warning')
             ->with('Skipping non-array vulnerability entry from LLM', [
+                'reason' => VulnerabilityDropReason::NON_ARRAY_ENTRY->value,
                 'entry_type' => 'int',
                 'entry_preview' => null,
             ]);
@@ -184,7 +224,7 @@ final class VulnerabilityFactoryTest extends TestCase
         self::assertSame(0.5, $vuln->confidence());
     }
 
-    public function test_it_logs_warning_when_data_is_invalid(): void
+    public function test_it_logs_warning_with_reason_code_when_data_is_invalid(): void
     {
         $invalidData = $this->validData(['type' => 'invalid_type']);
 
@@ -192,6 +232,7 @@ final class VulnerabilityFactoryTest extends TestCase
         $logger->expects(self::once())
             ->method('warning')
             ->with('Failed to create vulnerability from LLM data', [
+                'reason' => VulnerabilityDropReason::HYDRATION_FAILED->value,
                 'data' => $invalidData,
                 'error' => '"invalid_type" is not a valid backing value for enum VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType',
             ]);

--- a/tests/Phpunit/Unit/Application/Stage/StagesTest.php
+++ b/tests/Phpunit/Unit/Application/Stage/StagesTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\ErrorHandler\BufferingLogger;
+use Symfony\Component\Validator\Validation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestrator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
@@ -684,7 +685,7 @@ final class StagesTest extends TestCase
             attackerAgent: new AttackerAgent(
                 llmClient: $attackerLlm ?? self::createStub(LLMClientInterface::class),
                 attackerPromptBuilder: new AttackerPromptBuilder(),
-                vulnerabilityFactory: new VulnerabilityFactory(new NullLogger()),
+                vulnerabilityFactory: new VulnerabilityFactory(new NullLogger(), Validation::createValidator()),
                 attackerCache: new NullAttackerCache(),
                 logger: new NullLogger(),
             ),

--- a/tests/Phpunit/Unit/Application/Stage/StagesTest.php
+++ b/tests/Phpunit/Unit/Application/Stage/StagesTest.php
@@ -26,14 +26,18 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage\AuditS
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage\IngestionStage;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage\MappingStage;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\FormBindingParserInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\GitChangedFilesResolverInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProjectFileScannerInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParserInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\NullAttackerCache;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\AttackerPromptBuilder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\ReviewerPromptBuilder;
@@ -198,6 +202,117 @@ final class StagesTest extends TestCase
         self::assertSame([$unprotected], $mapping->controllersWithoutAccessCheck());
         self::assertSame(2, $auditContext->getMeta('mapping.routes'));
         self::assertSame(1, $auditContext->getMeta('mapping.routes_without_access_check'));
+    }
+
+    public function test_mapping_stage_aggregates_route_access_controls_from_multiple_controllers(): void
+    {
+        $controllerA = ProjectFile::create('src/Controller/AController.php', '/app/A', '<?php class AController {}');
+        $controllerB = ProjectFile::create('src/Controller/BController.php', '/app/B', '<?php class BController {}');
+        $entryA = new RouteAccessControl('src/Controller/AController.php', 'a', '/a', ['GET'], true, ['ROLE_A'], false, false);
+        $entryB = new RouteAccessControl('src/Controller/BController.php', 'b', '/b', ['POST'], true, ['ROLE_B'], false, false);
+
+        $parser = new readonly class($entryA, $entryB) implements ControllerAccessControlParserInterface {
+            public function __construct(private RouteAccessControl $entryA, private RouteAccessControl $entryB) {}
+
+            public function parse(ProjectFile $projectFile): array
+            {
+                return 'src/Controller/AController.php' === $projectFile->relativePath() ? [$this->entryA] : [$this->entryB];
+            }
+        };
+
+        $mappingStage = new MappingStage(new NullLogger(), $parser);
+        $auditContext = AuditContext::forProject($this->tmpDir);
+        $auditContext->setProjectFiles([$controllerA, $controllerB]);
+
+        $mappingStage->process($auditContext);
+
+        $mapping = $auditContext->mapping();
+        self::assertNotNull($mapping);
+        self::assertSame([$entryA, $entryB], $mapping->routeAccessControls());
+    }
+
+    public function test_mapping_stage_routes_voters_through_the_voter_capability_parser(): void
+    {
+        $voterFileA = ProjectFile::create('src/Security/UserVoter.php', '/app/U', '<?php class UserVoter {}');
+        $voterFileB = ProjectFile::create('src/Security/CommentVoter.php', '/app/C', '<?php class CommentVoter {}');
+        $capabilityA = new VoterCapability('src/Security/UserVoter.php', 'UserVoter', ['EDIT'], ['User']);
+        $capabilityB = new VoterCapability('src/Security/CommentVoter.php', 'CommentVoter', ['VIEW'], ['Comment']);
+        $parser = new readonly class($capabilityA, $capabilityB) implements VoterCapabilityParserInterface {
+            public function __construct(private VoterCapability $capA, private VoterCapability $capB) {}
+
+            public function parse(ProjectFile $projectFile): ?VoterCapability
+            {
+                return match ($projectFile->relativePath()) {
+                    'src/Security/UserVoter.php' => $this->capA,
+                    'src/Security/CommentVoter.php' => $this->capB,
+                    default => null,
+                };
+            }
+        };
+
+        $mappingStage = new MappingStage(new NullLogger(), null, $parser);
+        $auditContext = AuditContext::forProject($this->tmpDir);
+        $auditContext->setProjectFiles([$voterFileA, $voterFileB]);
+
+        $mappingStage->process($auditContext);
+
+        $mapping = $auditContext->mapping();
+        self::assertNotNull($mapping);
+        self::assertSame([$capabilityA, $capabilityB], $mapping->voterCapabilities());
+        self::assertSame(2, $auditContext->getMeta('mapping.voter_capabilities'));
+    }
+
+    public function test_mapping_stage_skips_null_voter_parser_results(): void
+    {
+        $voterFile = ProjectFile::create('src/Security/SilentVoter.php', '/app/x', '<?php class SilentVoter {}');
+        $parser = new readonly class implements VoterCapabilityParserInterface {
+            public function parse(ProjectFile $projectFile): ?VoterCapability
+            {
+                return null;
+            }
+        };
+
+        $mappingStage = new MappingStage(new NullLogger(), null, $parser);
+        $auditContext = AuditContext::forProject($this->tmpDir);
+        $auditContext->setProjectFiles([$voterFile]);
+
+        $mappingStage->process($auditContext);
+
+        $mapping = $auditContext->mapping();
+        self::assertNotNull($mapping);
+        self::assertSame([], $mapping->voterCapabilities());
+    }
+
+    public function test_mapping_stage_routes_controllers_through_the_form_binding_parser(): void
+    {
+        $controllerA = ProjectFile::create('src/Controller/UserController.php', '/app/U', '<?php class UserController {}');
+        $controllerB = ProjectFile::create('src/Controller/AdminController.php', '/app/A', '<?php class AdminController {}');
+        $bindingA = new FormBinding('src/Controller/UserController.php', 'edit', 'App\\Form\\UserType');
+        $bindingB = new FormBinding('src/Controller/AdminController.php', 'create', 'App\\Form\\AdminType');
+
+        $parser = new readonly class($bindingA, $bindingB) implements FormBindingParserInterface {
+            public function __construct(private FormBinding $a, private FormBinding $b) {}
+
+            public function parse(ProjectFile $projectFile): array
+            {
+                return match ($projectFile->relativePath()) {
+                    'src/Controller/UserController.php' => [$this->a],
+                    'src/Controller/AdminController.php' => [$this->b],
+                    default => [],
+                };
+            }
+        };
+
+        $mappingStage = new MappingStage(new NullLogger(), null, null, $parser);
+        $auditContext = AuditContext::forProject($this->tmpDir);
+        $auditContext->setProjectFiles([$controllerA, $controllerB]);
+
+        $mappingStage->process($auditContext);
+
+        $mapping = $auditContext->mapping();
+        self::assertNotNull($mapping);
+        self::assertSame([$bindingA, $bindingB], $mapping->formBindings());
+        self::assertSame(2, $auditContext->getMeta('mapping.form_bindings'));
     }
 
     public function test_mapping_stage_creates_mapping_from_project_files(): void

--- a/tests/Phpunit/Unit/Application/Stage/StagesTest.php
+++ b/tests/Phpunit/Unit/Application/Stage/StagesTest.php
@@ -27,7 +27,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage\Ingest
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage\MappingStage;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessControlParserInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\GitChangedFilesResolverInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
@@ -148,6 +150,54 @@ final class StagesTest extends TestCase
         $mappingStage = new MappingStage(new NullLogger());
 
         self::assertSame('mapping', $mappingStage->name());
+    }
+
+    public function test_mapping_stage_routes_controllers_through_the_access_control_parser(): void
+    {
+        $controllerFile = ProjectFile::create('src/Controller/AdminController.php', '/app/x', '<?php class AdminController {}');
+        $protected = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'edit',
+            routePath: '/admin/edit',
+            routeMethods: ['POST'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: ['ROLE_ADMIN'],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+        $unprotected = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'leak',
+            routePath: '/admin/leak',
+            routeMethods: [],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+        $parser = new readonly class([$protected, $unprotected]) implements ControllerAccessControlParserInterface {
+            /** @param list<RouteAccessControl> $entries */
+            public function __construct(private array $entries) {}
+
+            public function parse(ProjectFile $projectFile): array
+            {
+                return $this->entries;
+            }
+        };
+
+        $mappingStage = new MappingStage(new NullLogger(), $parser);
+
+        $auditContext = AuditContext::forProject($this->tmpDir);
+        $auditContext->setProjectFiles([$controllerFile]);
+
+        $mappingStage->process($auditContext);
+
+        $mapping = $auditContext->mapping();
+        self::assertNotNull($mapping);
+        self::assertSame([$protected, $unprotected], $mapping->routeAccessControls());
+        self::assertSame([$unprotected], $mapping->controllersWithoutAccessCheck());
+        self::assertSame(2, $auditContext->getMeta('mapping.routes'));
+        self::assertSame(1, $auditContext->getMeta('mapping.routes_without_access_check'));
     }
 
     public function test_mapping_stage_creates_mapping_from_project_files(): void

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -115,8 +115,10 @@ final class AuditPresenterTest extends TestCase
         $this->auditPresenter->preflightWarnings($symfonyStyle, secretScrubbingEnabled: false);
 
         $display = $bufferedOutput->fetch();
-        self::assertStringContainsString('Secret scrubbing is disabled', $display);
-        self::assertStringContainsString('scan.secret_scrubbing.enabled', $display);
+        $flattened = preg_replace('/\s+/', ' ', $display) ?? '';
+        self::assertStringContainsString('Secret scrubbing is disabled. File contents will be sent verbatim to the configured LLM provider.', $flattened);
+        self::assertStringContainsString('If that provider runs in the cloud, credentials in committed configs or .env.dist files may be exposed.', $flattened);
+        self::assertStringContainsString('Re-enable scan.secret_scrubbing.enabled (the default) or confirm you are using a local provider.', $flattened);
     }
 
     public function test_preflight_warnings_are_silent_when_secret_scrubbing_enabled(): void

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -107,6 +107,28 @@ final class AuditPresenterTest extends TestCase
         self::assertStringNotContainsString('CRITICAL risk level', $display);
     }
 
+    public function test_preflight_warnings_emit_secret_scrubbing_warning_when_disabled(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->preflightWarnings($symfonyStyle, secretScrubbingEnabled: false);
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('Secret scrubbing is disabled', $display);
+        self::assertStringContainsString('scan.secret_scrubbing.enabled', $display);
+    }
+
+    public function test_preflight_warnings_are_silent_when_secret_scrubbing_enabled(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->preflightWarnings($symfonyStyle, secretScrubbingEnabled: true);
+
+        self::assertSame('', $bufferedOutput->fetch());
+    }
+
     public function test_running_section_emits_section_header(): void
     {
         $bufferedOutput = new BufferedOutput();

--- a/tests/Phpunit/Unit/Domain/Model/FormBindingTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/FormBindingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
+
+final class FormBindingTest extends TestCase
+{
+    public function test_it_exposes_controller_action_and_form_type(): void
+    {
+        $formBinding = new FormBinding(
+            controllerFilePath: 'src/Controller/UserController.php',
+            controllerMethod: 'edit',
+            formTypeClass: 'App\\Form\\UserType',
+        );
+
+        self::assertSame('src/Controller/UserController.php', $formBinding->controllerFilePath());
+        self::assertSame('edit', $formBinding->controllerMethod());
+        self::assertSame('App\\Form\\UserType', $formBinding->formTypeClass());
+    }
+}

--- a/tests/Phpunit/Unit/Domain/Model/RouteAccessControlTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/RouteAccessControlTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
+
+final class RouteAccessControlTest extends TestCase
+{
+    public function test_action_with_route_and_no_check_lacks_access_check(): void
+    {
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'deleteUser',
+            routePath: '/admin/users/{id}',
+            routeMethods: ['DELETE'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        self::assertFalse($routeAccessControl->hasAccessCheck());
+        self::assertTrue($routeAccessControl->lacksAccessCheck());
+    }
+
+    public function test_action_with_method_level_is_granted_has_access_check(): void
+    {
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'deleteUser',
+            routePath: '/admin/users/{id}',
+            routeMethods: ['DELETE'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: ['ROLE_ADMIN'],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        self::assertTrue($routeAccessControl->hasAccessCheck());
+        self::assertFalse($routeAccessControl->lacksAccessCheck());
+    }
+
+    public function test_action_with_class_level_is_granted_has_access_check(): void
+    {
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'list',
+            routePath: '/admin/users',
+            routeMethods: ['GET'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: true,
+        );
+
+        self::assertTrue($routeAccessControl->hasAccessCheck());
+        self::assertFalse($routeAccessControl->lacksAccessCheck());
+    }
+
+    public function test_action_with_deny_access_call_has_access_check(): void
+    {
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'edit',
+            routePath: '/admin/users/{id}/edit',
+            routeMethods: ['POST'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: true,
+            classHasIsGranted: false,
+        );
+
+        self::assertTrue($routeAccessControl->hasAccessCheck());
+        self::assertFalse($routeAccessControl->lacksAccessCheck());
+    }
+
+    public function test_method_without_route_attribute_does_not_count_as_lacking_access_check(): void
+    {
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/SupportController.php',
+            methodName: 'privateHelper',
+            routePath: null,
+            routeMethods: [],
+            hasRouteAttribute: false,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        self::assertFalse($routeAccessControl->lacksAccessCheck());
+    }
+}

--- a/tests/Phpunit/Unit/Domain/Model/SymfonyMappingTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/SymfonyMappingTest.php
@@ -65,6 +65,24 @@ final class SymfonyMappingTest extends TestCase
         self::assertSame([], $symfonyMapping->votersFor('PUBLISH', 'Post'));
     }
 
+    public function test_voters_for_excludes_voter_matching_attribute_but_not_subject(): void
+    {
+        $voterCapability = new VoterCapability('src/Security/UserVoter.php', 'UserVoter', ['EDIT'], ['User']);
+
+        $symfonyMapping = SymfonyMapping::create(voterCapabilities: [$voterCapability]);
+
+        self::assertSame([], $symfonyMapping->votersFor('EDIT', 'Comment'));
+    }
+
+    public function test_voters_for_excludes_voter_matching_subject_but_not_attribute(): void
+    {
+        $voterCapability = new VoterCapability('src/Security/UserVoter.php', 'UserVoter', ['EDIT'], ['User']);
+
+        $symfonyMapping = SymfonyMapping::create(voterCapabilities: [$voterCapability]);
+
+        self::assertSame([], $symfonyMapping->votersFor('PUBLISH', 'User'));
+    }
+
     public function test_it_exposes_form_bindings_and_can_filter_by_controller(): void
     {
         $userEdit = new FormBinding('src/Controller/UserController.php', 'edit', 'App\\Form\\UserType');

--- a/tests/Phpunit/Unit/Domain/Model/SymfonyMappingTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/SymfonyMappingTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 
 final class SymfonyMappingTest extends TestCase
@@ -32,7 +33,38 @@ final class SymfonyMappingTest extends TestCase
         self::assertEmpty($symfonyMapping->templates());
         self::assertEmpty($symfonyMapping->routeAccessMap());
         self::assertEmpty($symfonyMapping->firewallRules());
+        self::assertEmpty($symfonyMapping->routeAccessControls());
+        self::assertEmpty($symfonyMapping->controllersWithoutAccessCheck());
         self::assertSame(0, $symfonyMapping->totalFiles());
+    }
+
+    public function test_it_exposes_route_access_controls(): void
+    {
+        $protected = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'list',
+            routePath: '/admin',
+            routeMethods: ['GET'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: ['ROLE_ADMIN'],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+        $unprotected = new RouteAccessControl(
+            filePath: 'src/Controller/PublicController.php',
+            methodName: 'leak',
+            routePath: '/leak',
+            routeMethods: [],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        $symfonyMapping = SymfonyMapping::create(routeAccessControls: [$protected, $unprotected]);
+
+        self::assertSame([$protected, $unprotected], $symfonyMapping->routeAccessControls());
+        self::assertSame([$unprotected], $symfonyMapping->controllersWithoutAccessCheck());
     }
 
     public function test_it_counts_total_files_correctly(): void

--- a/tests/Phpunit/Unit/Domain/Model/SymfonyMappingTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/SymfonyMappingTest.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
 
 final class SymfonyMappingTest extends TestCase
 {
@@ -35,7 +37,45 @@ final class SymfonyMappingTest extends TestCase
         self::assertEmpty($symfonyMapping->firewallRules());
         self::assertEmpty($symfonyMapping->routeAccessControls());
         self::assertEmpty($symfonyMapping->controllersWithoutAccessCheck());
+        self::assertEmpty($symfonyMapping->voterCapabilities());
+        self::assertEmpty($symfonyMapping->formBindings());
         self::assertSame(0, $symfonyMapping->totalFiles());
+    }
+
+    public function test_it_exposes_voter_capabilities_and_can_find_voters_for_attribute_and_subject(): void
+    {
+        $userVoter = new VoterCapability(
+            filePath: 'src/Security/UserVoter.php',
+            className: 'App\\Security\\UserVoter',
+            supportedAttributes: ['EDIT', 'DELETE'],
+            supportedSubjects: ['App\\Entity\\User'],
+        );
+        $commentVoter = new VoterCapability(
+            filePath: 'src/Security/CommentVoter.php',
+            className: 'App\\Security\\CommentVoter',
+            supportedAttributes: ['VIEW'],
+            supportedSubjects: ['App\\Entity\\Comment'],
+        );
+
+        $symfonyMapping = SymfonyMapping::create(voterCapabilities: [$userVoter, $commentVoter]);
+
+        self::assertSame([$userVoter, $commentVoter], $symfonyMapping->voterCapabilities());
+        self::assertSame([$userVoter], $symfonyMapping->votersFor('EDIT', 'User'));
+        self::assertSame([$commentVoter], $symfonyMapping->votersFor('VIEW', 'App\\Entity\\Comment'));
+        self::assertSame([], $symfonyMapping->votersFor('PUBLISH', 'Post'));
+    }
+
+    public function test_it_exposes_form_bindings_and_can_filter_by_controller(): void
+    {
+        $userEdit = new FormBinding('src/Controller/UserController.php', 'edit', 'App\\Form\\UserType');
+        $userPassword = new FormBinding('src/Controller/UserController.php', 'changePassword', 'App\\Form\\PasswordType');
+        $admin = new FormBinding('src/Controller/AdminController.php', 'create', 'App\\Form\\AdminType');
+
+        $symfonyMapping = SymfonyMapping::create(formBindings: [$userEdit, $userPassword, $admin]);
+
+        self::assertSame([$userEdit, $userPassword, $admin], $symfonyMapping->formBindings());
+        self::assertSame([$userEdit, $userPassword], $symfonyMapping->formBindingsForController('src/Controller/UserController.php'));
+        self::assertSame([], $symfonyMapping->formBindingsForController('src/Controller/Other.php'));
     }
 
     public function test_it_exposes_route_access_controls(): void

--- a/tests/Phpunit/Unit/Domain/Model/VoterCapabilityTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VoterCapabilityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
+
+final class VoterCapabilityTest extends TestCase
+{
+    public function test_it_exposes_file_path_class_name_attributes_and_subjects(): void
+    {
+        $voterCapability = new VoterCapability(
+            filePath: 'src/Security/UserVoter.php',
+            className: 'App\\Security\\UserVoter',
+            supportedAttributes: ['EDIT', 'DELETE'],
+            supportedSubjects: ['App\\Entity\\User'],
+        );
+
+        self::assertSame('src/Security/UserVoter.php', $voterCapability->filePath());
+        self::assertSame('App\\Security\\UserVoter', $voterCapability->className());
+        self::assertSame(['EDIT', 'DELETE'], $voterCapability->supportedAttributes());
+        self::assertSame(['App\\Entity\\User'], $voterCapability->supportedSubjects());
+    }
+
+    public function test_covers_attribute_returns_true_for_supported_attribute(): void
+    {
+        $voterCapability = new VoterCapability('src/Security/V.php', 'V', ['EDIT'], []);
+
+        self::assertTrue($voterCapability->coversAttribute('EDIT'));
+        self::assertFalse($voterCapability->coversAttribute('DELETE'));
+    }
+
+    public function test_covers_subject_matches_by_short_name_or_full_class_name(): void
+    {
+        $voterCapability = new VoterCapability('src/Security/V.php', 'V', [], ['App\\Entity\\User']);
+
+        self::assertTrue($voterCapability->coversSubject('App\\Entity\\User'));
+        self::assertTrue($voterCapability->coversSubject('User'));
+        self::assertFalse($voterCapability->coversSubject('Comment'));
+    }
+}

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityHydrationResultTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityHydrationResultTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityDropReason;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityHydrationResult;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
+
+final class VulnerabilityHydrationResultTest extends TestCase
+{
+    public function test_empty_result_has_no_vulnerabilities_and_no_drops(): void
+    {
+        $vulnerabilityHydrationResult = VulnerabilityHydrationResult::empty();
+
+        self::assertSame([], $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertSame(0, $vulnerabilityHydrationResult->totalDropped());
+        self::assertFalse($vulnerabilityHydrationResult->hasDrops());
+    }
+
+    public function test_total_dropped_sums_drops_across_reasons(): void
+    {
+        $vulnerabilityHydrationResult = new VulnerabilityHydrationResult([], [
+            VulnerabilityDropReason::NON_ARRAY_ENTRY->value => 2,
+            VulnerabilityDropReason::HYDRATION_FAILED->value => 3,
+        ]);
+
+        self::assertSame(5, $vulnerabilityHydrationResult->totalDropped());
+        self::assertTrue($vulnerabilityHydrationResult->hasDrops());
+    }
+
+    public function test_dropped_by_reports_count_for_each_reason(): void
+    {
+        $vulnerabilityHydrationResult = new VulnerabilityHydrationResult([], [
+            VulnerabilityDropReason::NON_ARRAY_ENTRY->value => 4,
+        ]);
+
+        self::assertSame(4, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::NON_ARRAY_ENTRY));
+        self::assertSame(0, $vulnerabilityHydrationResult->droppedBy(VulnerabilityDropReason::HYDRATION_FAILED));
+    }
+
+    public function test_drops_by_reason_returns_full_map(): void
+    {
+        $vulnerabilityHydrationResult = new VulnerabilityHydrationResult([], [
+            VulnerabilityDropReason::NON_ARRAY_ENTRY->value => 1,
+            VulnerabilityDropReason::HYDRATION_FAILED->value => 2,
+        ]);
+
+        self::assertSame(
+            [
+                VulnerabilityDropReason::NON_ARRAY_ENTRY->value => 1,
+                VulnerabilityDropReason::HYDRATION_FAILED->value => 2,
+            ],
+            $vulnerabilityHydrationResult->dropsByReason(),
+        );
+    }
+
+    public function test_result_holds_vulnerabilities(): void
+    {
+        $vulnerability = $this->makeVulnerability();
+
+        $vulnerabilityHydrationResult = new VulnerabilityHydrationResult([$vulnerability], []);
+
+        self::assertSame([$vulnerability], $vulnerabilityHydrationResult->vulnerabilities());
+        self::assertFalse($vulnerabilityHydrationResult->hasDrops());
+    }
+
+    private function makeVulnerability(): Vulnerability
+    {
+        return Vulnerability::create(
+            vulnerabilityType: VulnerabilityType::SQL_INJECTION,
+            vulnerabilitySeverity: VulnerabilitySeverity::HIGH,
+            title: 'Title',
+            description: 'Description',
+            filePath: 'src/X.php',
+            lineStart: 1,
+            lineEnd: 2,
+            vulnerableCode: 'code',
+            attackVector: 'vector',
+            proof: 'proof',
+            remediation: 'remediate',
+            confidence: 0.9,
+        );
+    }
+}

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
@@ -62,6 +62,7 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::CACHE_POISONING, 'Data Exposure'];
         yield [VulnerabilityType::WEBHOOK_REPLAY, 'Logic Flaw'];
         yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'Broken Access Control'];
+        yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'Symfony-Specific'];
     }
 
     public static function owaspProvider(): Iterator
@@ -92,6 +93,7 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::CACHE_POISONING, 'A05:2021'];
         yield [VulnerabilityType::WEBHOOK_REPLAY, 'A04:2021'];
         yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'A01:2021'];
+        yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'A05:2021'];
     }
 
     #[DataProvider('categoryProvider')]

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Prompt;
 
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\AttackerPromptBuilder;
 
@@ -40,6 +41,140 @@ final class AttackerPromptBuilderTest extends TestCase
         $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
 
         self::assertStringContainsString('  - src/Controller/PublicController.php', $message);
+    }
+
+    public function test_user_message_renders_route_access_control_map_with_lacks_check_marker(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/AdminController.php',
+            '/app/src/Controller/AdminController.php',
+            '<?php class AdminController {}',
+        );
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'deleteUser',
+            routePath: '/admin/users/{id}',
+            routeMethods: ['DELETE'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        $symfonyMapping = SymfonyMapping::create(
+            controllers: [$projectFile],
+            routeAccessControls: [$routeAccessControl],
+        );
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringContainsString('Route Access-Control Map', $message);
+        self::assertStringContainsString('/admin/users/{id}', $message);
+        self::assertStringContainsString('DELETE', $message);
+        self::assertStringContainsString('AdminController.php::deleteUser', $message);
+        self::assertStringContainsString('LACKS_ACCESS_CHECK', $message);
+    }
+
+    public function test_user_message_renders_access_check_labels_for_protected_action(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/UserController.php',
+            '/app/src/Controller/UserController.php',
+            '<?php class UserController {}',
+        );
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/UserController.php',
+            methodName: 'show',
+            routePath: '/users/{id}',
+            routeMethods: ['GET'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: ['ROLE_USER'],
+            methodHasDenyAccess: true,
+            classHasIsGranted: true,
+        );
+
+        $symfonyMapping = SymfonyMapping::create(
+            controllers: [$projectFile],
+            routeAccessControls: [$routeAccessControl],
+        );
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringContainsString('class:#[IsGranted]', $message);
+        self::assertStringContainsString('method:#[IsGranted(ROLE_USER)]', $message);
+        self::assertStringContainsString('body:denyAccessUnlessGranted()', $message);
+        self::assertStringNotContainsString('LACKS_ACCESS_CHECK', $message);
+    }
+
+    public function test_user_message_omits_access_control_section_when_no_routes_parsed(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/PlainController.php',
+            '/app/src/Controller/PlainController.php',
+            '<?php class PlainController {}',
+        );
+
+        $symfonyMapping = SymfonyMapping::create(controllers: [$projectFile]);
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringNotContainsString('Route Access-Control Map', $message);
+    }
+
+    public function test_user_message_renders_any_label_when_route_methods_are_unspecified(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/AnyController.php',
+            '/app/src/Controller/AnyController.php',
+            '<?php class AnyController {}',
+        );
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/AnyController.php',
+            methodName: 'index',
+            routePath: '/any',
+            routeMethods: [],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        $symfonyMapping = SymfonyMapping::create(
+            controllers: [$projectFile],
+            routeAccessControls: [$routeAccessControl],
+        );
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringContainsString('ANY /any', $message);
+    }
+
+    public function test_user_message_renders_unresolved_label_when_route_path_is_missing(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/UnresolvedController.php',
+            '/app/src/Controller/UnresolvedController.php',
+            '<?php class UnresolvedController {}',
+        );
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/UnresolvedController.php',
+            methodName: 'index',
+            routePath: null,
+            routeMethods: ['GET'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        $symfonyMapping = SymfonyMapping::create(
+            controllers: [$projectFile],
+            routeAccessControls: [$routeAccessControl],
+        );
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringContainsString('(unresolved)', $message);
     }
 
     public function test_it_excludes_secured_controllers_from_no_voter_list(): void
@@ -513,7 +648,7 @@ final class AttackerPromptBuilderTest extends TestCase
 
     public function test_prompt_version_is_bumped_when_modern_symfony_skill_blocks_are_added(): void
     {
-        self::assertSame(5, AttackerPromptBuilder::PROMPT_VERSION);
+        self::assertSame(6, AttackerPromptBuilder::PROMPT_VERSION);
     }
 
     public function test_entity_skill_block_mentions_over_permissive_serializer_groups(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -513,7 +513,21 @@ final class AttackerPromptBuilderTest extends TestCase
 
     public function test_prompt_version_is_bumped_when_modern_symfony_skill_blocks_are_added(): void
     {
-        self::assertSame(4, AttackerPromptBuilder::PROMPT_VERSION);
+        self::assertSame(5, AttackerPromptBuilder::PROMPT_VERSION);
+    }
+
+    public function test_entity_skill_block_mentions_over_permissive_serializer_groups(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Entity/User.php',
+            '/app/src/Entity/User.php',
+            '<?php namespace App\\Entity; class User {}',
+        );
+
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt([$projectFile]);
+
+        self::assertStringContainsString('#[Groups(', $prompt);
+        self::assertStringContainsString('over_permissive_serializer_group', $prompt);
     }
 
     public function test_it_injects_authenticator_skills_when_authenticator_in_chunk(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Prompt;
 
 use PHPUnit\Framework\TestCase;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -782,7 +782,7 @@ final class AttackerPromptBuilderTest extends TestCase
 
     public function test_prompt_version_is_bumped_when_modern_symfony_skill_blocks_are_added(): void
     {
-        self::assertSame(7, AttackerPromptBuilder::PROMPT_VERSION);
+        self::assertSame(5, AttackerPromptBuilder::PROMPT_VERSION);
     }
 
     public function test_entity_skill_block_mentions_over_permissive_serializer_groups(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -15,8 +15,10 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Prompt;
 
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\AttackerPromptBuilder;
 
 final class AttackerPromptBuilderTest extends TestCase
@@ -175,6 +177,88 @@ final class AttackerPromptBuilderTest extends TestCase
         $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
 
         self::assertStringContainsString('(unresolved)', $message);
+    }
+
+    public function test_user_message_renders_voter_coverage_when_capabilities_present(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Security/UserVoter.php',
+            '/app/src/Security/UserVoter.php',
+            '<?php class UserVoter {}',
+        );
+        $voterCapability = new VoterCapability(
+            filePath: 'src/Security/UserVoter.php',
+            className: 'App\\Security\\UserVoter',
+            supportedAttributes: ['EDIT', 'DELETE'],
+            supportedSubjects: ['App\\Entity\\User'],
+        );
+
+        $symfonyMapping = SymfonyMapping::create(
+            voters: [$projectFile],
+            voterCapabilities: [$voterCapability],
+        );
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringContainsString('Voter Coverage', $message);
+        self::assertStringContainsString('App\\Security\\UserVoter', $message);
+        self::assertStringContainsString('attributes: [EDIT,DELETE]', $message);
+        self::assertStringContainsString('subjects: [App\\Entity\\User]', $message);
+    }
+
+    public function test_user_message_omits_voter_coverage_section_when_no_capabilities(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/PlainController.php',
+            '/app/src/Controller/PlainController.php',
+            '<?php class PlainController {}',
+        );
+
+        $symfonyMapping = SymfonyMapping::create(controllers: [$projectFile]);
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringNotContainsString('Voter Coverage', $message);
+    }
+
+    public function test_user_message_renders_form_bindings_section(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/UserController.php',
+            '/app/src/Controller/UserController.php',
+            '<?php class UserController {}',
+        );
+        $formBinding = new FormBinding(
+            controllerFilePath: 'src/Controller/UserController.php',
+            controllerMethod: 'edit',
+            formTypeClass: 'App\\Form\\UserType',
+        );
+
+        $symfonyMapping = SymfonyMapping::create(
+            controllers: [$projectFile],
+            formBindings: [$formBinding],
+        );
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringContainsString('Form Bindings', $message);
+        self::assertStringContainsString('src/Controller/UserController.php::edit', $message);
+        self::assertStringContainsString('App\\Form\\UserType', $message);
+    }
+
+    public function test_user_message_omits_form_bindings_section_when_empty(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/PlainController.php',
+            '/app/src/Controller/PlainController.php',
+            '<?php class PlainController {}',
+        );
+
+        $symfonyMapping = SymfonyMapping::create(controllers: [$projectFile]);
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringNotContainsString('Form Bindings', $message);
     }
 
     public function test_it_excludes_secured_controllers_from_no_voter_list(): void
@@ -648,7 +732,7 @@ final class AttackerPromptBuilderTest extends TestCase
 
     public function test_prompt_version_is_bumped_when_modern_symfony_skill_blocks_are_added(): void
     {
-        self::assertSame(6, AttackerPromptBuilder::PROMPT_VERSION);
+        self::assertSame(7, AttackerPromptBuilder::PROMPT_VERSION);
     }
 
     public function test_entity_skill_block_mentions_over_permissive_serializer_groups(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -246,6 +246,56 @@ final class AttackerPromptBuilderTest extends TestCase
         self::assertStringContainsString('App\\Form\\UserType', $message);
     }
 
+    public function test_route_access_map_section_ends_with_blank_line_before_voter_coverage(): void
+    {
+        $projectFile = ProjectFile::create('src/Controller/X.php', '/app/x', '<?php class X {}');
+        $routeAccessControl = new RouteAccessControl('src/Controller/X.php', 'a', '/x', ['GET'], true, ['ROLE_X'], false, false);
+        $voterCapability = new VoterCapability('src/Security/V.php', 'V', ['EDIT'], ['User']);
+
+        $message = $this->attackerPromptBuilder->buildUserMessage(
+            [$projectFile],
+            SymfonyMapping::create(routeAccessControls: [$routeAccessControl], voterCapabilities: [$voterCapability]),
+        );
+
+        self::assertMatchesRegularExpression(
+            '/- GET \/x[^\n]+\n\n## Voter Coverage/',
+            $message,
+        );
+    }
+
+    public function test_voter_coverage_section_ends_with_blank_line_before_form_bindings(): void
+    {
+        $projectFile = ProjectFile::create('src/Controller/X.php', '/app/x', '<?php class X {}');
+        $voterCapability = new VoterCapability('src/Security/V.php', 'App\\Security\\V', ['EDIT'], ['User']);
+        $formBinding = new FormBinding('src/Controller/X.php', 'edit', 'App\\Form\\UserType');
+
+        $message = $this->attackerPromptBuilder->buildUserMessage(
+            [$projectFile],
+            SymfonyMapping::create(voterCapabilities: [$voterCapability], formBindings: [$formBinding]),
+        );
+
+        self::assertMatchesRegularExpression(
+            '/- App\\\\Security\\\\V[^\n]+\n\n## Form Bindings/',
+            $message,
+        );
+    }
+
+    public function test_form_bindings_section_ends_with_blank_line_before_source_code(): void
+    {
+        $projectFile = ProjectFile::create('src/Controller/X.php', '/app/x', '<?php class X {}');
+        $formBinding = new FormBinding('src/Controller/X.php', 'edit', 'App\\Form\\UserType');
+
+        $message = $this->attackerPromptBuilder->buildUserMessage(
+            [$projectFile],
+            SymfonyMapping::create(formBindings: [$formBinding]),
+        );
+
+        self::assertMatchesRegularExpression(
+            '/- src\/Controller\/X\.php::edit[^\n]+\n\n## Source Code/',
+            $message,
+        );
+    }
+
     public function test_user_message_omits_form_bindings_section_when_empty(): void
     {
         $projectFile = ProjectFile::create(

--- a/tests/Phpunit/Unit/Infrastructure/Scan/NullControllerAccessControlParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/NullControllerAccessControlParserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullControllerAccessControlParser;
+
+final class NullControllerAccessControlParserTest extends TestCase
+{
+    public function test_it_returns_empty_for_any_controller(): void
+    {
+        $nullControllerAccessControlParser = new NullControllerAccessControlParser();
+
+        $projectFile = ProjectFile::create('src/Controller/AdminController.php', '/app/x', '<?php class AdminController {}');
+
+        self::assertSame([], $nullControllerAccessControlParser->parse($projectFile));
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Scan/NullFormBindingParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/NullFormBindingParserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullFormBindingParser;
+
+final class NullFormBindingParserTest extends TestCase
+{
+    public function test_it_returns_empty_for_any_controller(): void
+    {
+        $nullFormBindingParser = new NullFormBindingParser();
+
+        $projectFile = ProjectFile::create('src/Controller/UserController.php', '/app/x', '<?php class UserController {}');
+
+        self::assertSame([], $nullFormBindingParser->parse($projectFile));
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Scan/NullVoterCapabilityParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/NullVoterCapabilityParserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullVoterCapabilityParser;
+
+final class NullVoterCapabilityParserTest extends TestCase
+{
+    public function test_it_returns_null_for_any_voter(): void
+    {
+        $nullVoterCapabilityParser = new NullVoterCapabilityParser();
+
+        $projectFile = ProjectFile::create('src/Security/UserVoter.php', '/app/x', '<?php class UserVoter {}');
+
+        self::assertNull($nullVoterCapabilityParser->parse($projectFile));
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserControllerAccessControlParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserControllerAccessControlParserTest.php
@@ -147,6 +147,47 @@ final class PhpParserControllerAccessControlParserTest extends TestCase
         self::assertSame('delete', $entries[1]->methodName());
     }
 
+    public function test_it_extracts_path_from_positional_route_argument(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            final class HomeController {
+                #[Route('/home', methods: ['GET'])]
+                public function index(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/HomeController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertCount(1, $entries);
+        self::assertSame('/home', $entries[0]->routePath());
+        self::assertSame(['GET'], $entries[0]->routeMethods());
+    }
+
+    public function test_it_continues_past_private_methods_to_reach_public_action_below(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            final class HelpController {
+                private function helperOne(): void {}
+                private function helperTwo(): void {}
+                #[Route(path: '/help', methods: ['GET'])]
+                public function show(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/HelpController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertCount(1, $entries);
+        self::assertSame('show', $entries[0]->methodName());
+    }
+
     public function test_it_returns_empty_for_unparseable_source(): void
     {
         $projectFile = $this->makeFile('src/Controller/Broken.php', '<?php class Broken { public function');

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserControllerAccessControlParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserControllerAccessControlParserTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserControllerAccessControlParser;
+
+final class PhpParserControllerAccessControlParserTest extends TestCase
+{
+    private PhpParserControllerAccessControlParser $phpParserControllerAccessControlParser;
+
+    protected function setUp(): void
+    {
+        $this->phpParserControllerAccessControlParser = new PhpParserControllerAccessControlParser();
+    }
+
+    public function test_it_returns_empty_for_non_controller_file(): void
+    {
+        $projectFile = $this->makeFile('src/Service/Mailer.php', '<?php class Mailer { public function send() {} }');
+
+        self::assertSame([], $this->phpParserControllerAccessControlParser->parse($projectFile));
+    }
+
+    public function test_it_extracts_action_with_route_and_no_access_check(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            final class AdminController {
+                #[Route(path: '/admin/users/{id}', methods: ['DELETE'])]
+                public function deleteUser(int $id): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/AdminController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertCount(1, $entries);
+        self::assertInstanceOf(RouteAccessControl::class, $entries[0]);
+        self::assertSame('deleteUser', $entries[0]->methodName());
+        self::assertSame('/admin/users/{id}', $entries[0]->routePath());
+        self::assertSame(['DELETE'], $entries[0]->routeMethods());
+        self::assertTrue($entries[0]->hasRouteAttribute());
+        self::assertTrue($entries[0]->lacksAccessCheck());
+    }
+
+    public function test_it_records_method_level_is_granted(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            use Symfony\Component\Security\Http\Attribute\IsGranted;
+            final class AdminController {
+                #[Route(path: '/admin/users/{id}', methods: ['DELETE'])]
+                #[IsGranted('ROLE_ADMIN')]
+                public function deleteUser(int $id): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/AdminController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertSame(['ROLE_ADMIN'], $entries[0]->methodLevelIsGranted());
+        self::assertTrue($entries[0]->hasAccessCheck());
+        self::assertFalse($entries[0]->lacksAccessCheck());
+    }
+
+    public function test_it_records_class_level_is_granted(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            use Symfony\Component\Security\Http\Attribute\IsGranted;
+            #[IsGranted('ROLE_USER')]
+            final class AdminController {
+                #[Route(path: '/admin/profile')]
+                public function profile(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/AdminController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertTrue($entries[0]->classHasIsGranted());
+        self::assertTrue($entries[0]->hasAccessCheck());
+    }
+
+    public function test_it_records_deny_access_unless_granted_call(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            final class AdminController {
+                #[Route(path: '/admin/users/{id}/edit')]
+                public function edit(int $id): void {
+                    $this->denyAccessUnlessGranted('EDIT', $id);
+                }
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/AdminController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertTrue($entries[0]->methodHasDenyAccess());
+        self::assertTrue($entries[0]->hasAccessCheck());
+    }
+
+    public function test_it_emits_one_entry_per_public_method(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            final class UserController {
+                #[Route(path: '/users', methods: ['GET'])]
+                public function list(): void {}
+
+                #[Route(path: '/users/{id}', methods: ['DELETE'])]
+                public function delete(int $id): void {}
+
+                private function helper(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/UserController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertCount(2, $entries);
+        self::assertSame('list', $entries[0]->methodName());
+        self::assertSame('delete', $entries[1]->methodName());
+    }
+
+    public function test_it_returns_empty_for_unparseable_source(): void
+    {
+        $projectFile = $this->makeFile('src/Controller/Broken.php', '<?php class Broken { public function');
+
+        self::assertSame([], $this->phpParserControllerAccessControlParser->parse($projectFile));
+    }
+
+    private function makeFile(string $relativePath, string $content): ProjectFile
+    {
+        return ProjectFile::create($relativePath, '/app/'.$relativePath, $content);
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserControllerAccessControlParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserControllerAccessControlParserTest.php
@@ -188,6 +188,104 @@ final class PhpParserControllerAccessControlParserTest extends TestCase
         self::assertSame('show', $entries[0]->methodName());
     }
 
+    public function test_it_extracts_methods_when_route_uses_methods_only(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            final class GetOnlyController {
+                #[Route(methods: ['GET'])]
+                public function index(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/GetOnlyController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertCount(1, $entries);
+        self::assertSame(['GET'], $entries[0]->routeMethods());
+        self::assertNull($entries[0]->routePath());
+    }
+
+    public function test_it_extracts_multiple_http_methods_from_route_attribute(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            final class MultiMethodController {
+                #[Route(path: '/multi', methods: ['GET', 'POST', 'PATCH'])]
+                public function multi(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/MultiMethodController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertSame(['GET', 'POST', 'PATCH'], $entries[0]->routeMethods());
+    }
+
+    public function test_it_records_multiple_is_granted_attributes_on_same_method(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            use Symfony\Component\Security\Http\Attribute\IsGranted;
+            final class MultiCheckController {
+                #[Route(path: '/double')]
+                #[IsGranted('ROLE_USER')]
+                #[IsGranted('ROLE_ADMIN')]
+                public function doubleCheck(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/MultiCheckController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertSame(['ROLE_USER', 'ROLE_ADMIN'], $entries[0]->methodLevelIsGranted());
+    }
+
+    public function test_it_keeps_only_first_string_argument_of_is_granted_attribute(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            use Symfony\Component\Security\Http\Attribute\IsGranted;
+            final class TwoArgController {
+                #[Route(path: '/two-args')]
+                #[IsGranted('PRIMARY_ROLE', 'SECONDARY_ROLE')]
+                public function twoArgs(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/TwoArgController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertSame(['PRIMARY_ROLE'], $entries[0]->methodLevelIsGranted());
+    }
+
+    public function test_it_finds_is_granted_in_attribute_group_after_a_non_is_granted_attribute(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use Symfony\Component\Routing\Attribute\Route;
+            use Symfony\Component\Security\Http\Attribute\IsGranted;
+            final class GroupedController {
+                #[Route(path: '/grouped'), IsGranted('ROLE_GROUPED')]
+                public function grouped(): void {}
+            }
+            PHP;
+        $projectFile = $this->makeFile('src/Controller/GroupedController.php', $source);
+
+        $entries = $this->phpParserControllerAccessControlParser->parse($projectFile);
+
+        self::assertSame(['ROLE_GROUPED'], $entries[0]->methodLevelIsGranted());
+    }
+
     public function test_it_returns_empty_for_unparseable_source(): void
     {
         $projectFile = $this->makeFile('src/Controller/Broken.php', '<?php class Broken { public function');

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserFormBindingParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserFormBindingParserTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserFormBindingParser;
+
+final class PhpParserFormBindingParserTest extends TestCase
+{
+    private PhpParserFormBindingParser $phpParserFormBindingParser;
+
+    protected function setUp(): void
+    {
+        $this->phpParserFormBindingParser = new PhpParserFormBindingParser();
+    }
+
+    public function test_it_returns_empty_for_non_controller_file(): void
+    {
+        $projectFile = ProjectFile::create('src/Service/Mailer.php', '/app/x', '<?php class Mailer {}');
+
+        self::assertSame([], $this->phpParserFormBindingParser->parse($projectFile));
+    }
+
+    public function test_it_returns_empty_for_unparseable_controller(): void
+    {
+        $projectFile = ProjectFile::create('src/Controller/Broken.php', '/app/x', '<?php class Broken { public function');
+
+        self::assertSame([], $this->phpParserFormBindingParser->parse($projectFile));
+    }
+
+    public function test_it_extracts_form_type_from_create_form_call(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use App\Form\UserType;
+            final class UserController {
+                public function edit(): void {
+                    $form = $this->createForm(UserType::class);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Controller/UserController.php', '/app/x', $source);
+
+        $bindings = $this->phpParserFormBindingParser->parse($projectFile);
+
+        self::assertCount(1, $bindings);
+        self::assertSame('edit', $bindings[0]->controllerMethod());
+        self::assertSame('App\\Form\\UserType', $bindings[0]->formTypeClass());
+        self::assertSame('src/Controller/UserController.php', $bindings[0]->controllerFilePath());
+    }
+
+    public function test_it_extracts_multiple_bindings_from_same_method(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use App\Form\UserType;
+            use App\Form\ProfileType;
+            final class UserController {
+                public function edit(): void {
+                    $userForm = $this->createForm(UserType::class);
+                    $profileForm = $this->createForm(ProfileType::class);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Controller/UserController.php', '/app/x', $source);
+
+        $bindings = $this->phpParserFormBindingParser->parse($projectFile);
+
+        self::assertCount(2, $bindings);
+        self::assertSame('App\\Form\\UserType', $bindings[0]->formTypeClass());
+        self::assertSame('App\\Form\\ProfileType', $bindings[1]->formTypeClass());
+    }
+
+    public function test_it_ignores_create_form_calls_with_non_class_argument(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            final class UserController {
+                public function edit(string $formClass): void {
+                    $form = $this->createForm($formClass);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Controller/UserController.php', '/app/x', $source);
+
+        $bindings = $this->phpParserFormBindingParser->parse($projectFile);
+
+        self::assertSame([], $bindings);
+    }
+
+    public function test_it_emits_no_bindings_when_controller_has_no_create_form_calls(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            final class UserController {
+                public function list(): void {}
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Controller/UserController.php', '/app/x', $source);
+
+        self::assertSame([], $this->phpParserFormBindingParser->parse($projectFile));
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserFormBindingParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserFormBindingParserTest.php
@@ -78,6 +78,27 @@ final class PhpParserFormBindingParserTest extends TestCase
         self::assertSame('App\\Form\\ProfileType', $bindings[1]->formTypeClass());
     }
 
+    public function test_it_skips_unresolvable_create_form_call_but_keeps_subsequent_ones(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use App\Form\UserType;
+            final class MixedController {
+                public function edit(string $dynamicClass): void {
+                    $unresolvable = $this->createForm($dynamicClass);
+                    $resolvable = $this->createForm(UserType::class);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Controller/MixedController.php', '/app/x', $source);
+
+        $bindings = $this->phpParserFormBindingParser->parse($projectFile);
+
+        self::assertCount(1, $bindings);
+        self::assertSame('App\\Form\\UserType', $bindings[0]->formTypeClass());
+    }
+
     public function test_it_continues_past_private_helpers_to_reach_public_create_form(): void
     {
         $source = <<<'PHP'

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserFormBindingParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserFormBindingParserTest.php
@@ -33,6 +33,73 @@ final class PhpParserFormBindingParserTest extends TestCase
         self::assertSame([], $this->phpParserFormBindingParser->parse($projectFile));
     }
 
+    public function test_it_skips_non_controller_files_even_when_they_call_create_form(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Service;
+            use App\Form\UserType;
+            final class Helper {
+                public function build(): void {
+                    $form = $this->createForm(UserType::class);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Service/Helper.php', '/app/x', $source);
+
+        self::assertSame([], $this->phpParserFormBindingParser->parse($projectFile));
+    }
+
+    public function test_it_collects_bindings_from_multiple_methods_in_the_same_controller(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use App\Form\UserType;
+            use App\Form\ProfileType;
+            final class UserController {
+                public function edit(): void {
+                    $form = $this->createForm(UserType::class);
+                }
+
+                public function profile(): void {
+                    $form = $this->createForm(ProfileType::class);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Controller/UserController.php', '/app/x', $source);
+
+        $bindings = $this->phpParserFormBindingParser->parse($projectFile);
+
+        self::assertCount(2, $bindings);
+        self::assertSame('edit', $bindings[0]->controllerMethod());
+        self::assertSame('App\\Form\\UserType', $bindings[0]->formTypeClass());
+        self::assertSame('profile', $bindings[1]->controllerMethod());
+        self::assertSame('App\\Form\\ProfileType', $bindings[1]->formTypeClass());
+    }
+
+    public function test_it_continues_past_private_helpers_to_reach_public_create_form(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Controller;
+            use App\Form\UserType;
+            final class HelpController {
+                private function helperOne(): void {}
+                private function helperTwo(): void {}
+                public function edit(): void {
+                    $form = $this->createForm(UserType::class);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Controller/HelpController.php', '/app/x', $source);
+
+        $bindings = $this->phpParserFormBindingParser->parse($projectFile);
+
+        self::assertCount(1, $bindings);
+        self::assertSame('edit', $bindings[0]->controllerMethod());
+    }
+
     public function test_it_returns_empty_for_unparseable_controller(): void
     {
         $projectFile = ProjectFile::create('src/Controller/Broken.php', '/app/x', '<?php class Broken { public function');

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
@@ -108,6 +108,47 @@ final class PhpParserVoterCapabilityParserTest extends TestCase
         self::assertSame(['App\\Entity\\Comment'], $voterCapability->supportedSubjects());
     }
 
+    public function test_it_collects_multiple_subject_types_from_supports_body(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Security;
+            use App\Entity\User;
+            use App\Entity\Comment;
+            final class CrossVoter {
+                public function supports(string $attribute, mixed $subject): bool {
+                    return $subject instanceof User || $subject instanceof Comment;
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Security/CrossVoter.php', '/app/x', $source);
+
+        $voterCapability = $this->phpParserVoterCapabilityParser->parse($projectFile);
+
+        self::assertNotNull($voterCapability);
+        self::assertSame(['App\\Entity\\User', 'App\\Entity\\Comment'], $voterCapability->supportedSubjects());
+    }
+
+    public function test_it_deduplicates_repeated_subject_type_in_supports_body(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Security;
+            use App\Entity\User;
+            final class RepeatVoter {
+                public function supports(string $attribute, mixed $subject): bool {
+                    return $subject instanceof User || ($subject instanceof User && $attribute === 'EDIT');
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Security/RepeatVoter.php', '/app/x', $source);
+
+        $voterCapability = $this->phpParserVoterCapabilityParser->parse($projectFile);
+
+        self::assertNotNull($voterCapability);
+        self::assertSame(['App\\Entity\\User'], $voterCapability->supportedSubjects());
+    }
+
     public function test_it_extracts_class_name_with_namespace(): void
     {
         $source = <<<'PHP'

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserVoterCapabilityParser;
+
+final class PhpParserVoterCapabilityParserTest extends TestCase
+{
+    private PhpParserVoterCapabilityParser $phpParserVoterCapabilityParser;
+
+    protected function setUp(): void
+    {
+        $this->phpParserVoterCapabilityParser = new PhpParserVoterCapabilityParser();
+    }
+
+    public function test_it_returns_null_for_non_voter_file(): void
+    {
+        $projectFile = ProjectFile::create('src/Service/Mailer.php', '/app/x', '<?php class Mailer {}');
+
+        self::assertNull($this->phpParserVoterCapabilityParser->parse($projectFile));
+    }
+
+    public function test_it_returns_null_for_unparseable_voter(): void
+    {
+        $projectFile = ProjectFile::create('src/Security/Broken.php', '/app/x', '<?php class Broken { public function');
+
+        self::assertNull($this->phpParserVoterCapabilityParser->parse($projectFile));
+    }
+
+    public function test_it_returns_null_when_voter_has_no_supports_method(): void
+    {
+        $projectFile = ProjectFile::create('src/Security/Bare.php', '/app/x', '<?php class Bare { public function hello(): void {} }');
+
+        self::assertNull($this->phpParserVoterCapabilityParser->parse($projectFile));
+    }
+
+    public function test_it_extracts_attributes_from_in_array_call(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Security;
+            use App\Entity\User;
+            final class UserVoter {
+                public function supports(string $attribute, mixed $subject): bool {
+                    return in_array($attribute, ['EDIT', 'DELETE'], true) && $subject instanceof User;
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Security/UserVoter.php', '/app/x', $source);
+
+        $voterCapability = $this->phpParserVoterCapabilityParser->parse($projectFile);
+
+        self::assertNotNull($voterCapability);
+        self::assertSame(['EDIT', 'DELETE'], $voterCapability->supportedAttributes());
+        self::assertSame(['App\\Entity\\User'], $voterCapability->supportedSubjects());
+    }
+
+    public function test_it_extracts_attributes_from_match_arms(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Security;
+            use App\Entity\Comment;
+            final class CommentVoter {
+                public function supports(string $attribute, mixed $subject): bool {
+                    return match ($attribute) {
+                        'VIEW', 'EDIT' => $subject instanceof Comment,
+                        default => false,
+                    };
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Security/CommentVoter.php', '/app/x', $source);
+
+        $voterCapability = $this->phpParserVoterCapabilityParser->parse($projectFile);
+
+        self::assertNotNull($voterCapability);
+        self::assertSame(['VIEW', 'EDIT'], $voterCapability->supportedAttributes());
+        self::assertSame(['App\\Entity\\Comment'], $voterCapability->supportedSubjects());
+    }
+
+    public function test_it_extracts_class_name_with_namespace(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Security;
+            final class PostVoter {
+                public function supports(string $attribute, mixed $subject): bool {
+                    return $attribute === 'EDIT';
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Security/PostVoter.php', '/app/x', $source);
+
+        $voterCapability = $this->phpParserVoterCapabilityParser->parse($projectFile);
+
+        self::assertNotNull($voterCapability);
+        self::assertSame('App\\Security\\PostVoter', $voterCapability->className());
+        self::assertSame(['EDIT'], $voterCapability->supportedAttributes());
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
@@ -33,6 +33,22 @@ final class PhpParserVoterCapabilityParserTest extends TestCase
         self::assertNull($this->phpParserVoterCapabilityParser->parse($projectFile));
     }
 
+    public function test_it_returns_null_for_non_voter_file_even_when_it_defines_a_supports_method(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Service;
+            final class Helper {
+                public function supports(string $attribute, mixed $subject): bool {
+                    return in_array($attribute, ['CAN_HELP'], true);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Service/Helper.php', '/app/x', $source);
+
+        self::assertNull($this->phpParserVoterCapabilityParser->parse($projectFile));
+    }
+
     public function test_it_returns_null_for_unparseable_voter(): void
     {
         $projectFile = ProjectFile::create('src/Security/Broken.php', '/app/x', '<?php class Broken { public function');

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
@@ -129,24 +129,46 @@ final class PhpParserVoterCapabilityParserTest extends TestCase
         self::assertSame(['App\\Entity\\User', 'App\\Entity\\Comment'], $voterCapability->supportedSubjects());
     }
 
-    public function test_it_deduplicates_repeated_subject_type_in_supports_body(): void
+    public function test_it_deduplicates_repeated_subject_type_in_supports_body_and_continues_to_collect_later_unique_types(): void
     {
         $source = <<<'PHP'
             <?php
             namespace App\Security;
             use App\Entity\User;
-            final class RepeatVoter {
+            use App\Entity\Comment;
+            final class MixedVoter {
                 public function supports(string $attribute, mixed $subject): bool {
-                    return $subject instanceof User || ($subject instanceof User && $attribute === 'EDIT');
+                    return $subject instanceof User
+                        || $subject instanceof User
+                        || $subject instanceof Comment;
                 }
             }
             PHP;
-        $projectFile = ProjectFile::create('src/Security/RepeatVoter.php', '/app/x', $source);
+        $projectFile = ProjectFile::create('src/Security/MixedVoter.php', '/app/x', $source);
 
         $voterCapability = $this->phpParserVoterCapabilityParser->parse($projectFile);
 
         self::assertNotNull($voterCapability);
-        self::assertSame(['App\\Entity\\User'], $voterCapability->supportedSubjects());
+        self::assertSame(['App\\Entity\\User', 'App\\Entity\\Comment'], $voterCapability->supportedSubjects());
+    }
+
+    public function test_it_deduplicates_repeated_string_literal_in_supports_body_and_continues_to_collect_later_unique_attributes(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            namespace App\Security;
+            final class RepeatAttrVoter {
+                public function supports(string $attribute, mixed $subject): bool {
+                    return in_array($attribute, ['EDIT', 'EDIT', 'DELETE'], true);
+                }
+            }
+            PHP;
+        $projectFile = ProjectFile::create('src/Security/RepeatAttrVoter.php', '/app/x', $source);
+
+        $voterCapability = $this->phpParserVoterCapabilityParser->parse($projectFile);
+
+        self::assertNotNull($voterCapability);
+        self::assertSame(['EDIT', 'DELETE'], $voterCapability->supportedAttributes());
     }
 
     public function test_it_extracts_class_name_with_namespace(): void

--- a/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
@@ -74,6 +74,20 @@ final class RegexStaticPreScannerTest extends TestCase
         self::assertSame(2, $markers[0]->line());
     }
 
+    public function test_it_flags_groups_attribute_on_entity(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Entity/User.php',
+            '/app/src/Entity/User.php',
+            "<?php\nclass User {\n    #[Groups(['user:write', 'admin:write'])]\n    private string \$role;\n}",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('serializer_groups_attribute', $patterns);
+    }
+
     public function test_it_flags_csrf_disabled_in_form(): void
     {
         $projectFile = ProjectFile::create(


### PR DESCRIPTION
## Summary

Adds AST-based parsing of Symfony controller routes, access-control attributes (`#[IsGranted]`, `denyAccessUnlessGranted()`), voter capabilities, and form type bindings. These are collected into domain value objects (`RouteAccessControl`, `VoterCapability`, `FormBinding`) and exposed via `SymfonyMapping`, enabling the attacker prompt to reason about the full route→controller→access-check graph and form binding surface. Also hardens `VulnerabilityFactory` with validation constraints and visible hydration drop tracking.

Closes #xxx

## Type of change

- [x] New feature
- [x] Refactor / internal improvement

## Details

### New Domain Models & Ports

- **`RouteAccessControl`** — one per public controller action; captures `#[Route]` path/methods, class- and method-level `#[IsGranted]` attributes, `denyAccessUnlessGranted()` call sites, and a `lacksAccessCheck()` predicate
- **`VoterCapability`** — one per voter file; approximates `supports()` vocabulary by collecting string literals (attribute names) and `instanceof` checks (subject types)
- **`FormBinding`** — one per `$this->createForm(FooType::class)` call site in a controller method
- **`VulnerabilityHydrationResult`** — wraps vulnerabilities + drop counts bucketed by `VulnerabilityDropReason` (non_array_entry, validation_failed, hydration_failed)
- **`VulnerabilityDropReason`** enum — tracks why entries were dropped during hydration

### New Parsers (Infrastructure)

- **`PhpParserControllerAccessControlParser`** — walks controller AST to extract one `RouteAccessControl` per public action; recognizes `#[Route]`, `#[IsGranted]` (by short name to survive aliased imports), and `denyAccessUnlessGranted()` calls
- **`PhpParserVoterCapabilityParser`** — walks voter AST to collect string literals and `instanceof` class names from `supports()` method body
- **`PhpParserFormBindingParser`** — walks controller AST to find `$this->createForm(SomeFormType::class)` call sites; only literal `FooType::class` arguments are recorded
- Null implementations for graceful degradation when parsing is unavailable

### Validation & Hydration Hardening

- `VulnerabilityFactory` now validates raw LLM data against `symfony/validator` constraints (title/file_path max length, long text fields)
- `fromList()` returns `VulnerabilityHydrationResult` instead of bare array; each drop is logged with structured `reason` code
- Per-audit totals appear on the `Attacker agent complete` info log line under `total_dropped_entries` / `dropped_by_reason`

### SymfonyMapping Enhancements

- New accessors: `routeAccessControls()`, `controllersWithoutAccessCheck()`, `voterCapabilities()`, `formBindings()`
- `MappingStage` now instantiates and wires the three parsers; collects results into the mapping

### Attacker Prompt Updates

- Route Access-Control Map block now renders the parsed graph (route path, HTTP methods, controller::method, access-check labels)
- Voter Coverage block now includes parsed `supports()` vocabulary (attributes + subject types)
- Form Binding block now lists parsed form type bindings
- Prompt version bumped to 7 (cache invalidation)
- New vulnerability type: `over_permissive_serializer_group` (detects privileged fields in write-side serializer groups)

### Testing

- Added unit tests for all three parsers (happy path, error handling, edge cases)
- Added domain model tests for `RouteAccessControl`, `VoterCapability`, `FormBinding`, `VulnerabilityHydrationResult`
- Updated existing tests to work with new `VulnerabilityHydrationResult` return type
- All tests pass; 100% MSI maintained
