### PR TITLE
fix(llm): empty responses as dropped instead of fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,44 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.6.1] — 2026-05-28 — Soft Landing
+
+A resilience release. The LLM client now treats truly empty model responses as a
+graceful drop instead of a fatal abort, and the mutation gate becomes
+deterministic on `AuditContext::auditId` so the test matrix stops flapping on
+randomness.
+
+### Fixed
+
+- **Empty-content LLM responses no longer abort the audit.** Anthropic (and
+  other providers) occasionally return a successful response with zero content
+  blocks — refusal-style stops, content-filter hits, or quirks under heavy
+  prompt-cache pressure. `symfony/ai`'s converter then throws "Response does not
+  contain any content." from `DeferredResult::getResult()`. Previously that
+  bubbled through `SymfonyAiLLMClient::invokeWithRetry()` →
+  `TransientFailureClassifier` (no transient match) →
+  `NonTransientLLMFailureException`, aborting the entire audit mid-run — most
+  visibly at ~50% on a long `audit.structured_collection: true` run where the
+  attacker had already recorded findings via `record_vulnerability` tool calls.
+  `TransientFailureClassifier` now exposes `isEmptyContent()`; the client
+  rethrows those as the new internal `EmptyLLMResponseException`, and
+  `complete()` / `completeWithTools()` catch and translate into an empty
+  `LLMResponse` with `stopReason: 'empty_content'`. The attacker chunk records
+  as `analyzed`, the `VulnerabilityCollector` still drains any
+  `record_vulnerability` calls that preceded the empty turn, and the pipeline
+  continues. The retry classifier is unchanged for transport / auth / rate-limit
+  failures — only the framework-level "no content blocks" signature is reclassed
+  out of the non-transient path.
+
+### Tooling
+
+- Mutation gate now deterministically kills the `UnwrapStrToUpper` mutant on
+  `AuditContext::forProject()`'s `auditId` formatting. The single-draw assertion
+  let the mutant escape whenever `bin2hex(random_bytes(4))` rolled all digits
+  (~2.33% per Infection run, ~19% across the 9-cell PHP × Symfony matrix) — the
+  source of the matrix-cell-specific escapes recently observed on `main`. The
+  test now loops 64 draws, dropping the escape probability to ~10⁻¹⁰⁴.
+
 ## [1.6.0] — 2026-05-28 — Sentinel
 
 A correctness release. The attacker now records findings through a strict

--- a/src/Audit/Infrastructure/LLM/Exception/EmptyLLMResponseException.php
+++ b/src/Audit/Infrastructure/LLM/Exception/EmptyLLMResponseException.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception;
+
+use RuntimeException;
+use Throwable;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final class EmptyLLMResponseException extends RuntimeException
+{
+    public static function from(Throwable $throwable): self
+    {
+        return new self(
+            \sprintf('LLM returned a response with no content: %s', $throwable->getMessage()),
+            previous: $throwable,
+        );
+    }
+}

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -41,6 +41,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolDefinition;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay\SleeperInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay\UsleepSleeper;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\EmptyLLMResponseException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\NonTransientLLMFailureException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\TransientLLMFailureException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RateLimit\NullRateLimiter;
@@ -89,7 +90,12 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
         \assert('' !== $this->model, 'Model must be a non-empty string');
 
         $estimatedInputTokens = $this->estimateInputTokens($systemPrompt, $userMessage);
-        $deferredResult = $this->invokeWithRetry($messageBag, $this->baseOptions(), $estimatedInputTokens);
+        try {
+            $deferredResult = $this->invokeWithRetry($messageBag, $this->baseOptions(), $estimatedInputTokens);
+        } catch (EmptyLLMResponseException $emptyllmResponseException) {
+            return $this->emptyResponseAndLog($emptyllmResponseException);
+        }
+
         $content = $deferredResult->asText();
         [$inputTokens, $outputTokens] = $this->extractTokens($deferredResult);
 
@@ -224,7 +230,12 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
         $totalInputTokens = 0;
         $totalOutputTokens = 0;
         while ($iteration < $maxToolIterations) {
-            $deferredResult = $this->invokeWithRetry($messageBag, $options, $estimatedInputTokens);
+            try {
+                $deferredResult = $this->invokeWithRetry($messageBag, $options, $estimatedInputTokens);
+            } catch (EmptyLLMResponseException $emptyllmResponseException) {
+                return $this->emptyToolLoopResponseAndLog($emptyllmResponseException, $iteration, $totalInputTokens, $totalOutputTokens);
+            }
+
             $platformResult = $deferredResult->getResult();
             [$callInput, $callOutput] = $this->extractTokens($deferredResult);
             $totalInputTokens += $callInput;
@@ -295,6 +306,47 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
         return $this->model;
     }
 
+    private function emptyResponseAndLog(EmptyLLMResponseException $emptyllmResponseException): LLMResponse
+    {
+        $this->logger->warning('LLM returned a response with no content blocks', [
+            'error' => $emptyllmResponseException->getMessage(),
+        ]);
+
+        $llmResponse = LLMResponse::create(
+            content: '',
+            inputTokens: 0,
+            outputTokens: 0,
+            model: $this->model,
+            stopReason: 'empty_content',
+        );
+        $this->budgetTracker?->recordCall($llmResponse);
+        $this->budgetTracker?->assertWithinBudget();
+
+        return $llmResponse;
+    }
+
+    private function emptyToolLoopResponseAndLog(
+        EmptyLLMResponseException $emptyllmResponseException,
+        int $iteration,
+        int $totalInputTokens,
+        int $totalOutputTokens,
+    ): LLMResponse {
+        $this->logger->warning('Tool-using loop ended with empty content response', [
+            'iterations' => $iteration,
+            'input_tokens' => $totalInputTokens,
+            'output_tokens' => $totalOutputTokens,
+            'error' => $emptyllmResponseException->getMessage(),
+        ]);
+
+        return LLMResponse::create(
+            content: '',
+            inputTokens: $totalInputTokens,
+            outputTokens: $totalOutputTokens,
+            model: $this->model,
+            stopReason: 'empty_content',
+        );
+    }
+
     /**
      * @return list<ToolCall>
      */
@@ -350,6 +402,10 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
 
                 return $deferredResult;
             } catch (Throwable $throwable) {
+                if ($classifier->isEmptyContent($throwable)) {
+                    throw EmptyLLMResponseException::from($throwable);
+                }
+
                 if (!$classifier->isTransient($throwable)) {
                     throw NonTransientLLMFailureException::from($throwable);
                 }

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -312,17 +312,13 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
             'error' => $emptyllmResponseException->getMessage(),
         ]);
 
-        $llmResponse = LLMResponse::create(
+        return LLMResponse::create(
             content: '',
             inputTokens: 0,
             outputTokens: 0,
             model: $this->model,
             stopReason: 'empty_content',
         );
-        $this->budgetTracker?->recordCall($llmResponse);
-        $this->budgetTracker?->assertWithinBudget();
-
-        return $llmResponse;
     }
 
     private function emptyToolLoopResponseAndLog(

--- a/src/Audit/Infrastructure/LLM/TransientFailureClassifier.php
+++ b/src/Audit/Infrastructure/LLM/TransientFailureClassifier.php
@@ -66,6 +66,13 @@ final readonly class TransientFailureClassifier
         'rate_limit',
     ];
 
+    /** @var list<string> */
+    private const array EMPTY_CONTENT_HINTS = [
+        'does not contain any content',
+        'response does not contain',
+        'no content blocks',
+    ];
+
     public function isTransient(Throwable $throwable): bool
     {
         $joined = $this->joinMessages($throwable);
@@ -75,6 +82,19 @@ final readonly class TransientFailureClassifier
         }
 
         return u($joined)->containsAny(self::TRANSIENT_HINTS);
+    }
+
+    /**
+     * Recognises framework-level "the LLM returned no content blocks" errors
+     * raised by symfony/ai converters when the model responds with an empty
+     * content array. Such responses are not a transport or auth failure —
+     * the call succeeded, the model chose to say nothing — so they must not
+     * abort the audit. Callers translate this into an empty `LLMResponse`
+     * and continue.
+     */
+    public function isEmptyContent(Throwable $throwable): bool
+    {
+        return u($this->joinMessages($throwable))->containsAny(self::EMPTY_CONTENT_HINTS);
     }
 
     /**

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -1188,6 +1188,127 @@ final class SymfonyAiLLMClientTest extends TestCase
         }
     }
 
+    public function test_complete_returns_empty_response_when_platform_reports_empty_content(): void
+    {
+        $fakeSleeper = new FakeSleeper();
+        $platform = $this->emptyContentPlatform('Response does not contain any content.');
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(
+            $platform,
+            'm',
+            new NullLogger(),
+            retryPolicy: new RetryPolicy(maxAttempts: 5, jitterSource: static fn (): float => 0.5),
+            transientFailureClassifier: new TransientFailureClassifier(),
+            sleeper: $fakeSleeper,
+        );
+
+        $llmResponse = $symfonyAiLLMClient->complete('sys', 'usr');
+
+        self::assertSame('', $llmResponse->content());
+        self::assertSame('empty_content', $llmResponse->stopReason());
+        self::assertTrue($llmResponse->isEmpty());
+        self::assertSame([], $fakeSleeper->durations);
+    }
+
+    public function test_complete_logs_warning_when_platform_reports_empty_content(): void
+    {
+        /** @var list<array{string, array<string, mixed>}> $warnings */
+        $warnings = [];
+        $logger = self::createStub(LoggerInterface::class);
+        $logger->method('warning')->willReturnCallback(
+            static function (string $msg, array $ctx = []) use (&$warnings): void {
+                $warnings[] = [$msg, $ctx];
+            },
+        );
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(
+            $this->emptyContentPlatform('Response does not contain any content.'),
+            'm',
+            $logger,
+            transientFailureClassifier: new TransientFailureClassifier(),
+        );
+
+        $symfonyAiLLMClient->complete('sys', 'usr');
+
+        $emptyLogs = array_values(array_filter(
+            $warnings,
+            static fn (array $entry): bool => 'LLM returned a response with no content blocks' === $entry[0],
+        ));
+        self::assertCount(1, $emptyLogs);
+        self::assertSame(
+            'LLM returned a response with no content: Response does not contain any content.',
+            $emptyLogs[0][1]['error'],
+        );
+    }
+
+    public function test_complete_with_tools_returns_empty_response_when_platform_reports_empty_content_on_first_iteration(): void
+    {
+        $tool = $this->makeTool('lookup', 'lookup');
+        $toolRegistry = new ToolRegistry([$tool], new NullLogger());
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(
+            $this->emptyContentPlatform('Response does not contain any content.'),
+            'm',
+            new NullLogger(),
+            transientFailureClassifier: new TransientFailureClassifier(),
+        );
+
+        $llmResponse = $symfonyAiLLMClient->completeWithTools('sys', 'usr', $toolRegistry, 5);
+
+        self::assertSame('', $llmResponse->content());
+        self::assertSame('empty_content', $llmResponse->stopReason());
+    }
+
+    public function test_complete_with_tools_logs_warning_when_platform_reports_empty_content(): void
+    {
+        $tool = $this->makeTool('lookup', 'lookup');
+        $toolRegistry = new ToolRegistry([$tool], new NullLogger());
+
+        /** @var list<array{string, array<string, mixed>}> $warnings */
+        $warnings = [];
+        $logger = self::createStub(LoggerInterface::class);
+        $logger->method('warning')->willReturnCallback(
+            static function (string $msg, array $ctx = []) use (&$warnings): void {
+                $warnings[] = [$msg, $ctx];
+            },
+        );
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(
+            $this->emptyContentPlatform('Response does not contain any content.'),
+            'm',
+            $logger,
+            transientFailureClassifier: new TransientFailureClassifier(),
+        );
+
+        $symfonyAiLLMClient->completeWithTools('sys', 'usr', $toolRegistry, 5);
+
+        $emptyLogs = array_values(array_filter(
+            $warnings,
+            static fn (array $entry): bool => 'Tool-using loop ended with empty content response' === $entry[0],
+        ));
+        self::assertCount(1, $emptyLogs);
+        self::assertSame(0, $emptyLogs[0][1]['iterations']);
+    }
+
+    public function test_complete_does_not_retry_empty_content_failures(): void
+    {
+        $fakeSleeper = new FakeSleeper();
+        $platformInvocationLog = new PlatformInvocationLog();
+        $platform = $this->emptyContentPlatform('Response does not contain any content.', $platformInvocationLog);
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(
+            $platform,
+            'm',
+            new NullLogger(),
+            retryPolicy: new RetryPolicy(maxAttempts: 5, jitterSource: static fn (): float => 0.5),
+            transientFailureClassifier: new TransientFailureClassifier(),
+            sleeper: $fakeSleeper,
+        );
+
+        $symfonyAiLLMClient->complete('sys', 'usr');
+
+        self::assertSame(1, $platformInvocationLog->invocations);
+        self::assertSame([], $fakeSleeper->durations);
+    }
+
     public function test_complete_uses_rate_limit_delay_for_429_errors(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1419,6 +1540,34 @@ final class SymfonyAiLLMClientTest extends TestCase
 
                 return new DeferredResult(
                     $converter,
+                    new InMemoryRawResult(['text' => ''], [], (object) []),
+                    $options,
+                );
+            }
+
+            public function getModelCatalog(): ModelCatalogInterface
+            {
+                return new FallbackModelCatalog();
+            }
+        };
+    }
+
+    private function emptyContentPlatform(string $message, ?PlatformInvocationLog $platformInvocationLog = null): PlatformInterface
+    {
+        return new class($message, $platformInvocationLog) implements PlatformInterface {
+            public function __construct(
+                private readonly string $message,
+                private readonly ?PlatformInvocationLog $platformInvocationLog,
+            ) {}
+
+            public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+            {
+                if ($this->platformInvocationLog instanceof PlatformInvocationLog) {
+                    ++$this->platformInvocationLog->invocations;
+                }
+
+                return new DeferredResult(
+                    new ThrowingConverter(new RuntimeException($this->message)),
                     new InMemoryRawResult(['text' => ''], [], (object) []),
                     $options,
                 );

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -1206,6 +1206,8 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('', $llmResponse->content());
         self::assertSame('empty_content', $llmResponse->stopReason());
         self::assertTrue($llmResponse->isEmpty());
+        self::assertSame(0, $llmResponse->inputTokens());
+        self::assertSame(0, $llmResponse->outputTokens());
         self::assertSame([], $fakeSleeper->durations);
     }
 
@@ -1256,6 +1258,8 @@ final class SymfonyAiLLMClientTest extends TestCase
 
         self::assertSame('', $llmResponse->content());
         self::assertSame('empty_content', $llmResponse->stopReason());
+        self::assertSame(0, $llmResponse->inputTokens());
+        self::assertSame(0, $llmResponse->outputTokens());
     }
 
     public function test_complete_with_tools_logs_warning_when_platform_reports_empty_content(): void
@@ -1287,6 +1291,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         ));
         self::assertCount(1, $emptyLogs);
         self::assertSame(0, $emptyLogs[0][1]['iterations']);
+        self::assertSame(
+            'LLM returned a response with no content: Response does not contain any content.',
+            $emptyLogs[0][1]['error'],
+        );
     }
 
     public function test_complete_does_not_retry_empty_content_failures(): void

--- a/tests/Phpunit/Unit/Domain/Model/AuditContextTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditContextTest.php
@@ -39,9 +39,12 @@ final class AuditContextTest extends TestCase
 
     public function test_audit_id_matches_expected_format(): void
     {
-        $auditContext = AuditContext::forProject($this->tmpDir);
-
-        self::assertMatchesRegularExpression('/^AUDIT-[A-F0-9]{8}$/', $auditContext->auditId());
+        for ($i = 0; $i < 64; ++$i) {
+            self::assertMatchesRegularExpression(
+                '/^AUDIT-[A-F0-9]{8}$/',
+                AuditContext::forProject($this->tmpDir)->auditId(),
+            );
+        }
     }
 
     public function test_it_throws_on_invalid_project_path(): void

--- a/tests/Phpunit/Unit/Infrastructure/LLM/TransientFailureClassifierTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/TransientFailureClassifierTest.php
@@ -105,4 +105,40 @@ final class TransientFailureClassifierTest extends TestCase
             new RuntimeException('connection reset', previous: new RuntimeException('HTTP 401')),
         ];
     }
+
+    #[DataProvider('emptyContentCases')]
+    public function test_it_recognizes_empty_content_failures(Throwable $throwable): void
+    {
+        self::assertTrue((new TransientFailureClassifier())->isEmptyContent($throwable));
+    }
+
+    /** @return iterable<string, array{Throwable}> */
+    public static function emptyContentCases(): iterable
+    {
+        yield 'symfony_ai_canonical_message' => [new RuntimeException('Response does not contain any content.')];
+        yield 'response_does_not_contain_variant' => [new RuntimeException('Response does not contain text blocks')];
+        yield 'no_content_blocks_variant' => [new RuntimeException('Anthropic returned no content blocks')];
+        yield 'case_insensitive_match' => [new RuntimeException('RESPONSE DOES NOT CONTAIN ANY CONTENT.')];
+        yield 'wrapped_empty_content' => [
+            new RuntimeException(
+                'platform invoke failed',
+                previous: new RuntimeException('Response does not contain any content.'),
+            ),
+        ];
+    }
+
+    #[DataProvider('nonEmptyContentCases')]
+    public function test_it_does_not_classify_unrelated_errors_as_empty_content(Throwable $throwable): void
+    {
+        self::assertFalse((new TransientFailureClassifier())->isEmptyContent($throwable));
+    }
+
+    /** @return iterable<string, array{Throwable}> */
+    public static function nonEmptyContentCases(): iterable
+    {
+        yield 'transient_503' => [new RuntimeException('HTTP 503 Service Unavailable')];
+        yield 'unauthorized_401' => [new RuntimeException('HTTP 401 Unauthorized')];
+        yield 'rate_limit' => [new RuntimeException('rate_limit exceeded')];
+        yield 'unrelated_runtime_error' => [new RuntimeException('connection reset by peer')];
+    }
 }


### PR DESCRIPTION
## Summary

Add detection and graceful handling of empty LLM responses (when the model returns no content blocks). These are not transient failures and should not trigger retries — instead, they return an empty `LLMResponse` with `stopReason: 'empty_content'` and log a warning.

Closes #xxx

## Type of change

- [x] Bug fix

## Changes

### Core Logic
- **`TransientFailureClassifier`**: Added `isEmptyContent()` method to detect framework-level "no content blocks" errors from `symfony/ai` converters. Recognizes multiple message variants (case-insensitive) and unwraps nested exceptions.
- **`EmptyLLMResponseException`**: New exception type to signal empty content and preserve the original error message.
- **`SymfonyAiLLMClient`**: 
  - Catches `EmptyLLMResponseException` in `complete()` and `completeWithTools()` 
  - Returns empty `LLMResponse` with `stopReason: 'empty_content'` instead of propagating/retrying
  - Logs warnings with context (error message, iteration count, token usage)
  - Does not consume retry budget — empty responses are treated as successful calls

### Test Coverage
- **Integration tests** (`SymfonyAiLLMClientTest`):
  - `test_complete_returns_empty_response_when_platform_reports_empty_content`: Verifies empty response structure and no retries
  - `test_complete_logs_warning_when_platform_reports_empty_content`: Validates warning log format
  - `test_complete_with_tools_returns_empty_response_when_platform_reports_empty_content_on_first_iteration`: Tool-using loop behavior
  - `test_complete_with_tools_logs_warning_when_platform_reports_empty_content`: Tool loop warning context
  - `test_complete_does_not_retry_empty_content_failures`: Confirms platform is invoked exactly once
  - Added `emptyContentPlatform()` test helper to simulate empty responses

- **Unit tests** (`TransientFailureClassifierTest`):
  - `test_it_recognizes_empty_content_failures`: Tests canonical and variant message patterns
  - `test_it_does_not_classify_unrelated_errors_as_empty_content`: Ensures no false positives

### Minor Fix
- **`AuditContextTest`**: Hardened `test_audit_id_matches_expected_format` to run 64 iterations, catching potential randomness issues in UUID generation.

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01WjYActvNK9iWWf8HrnqbUZ