### PR TITLE
fix(llm): drop empty-content log on tool iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.6.4] — 2026-05-28 — Hush
+
+A log-hygiene release. `audit:run` no longer emits a `warning` when the
+attacker's structured-collection tool loop ends with empty content after at
+least one tool-using iteration — that is the intended termination signal in
+structured-collection mode, not an error.
+
+### Fixed
+
+- **`Tool-using loop ended with empty content response` no longer fires at
+  `warning` level for normal-flow completions.** In structured-collection mode
+  (default since 1.6.0), the attacker emits findings via `record_vulnerability`
+  tool calls and is contracted to return no final prose — the empty content
+  block is how the model says "I'm done."
+  `SymfonyAiLLMClient::emptyToolLoopResponseAndLog()`
+  (`src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php`) was logging at
+  `warning` level regardless of iteration count, spamming the audit output once
+  per chunk on healthy runs (typical signature:
+  `iterations: 1, output_tokens: 1485, error: "Response does not contain any content."`).
+  The log now routes through `debug` when at least one tool-using iteration has
+  produced findings before the empty turn, and only stays at `warning` when the
+  very first call returns empty (genuine anomaly — refusal, content filter, or
+  provider quirk before any work was done). The message string and payload shape
+  are unchanged so existing log scrapers / dashboards continue to match.
+
 ## [1.6.3] — 2026-05-28 — Watertight
 
 A bug-fix release closing a credential-leak gap in the secret scrubber. URIs
@@ -938,6 +963,10 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.6.4]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.6.4
+[1.6.3]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.6.3
 [1.6.2]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.6.2
 [1.6.1]:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ structured-collection mode, not an error.
   very first call returns empty (genuine anomaly — refusal, content filter, or
   provider quirk before any work was done). The message string and payload shape
   are unchanged so existing log scrapers / dashboards continue to match.
+- **Misleading `(estimated)` suffix on the real-run cost line.**
+  `ReportRenderer::renderConsole()`
+  (`src/Audit/Infrastructure/Report/ReportRenderer.php`) appended `(estimated)`
+  to the `Cost    : $X.XXXX` line of the console report even after a real audit,
+  where the cost is computed from the platform's reported token usage — not
+  estimated. The suffix made operators second-guess what they actually spent.
+  The line now reads `Cost    : $0.3755` flat. The dry-run path
+  (`AuditPresenter::dryRunResult()`) still renders `(estimate)` because the cost
+  there really is an estimate from `EstimateAuditCostUseCase` with no LLM calls.
+  The SARIF `properties.estimated_cost_usd` key is unchanged (schema-stable).
 
 ## [1.6.3] — 2026-05-28 — Watertight
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,16 +34,17 @@ structured-collection mode, not an error.
   very first call returns empty (genuine anomaly — refusal, content filter, or
   provider quirk before any work was done). The message string and payload shape
   are unchanged so existing log scrapers / dashboards continue to match.
-- **Misleading `(estimated)` suffix on the real-run cost line.**
+- **Cost line removed from the real-run console report.**
   `ReportRenderer::renderConsole()`
-  (`src/Audit/Infrastructure/Report/ReportRenderer.php`) appended `(estimated)`
-  to the `Cost    : $X.XXXX` line of the console report even after a real audit,
-  where the cost is computed from the platform's reported token usage — not
-  estimated. The suffix made operators second-guess what they actually spent.
-  The line now reads `Cost    : $0.3755` flat. The dry-run path
-  (`AuditPresenter::dryRunResult()`) still renders `(estimate)` because the cost
-  there really is an estimate from `EstimateAuditCostUseCase` with no LLM calls.
-  The SARIF `properties.estimated_cost_usd` key is unchanged (schema-stable).
+  (`src/Audit/Infrastructure/Report/ReportRenderer.php`) used to print
+  `Cost    : $X.XXXX` and a per-role breakdown after every audit. The number
+  comes from a static `PricingProvider` table multiplied against actual token
+  usage, so it's a rough estimate that diverges from real provider invoices
+  (volume discounts, contract pricing, prompt-cache rebates) and operators
+  shouldn't anchor on it. The tokens line still prints (factual, model-tagged),
+  and the dry-run path (`AuditPresenter::dryRunResult()`) is unchanged —
+  estimating cost is its whole point. JSON and SARIF outputs still carry
+  `estimated_cost_usd` for downstream parsers / dashboards.
 
 ## [1.6.3] — 2026-05-28 — Watertight
 

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -330,12 +330,18 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
         int $totalInputTokens,
         int $totalOutputTokens,
     ): LLMResponse {
-        $this->logger->warning('Tool-using loop ended with empty content response', [
+        $context = [
             'iterations' => $iteration,
             'input_tokens' => $totalInputTokens,
             'output_tokens' => $totalOutputTokens,
             'error' => $emptyllmResponseException->getMessage(),
-        ]);
+        ];
+
+        if ($iteration > 0) {
+            $this->logger->debug('Tool-using loop ended with empty content response', $context);
+        } else {
+            $this->logger->warning('Tool-using loop ended with empty content response', $context);
+        }
 
         return LLMResponse::create(
             content: '',

--- a/src/Audit/Infrastructure/Report/ReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/ReportRenderer.php
@@ -48,7 +48,7 @@ final readonly class ReportRenderer
             '{{filesScanned}}' => $auditReport->filesScanned(),
             '{{tokens}}' => \sprintf('%s in / %s out', number_format($cost->inputTokens()), number_format($cost->outputTokens())),
             '{{primaryModel}}' => '' === $cost->primaryModel() ? 'unknown model' : $cost->primaryModel(),
-            '{{cost}}' => \sprintf('$%.4f (estimated)', $cost->estimatedCostUsd()),
+            '{{cost}}' => \sprintf('$%.4f', $cost->estimatedCostUsd()),
             '{{costBreakdown}}' => $this->renderCostBreakdown($auditReport),
             '{{riskLevel}}' => $auditReport->riskLevel(),
             '{{riskScore}}' => $auditReport->riskScore(),

--- a/src/Audit/Infrastructure/Report/ReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/ReportRenderer.php
@@ -48,29 +48,10 @@ final readonly class ReportRenderer
             '{{filesScanned}}' => $auditReport->filesScanned(),
             '{{tokens}}' => \sprintf('%s in / %s out', number_format($cost->inputTokens()), number_format($cost->outputTokens())),
             '{{primaryModel}}' => '' === $cost->primaryModel() ? 'unknown model' : $cost->primaryModel(),
-            '{{cost}}' => \sprintf('$%.4f', $cost->estimatedCostUsd()),
-            '{{costBreakdown}}' => $this->renderCostBreakdown($auditReport),
             '{{riskLevel}}' => $auditReport->riskLevel(),
             '{{riskScore}}' => $auditReport->riskScore(),
             '{{body}}' => $this->renderBody($auditReport),
         ]);
-    }
-
-    private function renderCostBreakdown(AuditReport $auditReport): string
-    {
-        $lines = [];
-        foreach ($auditReport->cost()->byRole() as $role => $entry) {
-            $lines[] = \sprintf(
-                '  - %-8s (%s): $%.4f — %s in / %s out',
-                $role,
-                '' === $entry['model'] ? 'unknown model' : $entry['model'],
-                $entry['estimated_cost_usd'],
-                number_format($entry['input_tokens']),
-                number_format($entry['output_tokens']),
-            );
-        }
-
-        return implode("\n", $lines);
     }
 
     public function renderJson(AuditReport $auditReport): string

--- a/src/Audit/Infrastructure/Report/Template/console.txt
+++ b/src/Audit/Infrastructure/Report/Template/console.txt
@@ -9,8 +9,6 @@
   Duration: {{duration}}
   Files   : {{filesScanned}} scanned
   Tokens  : {{tokens}} ({{primaryModel}})
-  Cost    : {{cost}}
-{{costBreakdown}}
 
 ──────────────────────────────────────────────────────────────────────
   RISK LEVEL: {{riskLevel}}  (Score: {{riskScore}})

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -1347,6 +1347,49 @@ final class SymfonyAiLLMClientTest extends TestCase
         );
     }
 
+    public function test_complete_with_tools_demotes_empty_content_to_debug_after_at_least_one_tool_iteration(): void
+    {
+        $tool = $this->makeTool('lookup', 'lookup');
+        $toolRegistry = new ToolRegistry([$tool], new NullLogger());
+
+        /** @var list<array{string, array<string, mixed>}> $warnings */
+        $warnings = [];
+        /** @var list<array{string, array<string, mixed>}> $debugs */
+        $debugs = [];
+        $logger = self::createStub(LoggerInterface::class);
+        $logger->method('warning')->willReturnCallback(
+            static function (string $msg, array $ctx = []) use (&$warnings): void {
+                $warnings[] = [$msg, $ctx];
+            },
+        );
+        $logger->method('debug')->willReturnCallback(
+            static function (string $msg, array $ctx = []) use (&$debugs): void {
+                $debugs[] = [$msg, $ctx];
+            },
+        );
+
+        $platform = $this->lazilyFailingPlatform([
+            new MultiPartResult([new ToolCallResult([new ToolCall('1', 'lookup')])]),
+            new RuntimeException('Response does not contain any content.'),
+        ]);
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(
+            $platform,
+            'm',
+            $logger,
+            transientFailureClassifier: new TransientFailureClassifier(),
+        );
+
+        $symfonyAiLLMClient->completeWithTools('sys', 'usr', $toolRegistry, 5);
+
+        $matchesMessage = static fn (array $entry): bool => 'Tool-using loop ended with empty content response' === $entry[0];
+
+        self::assertCount(0, array_filter($warnings, $matchesMessage));
+        $emptyDebugs = array_values(array_filter($debugs, $matchesMessage));
+        self::assertCount(1, $emptyDebugs);
+        self::assertSame(1, $emptyDebugs[0][1]['iterations']);
+    }
+
     public function test_complete_does_not_retry_empty_content_failures(): void
     {
         $fakeSleeper = new FakeSleeper();

--- a/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
@@ -520,11 +520,25 @@ final class ReportRendererTest extends TestCase
 
     public function test_render_console_renders_cost_without_estimated_suffix(): void
     {
-        $auditReport = $this->makeReportWithCost(AuditCost::of(100, 50, 0.3755, 'claude-opus-4-7'));
+        $auditReport = $this->makeReportWithCost(AuditCost::of(
+            inputTokens: 100,
+            outputTokens: 50,
+            estimatedCostUsd: 0.3755,
+            primaryModel: 'claude-opus-4-7',
+            byRole: [
+                'attacker' => ['model' => 'claude-opus-4-7', 'input_tokens' => 100, 'output_tokens' => 20, 'estimated_cost_usd' => 0.035],
+                'reviewer' => ['model' => 'claude-haiku-4-5', 'input_tokens' => 50, 'output_tokens' => 10, 'estimated_cost_usd' => 0.005],
+            ],
+        ));
         $output = $this->reportRenderer->renderConsole($auditReport);
 
-        self::assertStringContainsString('Cost    : $0.3755', $output);
-        self::assertStringNotContainsString('(estimated)', $output);
+        self::assertStringNotContainsString('Cost', $output);
+        self::assertStringNotContainsString('$0.3755', $output);
+        self::assertStringNotContainsString('$0.0350', $output);
+        self::assertStringNotContainsString('$0.0050', $output);
+        self::assertStringNotContainsString('{{cost}}', $output);
+        self::assertStringNotContainsString('{{costBreakdown}}', $output);
+        self::assertStringContainsString('100 in / 50 out (claude-opus-4-7)', $output);
     }
 
     public function test_render_console_substitutes_actual_model_name_when_primary_model_is_set(): void
@@ -722,39 +736,6 @@ final class ReportRendererTest extends TestCase
         }
 
         return AuditReport::fromContext($auditContext);
-    }
-
-    public function test_render_console_includes_per_role_cost_breakdown_when_present(): void
-    {
-        $auditCost = AuditCost::of(
-            inputTokens: 150,
-            outputTokens: 30,
-            estimatedCostUsd: 0.04,
-            primaryModel: 'claude-opus-4-7',
-            byRole: [
-                'attacker' => ['model' => 'claude-opus-4-7', 'input_tokens' => 100, 'output_tokens' => 20, 'estimated_cost_usd' => 0.035],
-                'reviewer' => ['model' => 'claude-haiku-4-5', 'input_tokens' => 50, 'output_tokens' => 10, 'estimated_cost_usd' => 0.005],
-            ],
-        );
-
-        $output = $this->reportRenderer->renderConsole($this->makeReportWithCost($auditCost));
-
-        self::assertStringContainsString('attacker', $output);
-        self::assertStringContainsString('claude-opus-4-7', $output);
-        self::assertStringContainsString('reviewer', $output);
-        self::assertStringContainsString('claude-haiku-4-5', $output);
-        self::assertStringContainsString('$0.0350', $output);
-        self::assertStringContainsString('$0.0050', $output);
-    }
-
-    public function test_render_console_omits_breakdown_section_when_no_by_role_data(): void
-    {
-        $auditCost = AuditCost::of(150, 30, 0.04, 'claude-opus-4-7');
-
-        $output = $this->reportRenderer->renderConsole($this->makeReportWithCost($auditCost));
-
-        self::assertStringNotContainsString('attacker', $output);
-        self::assertStringNotContainsString('reviewer', $output);
     }
 
     private function makeReportWithCost(AuditCost $auditCost, Vulnerability ...$vulnerabilities): AuditReport

--- a/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
@@ -518,6 +518,15 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{primaryModel}}', $output);
     }
 
+    public function test_render_console_renders_cost_without_estimated_suffix(): void
+    {
+        $auditReport = $this->makeReportWithCost(AuditCost::of(100, 50, 0.3755, 'claude-opus-4-7'));
+        $output = $this->reportRenderer->renderConsole($auditReport);
+
+        self::assertStringContainsString('Cost    : $0.3755', $output);
+        self::assertStringNotContainsString('(estimated)', $output);
+    }
+
     public function test_render_console_substitutes_actual_model_name_when_primary_model_is_set(): void
     {
         $auditReport = $this->makeReportWithCost(AuditCost::of(100, 50, 0.05, 'claude-opus-4-7'));


### PR DESCRIPTION
## Summary

This PR improves log hygiene and removes misleading cost estimates from the console audit report. The cost line and per-role breakdown are removed from `renderConsole()` output since they diverge from actual provider invoices due to volume discounts and contract pricing. Additionally, the "Tool-using loop ended with empty content response" message is demoted from `warning` to `debug` level when it occurs after at least one successful tool iteration — this is the intended termination signal in structured-collection mode (default since 1.6.0), not an error.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01WpZu2iEMjFFicuZbeK4bj2