### PR TITLE
fix(bundle): compile without AI platform 

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -1,0 +1,50 @@
+# Changelog Rules
+
+Every behavior-affecting change updates `CHANGELOG.md` **in the same
+commit/PR**. Docs-only, CI-only, and pure-tooling changes are exempt.
+
+## Step 1 — Classify the change first
+
+Before writing the entry, decide the SemVer impact against
+[`docs/versioning.md`](../../docs/versioning.md):
+
+| Class     | Criteria                                                                                                                                                             |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MAJOR** | Removes/alters public API (config keys, `audit:run` surface, JSON/SARIF schemas, Domain ports, models, `RunAuditUseCase`, Bundle class). Requires deprecation cycle. |
+| **MINOR** | New user-facing feature, new config key, `@internal` refactor with visible benefit.                                                                                  |
+| **PATCH** | Bug fix, no API surface change.                                                                                                                                      |
+
+If the release vehicle is not yet decided, file the entry under
+`## [Unreleased]` (pending) — never leave a shipped change undocumented.
+
+## Step 2 — Write the entry
+
+Place it under the correct Keep-a-Changelog subsection (`### Added`,
+`### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`)
+following the established entry style:
+
+- **Bold one-line summary stating the user-visible outcome.** Then: root cause
+  with file paths in backticks, exact error strings quoted verbatim, what
+  changed, and what the user observes now.
+- Reference classes/methods as `` `Class::method()` `` and files as
+  `` `src/...` ``.
+
+## Step 3 — At release time
+
+1. Rename `## [Unreleased]` content to `## [X.Y.Z] — YYYY-MM-DD — Codename`
+   (one-word codename: Polyglot, Hush, Watertight, …) and re-create an empty
+   `## [Unreleased]` above it.
+2. Add a short intro paragraph summarizing the release theme.
+3. Add the link reference at the bottom block:
+   `[X.Y.Z]: https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/X.Y.Z`.
+4. Prepare GitHub release notes in this exact format:
+
+   ```markdown
+   ## What's Changed
+
+   - <type>(<scope>): <description> by @vinceAmstoutz in https://github.com/vinceAmstoutz/symfony-security-auditor/pull/<N>
+
+   **Full Changelog**: https://github.com/vinceAmstoutz/symfony-security-auditor/compare/<prev>...<X.Y.Z>
+   ```
+
+   One bullet per conventional-commit-typed change, linked to its PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.7.1] — 2026-06-04 — Parachute
+
+A bare-install resilience release. Installing the bundle into a fresh Symfony
+skeleton — where the `symfony/ai-bundle` recipe ships `config/packages/ai.yaml`
+with every platform commented out — no longer breaks container compilation.
+
+### Fixed
+
+- **`cache:clear` no longer crashes when no AI platform is configured.** The
+  bundle's three `SymfonyAiLLMClient` service definitions
+  (`src/SymfonySecurityAuditorBundle.php`) hard-referenced
+  `Symfony\AI\Platform\PlatformInterface`. On a bare skeleton the
+  `symfony/ai-bundle` recipe registers no platform, so the alias never exists
+  and `CheckExceptionOnInvalidReferenceBehaviorPass` aborted **every** console
+  command (`cache:clear`, `cache:warmup`, recipe CI installs) with:
+
+  ```text
+  The service "security_auditor.attacker_client" has a dependency on a
+  non-existent service "Symfony\AI\Platform\PlatformInterface"
+  ```
+
+  The references are now declared `nullOnInvalid()` and the client constructor
+  accepts `?PlatformInterface`, so the container compiles without a platform.
+  The first actual LLM call raises the new `MissingAiPlatformException` (extends
+  `LLMProviderException`, so agents rethrow it instead of swallowing it into a
+  false-negative SAFE report) with an actionable message:
+
+  ```text
+  No AI platform is configured. Enable a platform (e.g. "anthropic") in
+  config/packages/ai.yaml and set its API key — the symfony/ai-bundle recipe
+  ships with every platform commented out.
+  ```
+
+  Every other console command keeps working; only `audit:run` needs a platform.
+
 ## [1.7.0] — 2026-05-29 — Polyglot
 
 ### Fixed
@@ -1015,6 +1050,10 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.7.1]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.7.1
+[1.7.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.7.0
 [1.6.4]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.6.4
 [1.6.3]:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,9 @@ Canonical policy: [`docs/versioning.md`](docs/versioning.md).
 
 Rules scoped to specific paths live in `.claude/rules/`:
 
+- [`changelog.md`](.claude/rules/changelog.md) — classify every change
+  (major/minor/patch or Unreleased) and update `CHANGELOG.md` in the same
+  commit; release-notes format.
 - [`ddd-layers.md`](.claude/rules/ddd-layers.md) — dependency direction across
   layers.
 - [`domain-models.md`](.claude/rules/domain-models.md) — immutability,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,10 +40,20 @@ Symfony\AI\AiBundle\AiBundle::class => ['all' => true],
 VinceAmstoutz\SymfonySecurityAuditor\SymfonySecurityAuditorBundle::class => ['dev' => true, 'test' => true],
 ```
 
+### `No AI platform is configured`
+
+`audit:run` aborts with this message when no
+`Symfony\AI\Platform\PlatformInterface` service exists in the container. The
+`symfony/ai-bundle` recipe ships `config/packages/ai.yaml` with **every platform
+commented out** — uncomment one (e.g. `anthropic`) and set its API key. See
+[Configuration → Platform Configuration](configuration.md#platform-configuration).
+
 ### `The service "VinceAmstoutz\..." has a dependency on a non-existent service "Symfony\AI\Platform\PlatformInterface"`
 
-No platform configured in `config/packages/ai.yaml`. Add one — see
-[Configuration → Platform Configuration](configuration.md#platform-configuration).
+Same root cause as above, surfaced at container compile time (`cache:clear`,
+`cache:warmup`) by versions **≤ 1.7.0**. Upgrade to `1.7.1` or later — the
+container then compiles without a platform and the actionable error above is
+raised only when an audit actually runs.
 
 ### `Argument #1 ... must be of type Symfony\AI\Platform\PlatformInterface, NULL given`
 

--- a/src/Audit/Infrastructure/LLM/Exception/MissingAiPlatformException.php
+++ b/src/Audit/Infrastructure/LLM/Exception/MissingAiPlatformException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\LLMProviderException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final class MissingAiPlatformException extends LLMProviderException
+{
+    public static function create(): self
+    {
+        return new self('No AI platform is configured. Enable a platform (e.g. "anthropic") in config/packages/ai.yaml and set its API key — the symfony/ai-bundle recipe ships with every platform commented out.');
+    }
+}

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -42,6 +42,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay\SleeperInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay\UsleepSleeper;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\EmptyLLMResponseException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\MissingAiPlatformException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\NonTransientLLMFailureException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\TransientLLMFailureException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RateLimit\NullRateLimiter;
@@ -57,7 +58,7 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
     public const ?int DEFAULT_MAX_OUTPUT_TOKENS = null;
 
     public function __construct(
-        private PlatformInterface $platform,
+        private ?PlatformInterface $platform,
         private string $model,
         private LoggerInterface $logger,
         private ?float $temperature = self::DEFAULT_TEMPERATURE,
@@ -151,6 +152,7 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
     {
         \assert('' !== $this->model, 'Model must be a non-empty string');
 
+        $platform = $this->platform();
         $deferred = [];
         foreach ($window as $index => $request) {
             $messageBag = new MessageBag(
@@ -161,7 +163,7 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
             $this->rateLimiter()->acquire($estimatedInputTokens);
 
             try {
-                $deferred[$index] = $this->platform->invoke($this->model, $messageBag, $this->baseOptions());
+                $deferred[$index] = $platform->invoke($this->model, $messageBag, $this->baseOptions());
             } catch (Throwable) {
                 $deferred[$index] = null;
             }
@@ -384,6 +386,7 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
     /** @param array<string, mixed> $options */
     private function invokeWithRetry(MessageBag $messageBag, array $options, int $estimatedInputTokens): DeferredResult
     {
+        $platform = $this->platform();
         $rateLimiter = $this->rateLimiter();
         $retryPolicy = $this->retryPolicy ?? new RetryPolicy();
         $classifier = $this->transientFailureClassifier ?? new TransientFailureClassifier();
@@ -398,7 +401,7 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
             $rateLimiter->acquire($estimatedInputTokens);
 
             try {
-                $deferredResult = $this->platform->invoke($this->model, $messageBag, $options);
+                $deferredResult = $platform->invoke($this->model, $messageBag, $options);
                 $deferredResult->getResult();
 
                 return $deferredResult;
@@ -438,6 +441,11 @@ final readonly class SymfonyAiLLMClient implements BatchCapableLLMClientInterfac
                 ++$attempt;
             }
         }
+    }
+
+    private function platform(): PlatformInterface
+    {
+        return $this->platform ?? throw MissingAiPlatformException::create();
     }
 
     private function rateLimiter(): RateLimiterInterface

--- a/src/SymfonySecurityAuditorBundle.php
+++ b/src/SymfonySecurityAuditorBundle.php
@@ -478,7 +478,7 @@ final class SymfonySecurityAuditorBundle extends AbstractBundle
         $services->set('security_auditor.attacker_client', SymfonyAiLLMClient::class)
             ->private()
             ->args([
-                service(PlatformInterface::class),
+                service(PlatformInterface::class)->nullOnInvalid(),
                 $bundleConfiguration->llm->attackerModel(),
                 service('logger'),
                 SymfonyAiLLMClient::DEFAULT_TEMPERATURE,
@@ -497,7 +497,7 @@ final class SymfonySecurityAuditorBundle extends AbstractBundle
         $services->set('security_auditor.reviewer_client', SymfonyAiLLMClient::class)
             ->private()
             ->args([
-                service(PlatformInterface::class),
+                service(PlatformInterface::class)->nullOnInvalid(),
                 $bundleConfiguration->llm->reviewerModel(),
                 service('logger'),
                 SymfonyAiLLMClient::DEFAULT_TEMPERATURE,
@@ -543,7 +543,7 @@ final class SymfonySecurityAuditorBundle extends AbstractBundle
             $services->set('security_auditor.cheap_attacker_client', SymfonyAiLLMClient::class)
                 ->private()
                 ->args([
-                    service(PlatformInterface::class),
+                    service(PlatformInterface::class)->nullOnInvalid(),
                     $cheapModel,
                     service('logger'),
                     SymfonyAiLLMClient::DEFAULT_TEMPERATURE,

--- a/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
+++ b/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
@@ -68,6 +68,13 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
         self::assertInstanceOf(AuditCommand::class, $this->getPrivateService($kernel, AuditCommand::class));
     }
 
+    public function test_bundle_boots_without_an_ai_platform_service(): void
+    {
+        $kernel = $this->boot(['model' => 'gpt-4o'], registerPlatform: false);
+
+        self::assertInstanceOf(AuditCommand::class, $this->getPrivateService($kernel, AuditCommand::class));
+    }
+
     public function test_bundle_default_model_is_claude_opus_4_5(): void
     {
         $kernel = $this->boot([]);
@@ -684,23 +691,26 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     /**
      * @param array<string, mixed> $bundleConfig
      */
-    private function boot(array $bundleConfig): Kernel
+    private function boot(array $bundleConfig, bool $registerPlatform = true): Kernel
     {
         $tmpDir = $this->tmpDir;
-        $kernel = new class('test', true, $tmpDir, $bundleConfig) extends Kernel {
+        $kernel = new class('test', true, $tmpDir, $bundleConfig, $registerPlatform) extends Kernel {
             /** @var array<string, mixed> */
             private array $bundleConfig;
 
             private string $tmpDir;
 
+            private bool $registerPlatform;
+
             /**
              * @param array<string, mixed> $bundleConfig
              */
-            public function __construct(string $environment, bool $debug, string $tmpDir, array $bundleConfig)
+            public function __construct(string $environment, bool $debug, string $tmpDir, array $bundleConfig, bool $registerPlatform)
             {
                 parent::__construct($environment, $debug);
                 $this->tmpDir = $tmpDir;
                 $this->bundleConfig = $bundleConfig;
+                $this->registerPlatform = $registerPlatform;
             }
 
             public function registerBundles(): iterable
@@ -712,7 +722,8 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
             public function registerContainerConfiguration(LoaderInterface $loader): void
             {
                 $bundleConfig = $this->bundleConfig;
-                $loader->load(static function (ContainerBuilder $containerBuilder) use ($bundleConfig): void {
+                $registerPlatform = $this->registerPlatform;
+                $loader->load(static function (ContainerBuilder $containerBuilder) use ($bundleConfig, $registerPlatform): void {
                     $containerBuilder->loadFromExtension('framework', [
                         'secret' => 'test',
                         'http_method_override' => false,
@@ -723,9 +734,11 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
                     ]);
                     $containerBuilder->loadFromExtension('symfony_security_auditor', $bundleConfig);
 
-                    $containerBuilder->register(PlatformInterface::class, InMemoryPlatform::class)
-                        ->setArguments(['stub-response'])
-                        ->setPublic(true);
+                    if ($registerPlatform) {
+                        $containerBuilder->register(PlatformInterface::class, InMemoryPlatform::class)
+                            ->setArguments(['stub-response'])
+                            ->setPublic(true);
+                    }
                 });
             }
 

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -55,6 +55,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolDefinition;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay\SleeperInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\MissingAiPlatformException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\NonTransientLLMFailureException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\TransientLLMFailureException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RetryPolicy;
@@ -302,6 +303,37 @@ final class SymfonyAiLLMClientTest extends TestCase
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new InMemoryPlatform(''), 'claude-test', new NullLogger());
 
         self::assertSame('claude-test', $symfonyAiLLMClient->model());
+    }
+
+    public function test_complete_throws_when_no_ai_platform_is_configured(): void
+    {
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(null, 'test-model', new NullLogger());
+
+        $this->expectException(MissingAiPlatformException::class);
+        $this->expectExceptionMessage('No AI platform is configured');
+
+        $symfonyAiLLMClient->complete('sys', 'usr');
+    }
+
+    public function test_complete_with_tools_throws_when_no_ai_platform_is_configured(): void
+    {
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(null, 'test-model', new NullLogger());
+        $toolRegistry = new ToolRegistry([$this->makeTool('lookup', 'lookup')], new NullLogger());
+
+        $this->expectException(MissingAiPlatformException::class);
+        $this->expectExceptionMessage('config/packages/ai.yaml');
+
+        $symfonyAiLLMClient->completeWithTools('sys', 'usr', $toolRegistry, 3);
+    }
+
+    public function test_complete_batch_throws_when_no_ai_platform_is_configured(): void
+    {
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(null, 'test-model', new NullLogger());
+
+        $this->expectException(MissingAiPlatformException::class);
+        $this->expectExceptionMessage('No AI platform is configured');
+
+        $symfonyAiLLMClient->completeBatch([['system' => 's', 'user' => 'u']], 2);
     }
 
     public function test_complete_batch_returns_empty_for_no_requests(): void


### PR DESCRIPTION
## Summary

  Installing the bundle into a bare Symfony skeleton crashed every console command at container
  compile time (`The service "security_auditor.attacker_client" has a dependency on a non-existent
  service "Symfony\AI\Platform\PlatformInterface"`), because the `symfony/ai-bundle` recipe ships
  `ai.yaml` with every platform commented out. The three `PlatformInterface` references are now
  declared `nullOnInvalid()` and `SymfonyAiLLMClient` accepts a nullable platform, so the container
  compiles without one; the first actual LLM call raises the new `MissingAiPlatformException`
  (extends `LLMProviderException`, so agents rethrow it instead of producing a false-negative SAFE
  report) with an actionable message pointing to `config/packages/ai.yaml`.

  Verified end-to-end on a fresh `symfony/skeleton` with the recipe-default `ai.yaml`:
  `composer require` + `cache:clear` exit 0, and `audit:run` prints the actionable error.
  Unblocks the symfony/recipes-contrib CI, which installs the bundle into a bare skeleton.

  ## Type of change

  - [x] Bug fix

  ## Checklist

  - [x] Tests added or updated (unit + integration where applicable)
  - [x] All checks pass: `bin/castor lint`
  - [x] 100% MSI maintained: `docker compose exec php bin/infection`
  - [x] No `createMock` without a matching `expects()` (use `createStub`
        otherwise)
  - [x] Commit messages follow
        [Conventional Commits](https://www.conventionalcommits.org/)
