### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run Prettier check MD files
         run: npx --yes prettier@3 --check "**/*.md"
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@v18
+        uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           config: .markdownlint-cli2.jsonc
           globs: '**/*.md'
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -119,7 +119,7 @@ jobs:
       SYMFONY_REQUIRE: ${{ matrix.symfony }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -128,7 +128,7 @@ jobs:
           coverage: pcov
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: composer-php${{ matrix.php }}-sf${{ matrix.symfony }}-${{ hashFiles('composer.json') }}
@@ -138,7 +138,7 @@ jobs:
         run: composer update --no-interaction --prefer-dist --no-progress
 
       - name: Cache PHPUnit result cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .phpunit.cache
           key: phpunit-php${{ matrix.php }}-sf${{ matrix.symfony }}-${{ hashFiles('src/**/*.php', 'tests/**/*.php', 'phpunit.xml', 'composer.json') }}


### PR DESCRIPTION
## Summary

GitHub removes Node 20 from runners on 2026-09-16; checkout@v4, setup-node@v4, markdownlint-cli2-action@v18 and cache@v4 all emit deprecation warnings. Prettier job's installed Node moves 20 -> 24 as well (20 is EOL since 2026-04). markdownlint-cli2 0.22.1 (the v23 action bundle) verified locally: 65 files, 0 errors.

## Type of change

- [x] Chore

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)
