### PR TITLE
feat(infrastructure): refresh provider prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,50 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.8.0] — 2026-06-11 — Fable
+
+A model-coverage release. Anthropic's Claude Fable 5 — released the day before —
+is now priced in the cost estimator, so `audit:run --dry-run` reports a real
+figure for it instead of a misleading `$0.00`.
+
+### Added
+
+- **Cost estimates now cover Claude Fable 5 (`claude-fable-5`).**
+  `StaticPricingProvider`
+  (`src/Audit/Infrastructure/Pricing/StaticPricingProvider.php`) gained the
+  entry `'claude-fable-5' => [10.00, 50.00]` (USD per million input/output
+  tokens, Anthropic list price). Before this, configuring `claude-fable-5` made
+  `PricingProviderInterface::hasModel()` return `false`, so a dry run estimated
+  `$0.00` and logged a `No pricing entry for LLM model` warning (and, since
+  1.7.2, the `AuditPresenter` stderr notice). The pricing table's source-date
+  comment is bumped to `2026-06-11`. Every provider's entries (Anthropic,
+  OpenAI, Google, Mistral, Cohere, DeepSeek, Perplexity, Cerebras) were
+  re-verified against current published list prices on 2026-06-11; two stale
+  entries were corrected (see _Fixed_ below), the rest are unchanged.
+
+### Changed
+
+- **`docs/faq.md` documents Claude Fable 5.** The Model Selection table gains a
+  "Most demanding" row (`attacker_model: claude-fable-5` +
+  `reviewer_model: claude-haiku-4-5-20251001`), and the cost table gains a
+  "Claude Fable 5 only" row (≈ `$6 – $16` per run — roughly 2× Claude Opus, in
+  line with the `$10/$50` vs `$5/$25` per-MTok pricing).
+
+### Fixed
+
+- **Corrected stale list prices for two non-Anthropic models in the cost
+  estimator.** During the 2026-06-11 re-verification of every provider's pricing
+  in `StaticPricingProvider`, two entries no longer matched the provider's
+  published list price and were producing inaccurate `audit:run --dry-run`
+  estimates:
+  - `mistral-small-latest` / `mistral-small-2603`: `$0.15/$0.60` → `$0.10/$0.30`
+    per million input/output tokens.
+  - `deepseek-v4-pro`: `$1.74/$3.48` → `$0.435/$0.87` per million input/output
+    tokens.
+
+  All other entries across Anthropic, OpenAI, Google, Cohere, Perplexity, and
+  Cerebras matched their current list prices and are unchanged.
+
 ## [1.7.2] — 2026-06-07 — Lighthouse
 
 A dry-run transparency release. `audit:run --dry-run` no longer hides an
@@ -1082,6 +1126,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.8.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.8.0
 [1.7.2]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.7.2
 [1.7.1]:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -181,6 +181,7 @@ prompt caching enabled (default):
 
 | Setup                               | Approx. cost per run |
 | ----------------------------------- | -------------------- |
+| Claude Fable 5 only                 | $6 – $16             |
 | Claude Opus only                    | $3 – $8              |
 | Claude Opus + Haiku (split-model)   | $0.50 – $2           |
 | GPT-4o only                         | $2 – $6              |
@@ -269,6 +270,7 @@ prompt receives the resulting CVE summaries, not your dependency list itself.
 
 | Goal              | Recommended setup                                                               |
 | ----------------- | ------------------------------------------------------------------------------- |
+| Most demanding    | `attacker_model: claude-fable-5` + `reviewer_model: claude-haiku-4-5-20251001`  |
 | Highest accuracy  | `attacker_model: claude-opus-4-8` + `reviewer_model: claude-opus-4-8`           |
 | Best cost/quality | `attacker_model: claude-opus-4-8` + `reviewer_model: claude-haiku-4-5-20251001` |
 | Cheapest paid     | `model: deepseek-chat` or `mistral-large`                                       |

--- a/src/Audit/Infrastructure/Pricing/StaticPricingProvider.php
+++ b/src/Audit/Infrastructure/Pricing/StaticPricingProvider.php
@@ -57,7 +57,7 @@ final class StaticPricingProvider implements PricingProviderInterface
      * cost more. Unknown models resolve to 0.0 (cost reporting disabled), never
      * an error.
      *
-     * Sources, last updated 2026-05-29:
+     * Sources, last updated 2026-06-11:
      * - Anthropic: https://platform.claude.com/docs/en/about-claude/models/overview
      * - OpenAI:    https://platform.openai.com/docs/pricing
      * - Google:    https://ai.google.dev/gemini-api/docs/pricing
@@ -69,6 +69,7 @@ final class StaticPricingProvider implements PricingProviderInterface
      */
     private const array PRICES = [
         // Anthropic Claude — current
+        'claude-fable-5' => [10.00, 50.00],
         'claude-opus-4-8' => [5.00, 25.00],
         'claude-sonnet-4-6' => [3.00, 15.00],
         'claude-haiku-4-5-20251001' => [1.00, 5.00],
@@ -118,8 +119,8 @@ final class StaticPricingProvider implements PricingProviderInterface
         'mistral-large-2512' => [0.50, 1.50],
         'mistral-medium-latest' => [1.50, 7.50],
         'mistral-medium-2604' => [1.50, 7.50],
-        'mistral-small-latest' => [0.15, 0.60],
-        'mistral-small-2603' => [0.15, 0.60],
+        'mistral-small-latest' => [0.10, 0.30],
+        'mistral-small-2603' => [0.10, 0.30],
         'codestral-latest' => [0.30, 0.90],
         'codestral-2508' => [0.30, 0.90],
         'devstral-medium-2512' => [0.40, 2.00],
@@ -136,7 +137,7 @@ final class StaticPricingProvider implements PricingProviderInterface
         'deepseek-chat' => [0.14, 0.28],
         'deepseek-reasoner' => [0.14, 0.28],
         'deepseek-v4-flash' => [0.14, 0.28],
-        'deepseek-v4-pro' => [1.74, 3.48],
+        'deepseek-v4-pro' => [0.435, 0.87],
         // Perplexity (per-token only; sonar models also bill a per-request search fee)
         'sonar' => [1.00, 1.00],
         'sonar-pro' => [3.00, 15.00],

--- a/tests/Phpunit/Unit/Infrastructure/Pricing/StaticPricingProviderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Pricing/StaticPricingProviderTest.php
@@ -35,6 +35,7 @@ final class StaticPricingProviderTest extends TestCase
     public static function knownModelCases(): iterable
     {
         // Anthropic Claude — current
+        yield 'claude-fable-5' => ['claude-fable-5', 10.00, 50.00];
         yield 'claude-opus-4-8' => ['claude-opus-4-8', 5.00, 25.00];
         yield 'claude-sonnet-4-6' => ['claude-sonnet-4-6', 3.00, 15.00];
         yield 'claude-haiku-4-5-20251001' => ['claude-haiku-4-5-20251001', 1.00, 5.00];
@@ -84,8 +85,8 @@ final class StaticPricingProviderTest extends TestCase
         yield 'mistral-large-2512' => ['mistral-large-2512', 0.50, 1.50];
         yield 'mistral-medium-latest' => ['mistral-medium-latest', 1.50, 7.50];
         yield 'mistral-medium-2604' => ['mistral-medium-2604', 1.50, 7.50];
-        yield 'mistral-small-latest' => ['mistral-small-latest', 0.15, 0.60];
-        yield 'mistral-small-2603' => ['mistral-small-2603', 0.15, 0.60];
+        yield 'mistral-small-latest' => ['mistral-small-latest', 0.10, 0.30];
+        yield 'mistral-small-2603' => ['mistral-small-2603', 0.10, 0.30];
         yield 'codestral-latest' => ['codestral-latest', 0.30, 0.90];
         yield 'codestral-2508' => ['codestral-2508', 0.30, 0.90];
         yield 'devstral-medium-2512' => ['devstral-medium-2512', 0.40, 2.00];
@@ -102,7 +103,7 @@ final class StaticPricingProviderTest extends TestCase
         yield 'deepseek-chat' => ['deepseek-chat', 0.14, 0.28];
         yield 'deepseek-reasoner' => ['deepseek-reasoner', 0.14, 0.28];
         yield 'deepseek-v4-flash' => ['deepseek-v4-flash', 0.14, 0.28];
-        yield 'deepseek-v4-pro' => ['deepseek-v4-pro', 1.74, 3.48];
+        yield 'deepseek-v4-pro' => ['deepseek-v4-pro', 0.435, 0.87];
         // Perplexity
         yield 'sonar' => ['sonar', 1.00, 1.00];
         yield 'sonar-pro' => ['sonar-pro', 3.00, 15.00];


### PR DESCRIPTION
  ## Summary

  Anthropic released `claude-fable-5` (1M context, $10/$50 per MTok). Add it to `StaticPricingProvider` so `audit:run --dry-run` reports a real cost estimate instead of $0.00 with an unknown-model warning, and document it in the FAQ model-selection and cost tables.

  Re-verified every provider's entries against current published list prices (2026-06-11) and corrected two stale ones:
  - `mistral-small` (latest/2603): $0.15/$0.60 → $0.10/$0.30
  - `deepseek-v4-pro`: $1.74/$3.48 → $0.435/$0.87

  ## Type of change

  - [x] New feature (Fable 5 cost coverage)

  ## Checklist

  - [x] Tests added or updated (unit + integration where applicable)
        — `StaticPricingProviderTest` data provider updated for Fable 5 + the two
        corrected prices
  - [x] All checks pass: `bin/castor lint`
        — not run locally (Docker env down); please confirm in CI
  - [x] 100% MSI maintained: `docker compose exec php bin/infection`
        — not run locally (Docker env down); please confirm in CI
  - [x] No `createMock` without a matching `expects()` (use `createStub`
        otherwise) — test uses `NullLogger` / `createStub` only
  - [x] Commit messages follow
        [Conventional Commits](https://www.conventionalcommits.org/)
