### PR TITLE
fix(prompt): align attacker/reviewer structured-output contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Fixed
+
+- **Attacker prompt no longer contradicts itself in the default
+  structured-collection mode.** `AttackerPromptBuilder::buildUserMessage()`
+  (`src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php`) always closed
+  the user message with `Return a JSON array of all vulnerabilities found.`,
+  even when `audit.structured_collection` is enabled (the default), where the
+  system prompt forbids JSON-array output and mandates `record_vulnerability`
+  tool calls. The conflicting instruction could push the model to emit a stray
+  JSON array that the pipeline then discards as malformed. The closing line is
+  now conditional: structured mode tells the model to record findings via the
+  `record_vulnerability` tool, and only the opt-out
+  (`structured_collection: false`) path keeps the JSON-array wording. The
+  attacker `PROMPT_VERSION` is bumped `6` → `7`, invalidating previously cached
+  attacker responses so the corrected prompt takes effect.
+- **Reviewer can now relabel a finding to `over_permissive_serializer_group`.**
+  The `corrected_type` enum advertised to the reviewer in
+  `ReviewerPromptBuilder`
+  (`src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php`) listed 39 of the
+  40 `VulnerabilityType` cases — `over_permissive_serializer_group`, which the
+  attacker can already emit, was missing, so the reviewer could neither correct
+  a mislabelled finding to it nor recognise it as a valid type. The value is now
+  listed, and a regression test asserts every `VulnerabilityType` case appears
+  in both the attacker and reviewer prompts so the two enumerations cannot drift
+  apart again.
+
 ## [1.8.0] — 2026-06-11 — Fable
 
 A model-coverage release. Anthropic's Claude Fable 5 — released the day before —

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -27,7 +27,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 6;
+    public const int PROMPT_VERSION = 7;
 
     public const bool DEFAULT_STRUCTURED_COLLECTION = true;
 
@@ -322,6 +322,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
         $accessControlMap = $this->renderRouteAccessControlMap($symfonyMapping);
         $voterCoverage = $this->renderVoterCoverage($symfonyMapping);
         $formBindings = $this->renderFormBindings($symfonyMapping);
+        $closingInstruction = $this->closingInstruction();
 
         return <<<PROMPT
             ## Project Mapping Summary
@@ -335,8 +336,17 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
 
             {$context}
 
-            Return a JSON array of all vulnerabilities found.
+            {$closingInstruction}
             PROMPT;
+    }
+
+    private function closingInstruction(): string
+    {
+        if ($this->useStructuredCollection) {
+            return 'Record every vulnerability you find via the `record_vulnerability` tool — one call per finding.';
+        }
+
+        return 'Return a JSON array of all vulnerabilities found.';
     }
 
     private function renderVoterCoverage(SymfonyMapping $symfonyMapping): string

--- a/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
@@ -89,7 +89,8 @@ final readonly class ReviewerPromptBuilder implements ReviewerPromptBuilderInter
         exposed_internal_service, misconfigured_firewall, insecure_redirect, sensitive_data_exposure,
         log_injection, path_traversal, ssrf, xxe, open_redirect, weak_cryptography, insecure_random,
         hardcoded_secret, missing_signature_verification, messenger_handler_unsafe, missing_rate_limiting,
-        cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass
+        cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass,
+        over_permissive_serializer_group
         SCHEMA;
 
     private const string DECISION_RULES = <<<'RULES'

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Prompt;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\FormBinding;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RouteAccessControl;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\AttackerPromptBuilder;
 
 final class AttackerPromptBuilderTest extends TestCase
@@ -788,7 +790,53 @@ final class AttackerPromptBuilderTest extends TestCase
 
     public function test_prompt_version_is_bumped_when_modern_symfony_skill_blocks_are_added(): void
     {
-        self::assertSame(6, AttackerPromptBuilder::PROMPT_VERSION);
+        self::assertSame(7, AttackerPromptBuilder::PROMPT_VERSION);
+    }
+
+    #[DataProvider('vulnerabilityTypeValues')]
+    public function test_base_prompt_lists_every_vulnerability_type_as_valid(string $typeValue): void
+    {
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString($typeValue, $prompt);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function vulnerabilityTypeValues(): iterable
+    {
+        foreach (VulnerabilityType::cases() as $vulnerabilityType) {
+            yield $vulnerabilityType->value => [$vulnerabilityType->value];
+        }
+    }
+
+    public function test_structured_collection_user_message_does_not_request_a_json_array(): void
+    {
+        $attackerPromptBuilder = new AttackerPromptBuilder(useStructuredCollection: true);
+        $projectFile = ProjectFile::create(
+            'src/Controller/UserController.php',
+            '/app/src/Controller/UserController.php',
+            '<?php class UserController {}',
+        );
+
+        $message = $attackerPromptBuilder->buildUserMessage([$projectFile], SymfonyMapping::create());
+
+        self::assertStringNotContainsString('Return a JSON array', $message);
+        self::assertStringContainsString('record_vulnerability', $message);
+    }
+
+    public function test_opt_out_user_message_requests_a_json_array(): void
+    {
+        $attackerPromptBuilder = new AttackerPromptBuilder(useStructuredCollection: false);
+        $projectFile = ProjectFile::create(
+            'src/Controller/UserController.php',
+            '/app/src/Controller/UserController.php',
+            '<?php class UserController {}',
+        );
+
+        $message = $attackerPromptBuilder->buildUserMessage([$projectFile], SymfonyMapping::create());
+
+        self::assertStringContainsString('Return a JSON array of all vulnerabilities found.', $message);
+        self::assertStringNotContainsString('record_vulnerability', $message);
     }
 
     public function test_entity_skill_block_mentions_over_permissive_serializer_groups(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Prompt;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
@@ -180,6 +181,30 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString('messenger_handler_unsafe', $prompt);
         self::assertStringContainsString('webhook_replay', $prompt);
         self::assertStringContainsString('authenticator_bypass', $prompt);
+    }
+
+    #[DataProvider('vulnerabilityTypeValues')]
+    public function test_system_prompt_lists_every_vulnerability_type_as_corrected_type(string $typeValue): void
+    {
+        $prompt = $this->reviewerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString($typeValue, $prompt);
+    }
+
+    #[DataProvider('vulnerabilityTypeValues')]
+    public function test_batch_system_prompt_lists_every_vulnerability_type_as_corrected_type(string $typeValue): void
+    {
+        $prompt = $this->reviewerPromptBuilder->buildBatchSystemPrompt();
+
+        self::assertStringContainsString($typeValue, $prompt);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function vulnerabilityTypeValues(): iterable
+    {
+        foreach (VulnerabilityType::cases() as $vulnerabilityType) {
+            yield $vulnerabilityType->value => [$vulnerabilityType->value];
+        }
     }
 
     public function test_false_positive_playbook_covers_constant_time_signature_comparison(): void


### PR DESCRIPTION
## Summary

Two prompt-contract bugs in the attacker–reviewer loop.

1. **Attacker contradiction (default mode):**
   `AttackerPromptBuilder::buildUserMessage()` always closed with `Return a JSON
   array of all vulnerabilities found.`, even when `audit.structured_collection`
   is enabled (the default), where the system prompt forbids JSON-array output
   and mandates `record_vulnerability` tool calls. The conflicting instruction
   could push the model to emit a stray JSON array the pipeline discards as
   malformed. The closing line is now conditional on the collection mode, and
   `PROMPT_VERSION` is bumped `6` → `7` to invalidate stale cached responses.
2. **Reviewer enum drift:** the `corrected_type` enum advertised to the reviewer
   listed 39 of the 40 `VulnerabilityType` cases —
   `over_permissive_serializer_group` (which the attacker can already emit) was
   missing. It is now listed, and a data-provider regression test asserts every
   `VulnerabilityType` case appears in both the attacker and reviewer prompts so
   the two enumerations cannot drift again.

SemVer: patch. Both classes are `@internal`; no public API, config key, or
output schema change. `CHANGELOG.md` updated under `[Unreleased] → Fixed`.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01MFGywTi6aU5t2SLUy4ZTxj