### PR TITLE
feat(prompt): keep uncertain findings instead of dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Changed
+
+- **Reviewer no longer drops real-but-hard-to-prove findings.** The reviewer
+  decision rules in `ReviewerPromptBuilder`
+  (`src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php`) opened with
+  `Be strict: reject any finding where exploitation is not clearly demonstrated`
+  — and current models follow that literally, silently discarding the very class
+  of issues the auditor exists to surface (race conditions, business-logic
+  flaws, context-dependent access control). The rules now invert the default:
+  reject only when a specific mitigating control can be named (a guard clause, a
+  parameterized query, an `access_control` rule, a framework default) or the
+  pattern is absent; when the pattern is present but exploitability is
+  uncertain, the reviewer accepts it with a downgraded severity (down to `info`)
+  and records the missing evidence in `reviewer_notes` instead of rejecting. The
+  false-positive playbook — which rejects against concrete Symfony mitigations —
+  is unchanged, so precision on known-safe patterns is preserved.
+
 ### Fixed
 
 - **Attacker prompt no longer contradicts itself in the default

--- a/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
@@ -95,7 +95,8 @@ final readonly class ReviewerPromptBuilder implements ReviewerPromptBuilderInter
 
     private const string DECISION_RULES = <<<'RULES'
         Rules:
-        - Be strict: reject any finding where exploitation is not clearly demonstrated
+        - Reject a finding ONLY when you can name a specific mitigating control (a guard clause, a parameterized query, an `access_control` rule, a framework default) or the vulnerable pattern is simply not present in the code. "Not clearly exploitable" is not, by itself, grounds to reject — that erases real-but-hard-to-prove issues (race conditions, business-logic flaws, context-dependent access control) that SAST tools already miss.
+        - When the vulnerable pattern is genuinely present but exploitability is uncertain, do NOT reject: accept it and downgrade the severity (down to `info` for pure defense-in-depth), and state what evidence is missing in `reviewer_notes`. A downstream human triage step ranks accepted findings, so preserving an uncertain finding is cheaper than discarding a real one.
         - Accept a finding if it represents a REAL risk, even if exploitation is complex
         - You MAY upgrade severity if context reveals a worse impact
         - You MAY downgrade if the scanner overstated impact

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
@@ -183,6 +183,41 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString('authenticator_bypass', $prompt);
     }
 
+    public function test_decision_rules_restrict_rejection_to_a_named_mitigating_control(): void
+    {
+        $prompt = $this->reviewerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString(
+            'Reject a finding ONLY when you can name a specific mitigating control',
+            $prompt,
+        );
+        self::assertStringContainsString(
+            '"Not clearly exploitable" is not, by itself, grounds to reject',
+            $prompt,
+        );
+    }
+
+    public function test_decision_rules_preserve_uncertain_findings_via_downgrade(): void
+    {
+        $prompt = $this->reviewerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString(
+            'do NOT reject: accept it and downgrade the severity',
+            $prompt,
+        );
+        self::assertStringContainsString('state what evidence is missing in `reviewer_notes`', $prompt);
+    }
+
+    public function test_batch_decision_rules_restrict_rejection_to_a_named_mitigating_control(): void
+    {
+        $prompt = $this->reviewerPromptBuilder->buildBatchSystemPrompt();
+
+        self::assertStringContainsString(
+            'Reject a finding ONLY when you can name a specific mitigating control',
+            $prompt,
+        );
+    }
+
     #[DataProvider('vulnerabilityTypeValues')]
     public function test_system_prompt_lists_every_vulnerability_type_as_corrected_type(string $typeValue): void
     {
@@ -247,7 +282,7 @@ final class ReviewerPromptBuilderTest extends TestCase
         $playbookPos = strpos($prompt, 'false-positive playbook');
         $outputDirectivePos = strpos($prompt, 'one entry per vulnerability reviewed');
         $schemaPos = strpos($prompt, 'Each entry of the JSON array MUST be shaped');
-        $rulesPos = strpos($prompt, 'Be strict: reject any finding');
+        $rulesPos = strpos($prompt, 'Reject a finding ONLY when');
 
         self::assertNotFalse($personaPos);
         self::assertNotFalse($rubricPos);
@@ -274,7 +309,7 @@ final class ReviewerPromptBuilderTest extends TestCase
         $outputDirectivePos = strpos($prompt, 'EXACTLY one entry per input vulnerability');
         $schemaPos = strpos($prompt, 'Each entry of the JSON array MUST be shaped');
         $orderingHintPos = strpos($prompt, 're-keyed by "id" when we parse your response');
-        $rulesPos = strpos($prompt, 'Be strict: reject any finding');
+        $rulesPos = strpos($prompt, 'Reject a finding ONLY when');
 
         self::assertNotFalse($personaPos);
         self::assertNotFalse($batchPreamblePos);


### PR DESCRIPTION
## Summary

The reviewer's decision rules opened with _"Be strict: reject any finding where
exploitation is not clearly demonstrated"_. Current-generation models follow
strictness filters literally, so this depressed recall: real-but-hard-to-prove
issues (race conditions, business-logic flaws, context-dependent access control)
— precisely what the dual-agent auditor exists to surface — were silently
rejected.

The decision rules now invert the default posture:

- **Reject only with a named mitigation** (a guard clause, a parameterized
  query, an `access_control` rule, a framework default) or when the pattern is
  absent. "Not clearly exploitable" is no longer grounds to reject on its own.
- **Accept-with-downgrade for uncertain findings** — accept and downgrade
  severity (down to `info`), recording the missing evidence in `reviewer_notes`,
  leaving final ranking to human triage.

The false-positive playbook is untouched, so precision on known-safe Symfony
patterns is preserved. The two order tests that anchored on the removed
"Be strict" sentence now anchor on the new rules lead-in.

SemVer: minor (`@internal` builder; behaviour improvement). `CHANGELOG.md`
updated under `[Unreleased] → Changed`.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01MFGywTi6aU5t2SLUy4ZTxj