### PR TITLE
fix(llm): estimate Fable and Mythos tokens with their denser tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   listed, and a regression test asserts every `VulnerabilityType` case appears
   in both the attacker and reviewer prompts so the two enumerations cannot drift
   apart again.
+- **`audit:run --dry-run` no longer undercounts tokens for Claude Fable 5 /
+  Mythos 5.** `CharacterBasedTokenEstimator`
+  (`src/Audit/Infrastructure/LLM/CharacterBasedTokenEstimator.php`) matched
+  `claude-fable-5` and `claude-mythos-5` against the generic `claude-` prefix
+  (3.5 characters per token), but those models ship a new tokenizer that emits
+  roughly 30% more tokens for the same text. The estimate was therefore about a
+  third too low, which flows straight into the dry-run cost figure. Two
+  more-specific prefixes (`claude-fable`, `claude-mythos`) are now matched ahead
+  of `claude-` with a denser 2.7-characters-per-token ratio, so the dry-run
+  estimate reflects the real token count. Non-Fable Claude models are unchanged.
 
 ## [1.8.0] — 2026-06-11 — Fable
 

--- a/src/Audit/Infrastructure/LLM/CharacterBasedTokenEstimator.php
+++ b/src/Audit/Infrastructure/LLM/CharacterBasedTokenEstimator.php
@@ -22,6 +22,8 @@ final readonly class CharacterBasedTokenEstimator implements TokenEstimatorInter
 {
     public const float CHARS_PER_TOKEN_CLAUDE = 3.5;
 
+    public const float CHARS_PER_TOKEN_CLAUDE_FABLE = 2.7;
+
     public const float CHARS_PER_TOKEN_GPT = 4.0;
 
     public const float CHARS_PER_TOKEN_GEMINI = 3.8;
@@ -43,6 +45,8 @@ final readonly class CharacterBasedTokenEstimator implements TokenEstimatorInter
      * @var list<array{prefix: string, charsPerToken: float}>
      */
     private const array DEFAULT_RATIOS = [
+        ['prefix' => 'claude-fable', 'charsPerToken' => self::CHARS_PER_TOKEN_CLAUDE_FABLE],
+        ['prefix' => 'claude-mythos', 'charsPerToken' => self::CHARS_PER_TOKEN_CLAUDE_FABLE],
         ['prefix' => 'claude-', 'charsPerToken' => self::CHARS_PER_TOKEN_CLAUDE],
         ['prefix' => 'gpt-', 'charsPerToken' => self::CHARS_PER_TOKEN_GPT],
         ['prefix' => 'o3', 'charsPerToken' => self::CHARS_PER_TOKEN_GPT],

--- a/tests/Phpunit/Unit/Infrastructure/LLM/CharacterBasedTokenEstimatorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/CharacterBasedTokenEstimatorTest.php
@@ -54,6 +54,8 @@ final class CharacterBasedTokenEstimatorTest extends TestCase
     public static function modelDivisorCases(): iterable
     {
         yield 'claude_uses_claude_divisor' => ['claude-opus-4-7', 29];
+        yield 'claude_fable_uses_denser_fable_divisor' => ['claude-fable-5', 38];
+        yield 'claude_mythos_uses_denser_fable_divisor' => ['claude-mythos-5', 38];
         yield 'gpt_uses_gpt_divisor' => ['gpt-4o', 25];
         yield 'o3_uses_gpt_divisor' => ['o3', 25];
         yield 'o4_uses_gpt_divisor' => ['o4-mini', 25];


### PR DESCRIPTION
## Summary

`CharacterBasedTokenEstimator` matched `claude-fable-5` and `claude-mythos-5`
against the generic `claude-` prefix (3.5 chars/token). Those models ship a new
tokenizer that emits ~30% more tokens for the same text, so the heuristic was
about a third too low — and that error flows straight into the `audit:run
--dry-run` cost figure (Fable is in the pricing table as of 1.8.0, so the
estimate is otherwise treated as authoritative).

Fix: add `CHARS_PER_TOKEN_CLAUDE_FABLE = 2.7` (≈ 3.5 / 1.3) and register
`claude-fable` / `claude-mythos` prefixes **ahead of** `claude-` in
`DEFAULT_RATIOS` (first-match-wins). Non-Fable Claude models keep the 3.5 ratio.

SemVer: patch. `CharacterBasedTokenEstimator` is `@internal`; the behaviour
change is a more accurate estimate only. `CHANGELOG.md` updated under
`[Unreleased] → Fixed`.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01MFGywTi6aU5t2SLUy4ZTxj