### PR TITLE
docs(faq): add per-agent reasoning-effort / thinking guidance

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -286,6 +286,45 @@ The Attacker has the harder job (discover vulnerabilities). The Reviewer's job
 model. Pairing Opus + Haiku saves ~20× on the Reviewer phase with no accuracy
 loss in practice.
 
+### How should I set reasoning effort / thinking per agent?
+
+The two agents want opposite trade-offs, so tune them independently with the
+split-model setup above plus per-agent model options (see
+[Configuration → Model Options](configuration.md#model-options)):
+
+- **Attacker — favour capability and reasoning depth.** It runs a long-horizon,
+  recall-sensitive search across the whole codebase, so it benefits from a more
+  capable model and higher reasoning effort. On models that expose an `effort`
+  option (e.g. Claude Opus 4.7+/Fable 5, where `high`/`xhigh` are the sweet spot
+  for this kind of work) or an adaptive `thinking` option, set it on the
+  attacker:
+
+  ```yaml
+  symfony_security_auditor:
+      attacker_model:
+          name: 'claude-opus-4-8'
+          options:
+              effort: 'high'
+      reviewer_model:
+          name: 'claude-haiku-4-5-20251001'
+  ```
+
+- **Reviewer — favour speed.** It validates one finding against context you
+  already hand it, so a faster, cheaper model at lower effort is usually enough;
+  spend the budget on the attacker instead.
+
+A note on recall: recent Claude models follow strict instructions literally, so
+at the _finding_ stage you want coverage, not premature filtering — the reviewer
+is where findings are adjudicated and ranked. Forcing the attacker into a very
+low effort or an aggressively terse budget can suppress the multi-step reasoning
+that surfaces business-logic and access-control flaws, which is exactly the
+class of issue this tool exists to find.
+
+> Which option keys are accepted (`effort`, `thinking`, …) depends on the
+> provider and model behind `symfony/ai`. Unknown options are passed straight
+> through to the provider, so check your provider's documentation; this bundle
+> does not validate them.
+
 ### Can I tune model parameters (temperature, max_tokens)?
 
 Yes. For `max_tokens`, use the dedicated bundle key — it defaults to `4096` and


### PR DESCRIPTION
## Summary

The Model Selection FAQ covered split-model and `model.options` passthrough but
never said how to set reasoning effort per agent — a direct cost-and-detection
lever. Adds a `### How should I set reasoning effort / thinking per agent?`
section to `docs/faq.md`:

- **Attacker** — higher capability + reasoning effort (the recall-sensitive,
  long-horizon search), with a worked `attacker_model.options.effort: high`
  example.
- **Reviewer** — faster/cheaper, lower effort (validates against provided
  context).
- A recall note: recent models follow strict instructions literally, so don't
  starve the attacker's reasoning at the finding stage — the reviewer is where
  findings are filtered.
- A caveat that accepted option keys (`effort`, `thinking`, …) depend on the
  `symfony/ai` provider; this bundle passes them through unvalidated.

Links to the existing `Configuration → Model Options` / `Split-Model Setup`
anchors (both verified present). Docs-only — changelog-exempt per
`.claude/rules/changelog.md`.

## Type of change

- [x] Documentation

## Checklist

- [ ] Tests added or updated (unit + integration where applicable) — N/A,
      docs-only; no source or test files touched
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — unaffected
      (no source change)
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise) — N/A
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01MFGywTi6aU5t2SLUy4ZTxj