### PR TITLE
feat(prompt): mark firewall-covered routes in the attacker route map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   more-specific prefixes (`claude-fable`, `claude-mythos`) are now matched ahead
   of `claude-` with a denser 2.7-characters-per-token ratio, so the dry-run
   estimate reflects the real token count. Non-Fable Claude models are unchanged.
+- **The attacker's Route Access-Control Map now flags firewall-covered routes
+  instead of mislabelling them as unprotected.** `AttackerPromptBuilder`
+  (`src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php`) rendered every
+  controller action with no `#[IsGranted]` / `denyAccessUnlessGranted()` as
+  `LACKS_ACCESS_CHECK`, even when a `security.yaml` `access_control` rule
+  already gated the route path — so the attacker flagged it as
+  `broken_access_control` and the reviewer then spent tool calls (or, in batch
+  mode, lacked the tools) rediscovering the firewall rule. The map now
+  cross-references each route path against the `access_control` patterns already
+  parsed into `SymfonyMapping::routeAccessMap()` and, on a match, tags the line
+  `COVERED_BY access_control[…]` with the gating roles, telling the model the
+  firewall protects it (unless the role is too permissive). This removes a whole
+  class of false positive at zero extra LLM cost. The attacker `PROMPT_VERSION`
+  is bumped `7` → `8`, invalidating previously cached responses.
 
 ## [1.8.0] — 2026-06-11 — Fable
 

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -27,7 +27,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 7;
+    public const int PROMPT_VERSION = 8;
 
     public const bool DEFAULT_STRUCTURED_COLLECTION = true;
 
@@ -390,8 +390,10 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             return '';
         }
 
+        $routeAccessMap = $symfonyMapping->routeAccessMap();
+
         $lines = ['## Route Access-Control Map'];
-        $lines[] = 'Each line describes a controller action: HTTP method(s), route path, source location, and the access-control surface (class- and method-level `#[IsGranted]`, `denyAccessUnlessGranted()` body calls). Lines marked at the end with the LACKS marker carry a route but no enforcement — treat them as primary candidates for `broken_access_control` and `missing_voter` findings unless a parent firewall covers them.';
+        $lines[] = 'Each line describes a controller action: HTTP method(s), route path, source location, and the access-control surface (class- and method-level `#[IsGranted]`, `denyAccessUnlessGranted()` body calls). A line whose surface is empty is tagged at the end: routes with no enforcement at all carry the LACKS marker — treat those as primary candidates for `broken_access_control` and `missing_voter`. Routes with no attribute or body check that nonetheless match a `security.yaml` `access_control` rule on their path carry a firewall-covered marker listing the gating roles — the firewall already protects them, so do NOT report `broken_access_control` there unless the gating role is too permissive for the action.';
 
         foreach ($routeAccessControls as $routeAccessControl) {
             $methods = [] === $routeAccessControl->routeMethods() ? 'ANY' : implode(',', $routeAccessControl->routeMethods());
@@ -409,11 +411,54 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
                 $checks[] = 'body:denyAccessUnlessGranted()';
             }
 
-            $checkLabel = [] === $checks ? 'LACKS_ACCESS_CHECK' : implode(' + ', $checks);
+            $checkLabel = $this->checkLabelFor($checks, $routeAccessControl->routePath(), $routeAccessMap);
             $lines[] = \sprintf('- %s %s — %s::%s — %s', $methods, $path, $routeAccessControl->filePath(), $routeAccessControl->methodName(), $checkLabel);
         }
 
         return implode("\n", $lines)."\n\n";
+    }
+
+    /**
+     * @param list<string>                $checks
+     * @param array<string, list<string>> $routeAccessMap
+     */
+    private function checkLabelFor(array $checks, ?string $routePath, array $routeAccessMap): string
+    {
+        if ([] !== $checks) {
+            return implode(' + ', $checks);
+        }
+
+        $firewallRoles = $this->firewallRolesForPath($routePath, $routeAccessMap);
+        if (null !== $firewallRoles) {
+            return 'COVERED_BY access_control['.implode(',', $firewallRoles).']';
+        }
+
+        return 'LACKS_ACCESS_CHECK';
+    }
+
+    /**
+     * Returns the roles of the first `security.yaml` `access_control` rule whose
+     * path pattern matches the route, or null when none matches. Symfony treats
+     * the `access_control` `path` as a regular expression, so it is matched as
+     * one; a malformed pattern simply fails to match rather than throwing.
+     *
+     * @param array<string, list<string>> $routeAccessMap
+     *
+     * @return list<string>|null
+     */
+    private function firewallRolesForPath(?string $routePath, array $routeAccessMap): ?array
+    {
+        if (null === $routePath) {
+            return null;
+        }
+
+        foreach ($routeAccessMap as $pattern => $roles) {
+            if (1 === @preg_match('#'.$pattern.'#', $routePath)) {
+                return $roles;
+            }
+        }
+
+        return null;
     }
 
     private function basePrompt(): string

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -79,6 +79,67 @@ final class AttackerPromptBuilderTest extends TestCase
         self::assertStringContainsString('LACKS_ACCESS_CHECK', $message);
     }
 
+    public function test_route_without_attribute_check_is_marked_covered_when_a_firewall_access_control_matches(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/AdminController.php',
+            '/app/src/Controller/AdminController.php',
+            '<?php class AdminController {}',
+        );
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/AdminController.php',
+            methodName: 'deleteUser',
+            routePath: '/admin/users/42',
+            routeMethods: ['DELETE'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        $symfonyMapping = SymfonyMapping::create(
+            controllers: [$projectFile],
+            routeAccessMap: ['^/admin' => ['ROLE_ADMIN', 'ROLE_SUPER_ADMIN']],
+            routeAccessControls: [$routeAccessControl],
+        );
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        // Two roles pin the comma separator in the rendered marker.
+        self::assertStringContainsString('COVERED_BY access_control[ROLE_ADMIN,ROLE_SUPER_ADMIN]', $message);
+        self::assertStringNotContainsString('LACKS_ACCESS_CHECK', $message);
+    }
+
+    public function test_route_without_attribute_check_still_lacks_when_no_firewall_access_control_matches(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/PublicController.php',
+            '/app/src/Controller/PublicController.php',
+            '<?php class PublicController {}',
+        );
+        $routeAccessControl = new RouteAccessControl(
+            filePath: 'src/Controller/PublicController.php',
+            methodName: 'show',
+            routePath: '/blog/42',
+            routeMethods: ['GET'],
+            hasRouteAttribute: true,
+            methodLevelIsGranted: [],
+            methodHasDenyAccess: false,
+            classHasIsGranted: false,
+        );
+
+        $symfonyMapping = SymfonyMapping::create(
+            controllers: [$projectFile],
+            routeAccessMap: ['^/admin' => ['ROLE_ADMIN']],
+            routeAccessControls: [$routeAccessControl],
+        );
+
+        $message = $this->attackerPromptBuilder->buildUserMessage([$projectFile], $symfonyMapping);
+
+        self::assertStringContainsString('LACKS_ACCESS_CHECK', $message);
+        self::assertStringNotContainsString('COVERED_BY access_control', $message);
+    }
+
     public function test_user_message_renders_access_check_labels_for_protected_action(): void
     {
         $projectFile = ProjectFile::create(
@@ -790,7 +851,7 @@ final class AttackerPromptBuilderTest extends TestCase
 
     public function test_prompt_version_is_bumped_when_modern_symfony_skill_blocks_are_added(): void
     {
-        self::assertSame(7, AttackerPromptBuilder::PROMPT_VERSION);
+        self::assertSame(8, AttackerPromptBuilder::PROMPT_VERSION);
     }
 
     #[DataProvider('vulnerabilityTypeValues')]


### PR DESCRIPTION
## Summary

The attacker's Route Access-Control Map rendered every controller action with no
`#[IsGranted]` / `denyAccessUnlessGranted()` as `LACKS_ACCESS_CHECK` — even when
a `security.yaml` `access_control` rule already gated the route path. The
attacker then flagged a `broken_access_control` finding and the reviewer spent
tool calls (or, in batch mode, had no tools) rediscovering the firewall rule
before rejecting it: a recurring false-positive + wasted-budget pattern.

`SymfonyMapping` already parses `access_control` rules into `routeAccessMap()`
(path-pattern → roles). The map now cross-references each route path against
those patterns (Symfony treats `access_control` `path` as a regex, so it's
matched as one; a malformed pattern simply fails to match rather than throwing)
and, on a match, tags the line `COVERED_BY access_control[…]` with the gating
roles, telling the model not to report `broken_access_control` there unless the
role is too permissive. Zero extra LLM cost — it reuses mapping data already in
the prompt. `PROMPT_VERSION` is bumped `7` → `8` to invalidate cached responses
(rebased on top of #41, which already took `6` → `7`).

Deliberately surgical: it reuses the existing regex-based `access_control` parse
rather than rewriting `MappingStage` to use `symfony/yaml` (worth a separate
PR).

SemVer: minor (`@internal` builder; behaviour improvement). `CHANGELOG.md` under
`[Unreleased] → Changed`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / internal improvement
- [ ] Documentation
- [ ] Tests only

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01MFGywTi6aU5t2SLUy4ZTxj