### PR TITLE
docs: rename Ollama platform option host_url to endpoint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,7 +299,7 @@ ai:
     # meta:
     #   api_key: '%env(META_API_KEY)%'
     # ollama:
-    #   host_url: 'http://localhost:11434'
+    #   endpoint: 'http://localhost:11434'
 ```
 
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -240,7 +240,7 @@ locally pulled model:
 ai:
   platform:
     ollama:
-      host_url: 'http://localhost:11434'
+      endpoint: 'http://localhost:11434'
 
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:

--- a/examples/configs/dev-fast.yaml
+++ b/examples/configs/dev-fast.yaml
@@ -5,7 +5,7 @@
 #   ai:
 #     platform:
 #       ollama:
-#         host_url: 'http://localhost:11434'
+#         endpoint: 'http://localhost:11434'
 #
 # Drop in as: config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:

--- a/examples/vulnerable-app/config/packages/ai.yaml
+++ b/examples/vulnerable-app/config/packages/ai.yaml
@@ -4,6 +4,6 @@ ai:
             api_key: '%env(ANTHROPIC_API_KEY)%'
         # Swap to any other platform without touching PHP.
         # ollama:
-        #     host_url: 'http://localhost:11434'
+        #     endpoint: 'http://localhost:11434'
         # openai:
         #     api_key: '%env(OPENAI_API_KEY)%'


### PR DESCRIPTION
Fixes #51
Supersedes #52 — thanks @kkevindev for spotting and reporting this!

## Summary

symfony/ai-bundle rejects `host_url` under `ai.platform.ollama`:

```text
Unrecognized option "host_url" under "ai.platform.ollama". Available options are "api_key", "endpoint", "http_client"
```

The accepted option is `endpoint` (verified against the bundle's `AiBundle.php`, which passes `$platform['endpoint']` to `OllamaFactory::createPlatform()`).

#52 fixed the occurrence in `docs/faq.md`; this PR fixes all four so the broken key can't be copy-pasted from elsewhere:

- `docs/faq.md` — "Can I run it fully offline?" example
- `docs/configuration.md` — supported-platforms reference
- `examples/configs/dev-fast.yaml` — commented Ollama pairing
- `examples/vulnerable-app/config/packages/ai.yaml` — commented platform swap

No `CHANGELOG.md` entry per `.claude/rules/changelog.md` (docs/examples only).

## Type of change

- [x] Documentation

## Checklist

- [ ] Tests added or updated (unit + integration where applicable) — n/a, docs only
- [x] All checks pass: `bin/castor lint`
- [ ] 100% MSI maintained: `docker compose exec php bin/infection` — n/a, docs only
- [ ] No `createMock` without a matching `expects()` (use `createStub` otherwise) — n/a
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01HdGxGUzZ1DestVUEqVxdSU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdGxGUzZ1DestVUEqVxdSU)_