### PR TITLE
feat(report): list vulnerabilities most-severe-first in every output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Changed
 
+- **Reports now list vulnerabilities most-severe-first.** `AuditReport`
+  (`src/Audit/Domain/Model/AuditReport.php`) kept vulnerabilities in discovery
+  order, so a lone high-severity finding could sit buried between medium and low
+  ones and readers had to scroll the whole list to find it
+  ([#40](https://github.com/vinceAmstoutz/symfony-security-auditor/issues/40)).
+  The report now orders findings by descending `VulnerabilitySeverity::score()`
+  — critical → high → medium → low → info, ties keeping discovery order — so the
+  console listing, the `--format=json` `vulnerabilities` array, and the SARIF
+  `results` array all lead with the most severe findings.
 - **Reviewer no longer drops real-but-hard-to-prove findings.** The reviewer
   decision rules in `ReviewerPromptBuilder`
   (`src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php`) opened with

--- a/src/Audit/Domain/Model/AuditReport.php
+++ b/src/Audit/Domain/Model/AuditReport.php
@@ -36,8 +36,23 @@ final readonly class AuditReport
         ?AuditCost $auditCost,
         Vulnerability ...$vulnerabilities,
     ) {
-        $this->vulnerabilities = array_values($vulnerabilities);
+        $this->vulnerabilities = $this->orderedMostSevereFirst(array_values($vulnerabilities));
         $this->auditCost = $auditCost ?? AuditCost::zero('');
+    }
+
+    /**
+     * @param list<Vulnerability> $vulnerabilities
+     *
+     * @return list<Vulnerability>
+     */
+    private function orderedMostSevereFirst(array $vulnerabilities): array
+    {
+        usort(
+            $vulnerabilities,
+            static fn (Vulnerability $left, Vulnerability $right): int => $right->severity()->score() <=> $left->severity()->score(),
+        );
+
+        return $vulnerabilities;
     }
 
     public static function fromContext(AuditContext $auditContext, ?AuditCost $auditCost = null): self

--- a/tests/Phpunit/Unit/Domain/Model/AuditReportTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditReportTest.php
@@ -108,6 +108,56 @@ final class AuditReportTest extends TestCase
         self::assertCount(0, $auditReport->vulnerabilitiesByType(VulnerabilityType::SSRF));
     }
 
+    public function test_vulnerabilities_are_ordered_most_severe_first(): void
+    {
+        $auditContext = AuditContext::forProject($this->tmpDir);
+
+        $discoveryOrder = [
+            VulnerabilitySeverity::LOW,
+            VulnerabilitySeverity::INFO,
+            VulnerabilitySeverity::CRITICAL,
+            VulnerabilitySeverity::MEDIUM,
+            VulnerabilitySeverity::HIGH,
+        ];
+        foreach ($discoveryOrder as $index => $severity) {
+            $auditContext->addVulnerability(
+                $this->makeVulnerability('order'.$index, $severity)->withReviewerValidation(true),
+            );
+        }
+
+        $severities = array_map(
+            static fn (Vulnerability $vulnerability): VulnerabilitySeverity => $vulnerability->severity(),
+            AuditReport::fromContext($auditContext)->vulnerabilities(),
+        );
+
+        self::assertSame(
+            [
+                VulnerabilitySeverity::CRITICAL,
+                VulnerabilitySeverity::HIGH,
+                VulnerabilitySeverity::MEDIUM,
+                VulnerabilitySeverity::LOW,
+                VulnerabilitySeverity::INFO,
+            ],
+            $severities,
+        );
+    }
+
+    public function test_vulnerabilities_with_equal_severity_keep_discovery_order(): void
+    {
+        $auditContext = AuditContext::forProject($this->tmpDir);
+
+        $auditContext->addVulnerability($this->makeVulnerability('firstHigh', VulnerabilitySeverity::HIGH)->withReviewerValidation(true));
+        $auditContext->addVulnerability($this->makeVulnerability('low', VulnerabilitySeverity::LOW)->withReviewerValidation(true));
+        $auditContext->addVulnerability($this->makeVulnerability('secondHigh', VulnerabilitySeverity::HIGH)->withReviewerValidation(true));
+
+        $filePaths = array_map(
+            static fn (Vulnerability $vulnerability): string => $vulnerability->filePath(),
+            AuditReport::fromContext($auditContext)->vulnerabilities(),
+        );
+
+        self::assertSame(['src/firstHigh.php', 'src/secondHigh.php', 'src/low.php'], $filePaths);
+    }
+
     public function test_it_serializes_to_array(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);

--- a/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
@@ -129,6 +129,20 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('VULNERABILITIES', $output);
     }
 
+    public function test_render_console_lists_vulnerabilities_most_severe_first(): void
+    {
+        $vulnerability = $this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::LOW, filePath: 'src/Low.php');
+        $critical = $this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::CRITICAL, filePath: 'src/Critical.php');
+
+        $output = $this->reportRenderer->renderConsole($this->makeReport($vulnerability, $critical));
+
+        $criticalPosition = strpos($output, 'src/Critical.php');
+        $lowPosition = strpos($output, 'src/Low.php');
+        self::assertNotFalse($criticalPosition);
+        self::assertNotFalse($lowPosition);
+        self::assertLessThan($lowPosition, $criticalPosition);
+    }
+
     public function test_render_console_with_vulnerabilities_skips_no_findings_message(): void
     {
         $output = $this->reportRenderer->renderConsole($this->makeReport($this->makeValidatedVuln()));


### PR DESCRIPTION
Closes #40

## What

Reports listed vulnerabilities in discovery order, so a lone high-severity finding could sit buried between medium and low ones — readers had to scroll the whole list to find what matters most.

`AuditReport` now orders its findings by descending `VulnerabilitySeverity::score()` at construction time: critical → high → medium → low → info, with ties keeping discovery order (`usort` is stable). Because the sort lives in the Domain model, every output format benefits at once:

- the console `VULNERABILITIES` listing,
- the `--format=json` `vulnerabilities` array (`AuditReport::toArray()`),
- the SARIF `results` array.

## Notes

- SemVer: **MINOR** — no public API removed or altered; the JSON/SARIF schemas documented in `docs/versioning.md` make no ordering guarantee, and all keys/fields are unchanged. `CHANGELOG.md` entry added under `## [Unreleased]` → `### Changed`.
- Domain stays pure PHP (plain `usort`, no new imports).

## Verification

All quality gates run locally on this branch:

- PHPUnit: 1777 tests green (new: ordering, severity-tie stability, console render order)
- Infection: **100% MSI / 100% covered MSI** (full run, 12m18s)
- PHPStan (max), PHP CS Fixer, Rector: clean
- Prettier + markdownlint + composer normalize: clean
- commitlint: header validated

https://claude.ai/code/session_01BGtQEBPhVatT5LZtqCQ976

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGtQEBPhVatT5LZtqCQ976)_