### PR TITLE
feat(command): surface live audit-stage progress and a long-run notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
+- **Live audit-stage progress and an upfront long-run notice in the console.**
+  During the audit stage — by far the longest — the progress bar sat frozen at
+  the same percentage with no sign the run was still alive, sometimes for 20+
+  minutes
+  ([#39](https://github.com/vinceAmstoutz/symfony-security-auditor/issues/39)).
+  `audit:run` (console format only) now prints a note above the progress bar
+  warning that the audit typically takes several minutes, and the bar message
+  updates continuously with the current activity, e.g.
+  `audit · iteration 1/3 · attacker chunk 4/12` and
+  `audit · iteration 1/3 · reviewing 4 finding(s)`. Three new wire-format
+  progress events back this: `audit.iteration.started` and `review.started`
+  (emitted by `AuditOrchestrator`) and `attacker.chunk.started` (emitted by
+  `AttackerAgent`), all flowing through the existing `ProgressReporterInterface`
+  port and rendered by `ConsoleProgressReporter`
+  (`src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php`).
+  Machine-readable stdout (`--format=json|sarif` without `--output`) stays clean
+  — neither the notice nor the bar is emitted there.
 - **The attacker now learns which findings the reviewer already rejected.**
   After the first iteration, `AuditOrchestrator`
   (`src/Audit/Application/Agent/AuditOrchestrator.php`) collected only the

--- a/config/services.php
+++ b/config/services.php
@@ -231,6 +231,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('logger'),
             param('symfony_security_auditor.audit.max_iterations'),
             param('symfony_security_auditor.audit.min_confidence'),
+            service(ProgressReporterInterface::class),
         ]);
     $defaultsConfigurator->alias(AuditOrchestratorInterface::class, AuditOrchestrator::class);
 
@@ -356,6 +357,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             null,
             service(RecordVulnerabilityToolFactoryInterface::class),
             param('symfony_security_auditor.audit.structured_collection'),
+            service(ProgressReporterInterface::class),
         ]);
 
     $defaultsConfigurator->alias(AttackerAgentInterface::class, AttackerAgent::class);

--- a/src/Audit/Application/Agent/AttackerAgent.php
+++ b/src/Audit/Application/Agent/AttackerAgent.php
@@ -20,6 +20,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunking\FileCh
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\LLMProviderException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AgentRole;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProgressEvent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityHydrationResult;
@@ -28,9 +29,11 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerCacheInterfac
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerPromptBuilderInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CodeSlicerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\StaticPreScannerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistryFactoryInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\NullProgressReporter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullCodeSlicer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\NullStaticPreScanner;
 
@@ -55,6 +58,8 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
     private AttackerContextPromptRenderer $attackerContextPromptRenderer;
 
+    private ProgressReporterInterface $progressReporter;
+
     public function __construct(
         private LLMClientInterface $llmClient,
         private AttackerPromptBuilderInterface $attackerPromptBuilder,
@@ -71,11 +76,13 @@ final readonly class AttackerAgent implements AttackerAgentInterface
         ?AttackerContextPromptRenderer $attackerContextPromptRenderer = null,
         private ?RecordVulnerabilityToolFactoryInterface $recordVulnerabilityToolFactory = null,
         private bool $useStructuredCollection = self::DEFAULT_STRUCTURED_COLLECTION,
+        ?ProgressReporterInterface $progressReporter = null,
     ) {
         $this->staticPreScanner = $staticPreScanner ?? new NullStaticPreScanner();
         $this->fileChunker = $fileChunker ?? new FileChunker();
         $this->codeSlicer = $codeSlicer ?? new NullCodeSlicer();
         $this->attackerContextPromptRenderer = $attackerContextPromptRenderer ?? new AttackerContextPromptRenderer();
+        $this->progressReporter = $progressReporter ?? new NullProgressReporter();
     }
 
     /**
@@ -123,6 +130,10 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
         foreach ($chunks as $index => $chunk) {
             $this->logger->debug(\sprintf('Analyzing chunk %d/%d', $index + 1, \count($chunks)));
+            $this->progressReporter->report(ProgressEvent::AttackerChunkStarted->value, [
+                'chunk' => $index + 1,
+                'total_chunks' => \count($chunks),
+            ]);
 
             $chunkResult = $this->analyzeChunk($chunk, $attackerAnalysisRequest, $coverageRecorder, $toolRegistry, $riskMarkerIndex);
             $allVulnerabilities = [...$allVulnerabilities, ...$chunkResult->vulnerabilities()];

--- a/src/Audit/Application/Agent/AuditOrchestrator.php
+++ b/src/Audit/Application/Agent/AuditOrchestrator.php
@@ -15,8 +15,11 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent;
 
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProgressEvent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\NullProgressReporter;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditOrchestrator implements AuditOrchestratorInterface
@@ -25,13 +28,18 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
 
     public const float DEFAULT_MIN_CONFIDENCE = 0.6;
 
+    private ProgressReporterInterface $progressReporter;
+
     public function __construct(
         private AttackerAgentInterface $attackerAgent,
         private ReviewerAgentInterface $reviewerAgent,
         private LoggerInterface $logger,
         private int $maxIterations = self::DEFAULT_MAX_ITERATIONS,
         private float $minConfidence = self::DEFAULT_MIN_CONFIDENCE,
-    ) {}
+        ?ProgressReporterInterface $progressReporter = null,
+    ) {
+        $this->progressReporter = $progressReporter ?? new NullProgressReporter();
+    }
 
     public function orchestrate(AuditContext $auditContext): void
     {
@@ -53,6 +61,10 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
         do {
             ++$iteration;
             $this->logger->info(\sprintf('Audit iteration %d/%d', $iteration, $this->maxIterations));
+            $this->progressReporter->report(ProgressEvent::AuditIterationStarted->value, [
+                'iteration' => $iteration,
+                'max_iterations' => $this->maxIterations,
+            ]);
 
             $previousFindings = array_values($auditContext->validatedVulnerabilities());
             $rejectedFindings = $this->rejectedFindings($auditContext);
@@ -73,6 +85,9 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
                 break;
             }
 
+            $this->progressReporter->report(ProgressEvent::ReviewStarted->value, [
+                'findings' => \count($filtered),
+            ]);
             $reviewed = $this->reviewerAgent->review($filtered, $files, $auditContext, $auditContext->isCacheBypassed());
             $newFindings = $this->persistReviewedFindings(array_values($reviewed), $auditContext);
 

--- a/src/Audit/Domain/Model/ProgressEvent.php
+++ b/src/Audit/Domain/Model/ProgressEvent.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
 
-/** @internal not part of the BC promise — the enum *values* (`pipeline.started`, `stage.started`, `stage.completed`, `pipeline.completed`) are the wire-format event names carried through `ProgressReporterInterface::report()` and are stable, but the PHP enum itself is for internal use only. */
+/** @internal not part of the BC promise — the enum *values* (`pipeline.started`, `stage.started`, `stage.completed`, `pipeline.completed`, `audit.iteration.started`, `attacker.chunk.started`, `review.started`) are the wire-format event names carried through `ProgressReporterInterface::report()` and are stable, but the PHP enum itself is for internal use only. */
 enum ProgressEvent: string
 {
     case PipelineStarted = 'pipeline.started';
     case StageStarted = 'stage.started';
     case StageCompleted = 'stage.completed';
     case PipelineCompleted = 'pipeline.completed';
+    case AuditIterationStarted = 'audit.iteration.started';
+    case AttackerChunkStarted = 'attacker.chunk.started';
+    case ReviewStarted = 'review.started';
 }

--- a/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
@@ -36,6 +36,10 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
 {
     private ?ProgressBar $progressBar = null;
 
+    private string $stageName = '';
+
+    private string $iterationLabel = '';
+
     public function __construct(private readonly OutputInterface $output) {}
 
     /**
@@ -48,6 +52,9 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
             ProgressEvent::StageStarted => $this->onStageStarted($context),
             ProgressEvent::StageCompleted => $this->onStageCompleted(),
             ProgressEvent::PipelineCompleted => $this->onPipelineCompleted(),
+            ProgressEvent::AuditIterationStarted => $this->onAuditIterationStarted($context),
+            ProgressEvent::AttackerChunkStarted => $this->onAttackerChunkStarted($context),
+            ProgressEvent::ReviewStarted => $this->onReviewStarted($context),
             null => null,
         };
     }
@@ -65,7 +72,58 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
     /** @param array<string, mixed> $context */
     private function onStageStarted(array $context): void
     {
-        $this->progressBar?->setMessage(\is_string($context['stage'] ?? null) ? $context['stage'] : '');
+        $this->stageName = \is_string($context['stage'] ?? null) ? $context['stage'] : '';
+        $this->iterationLabel = '';
+        $this->updateMessage();
+    }
+
+    /** @param array<string, mixed> $context */
+    private function onAuditIterationStarted(array $context): void
+    {
+        $iteration = $context['iteration'] ?? null;
+        $maxIterations = $context['max_iterations'] ?? null;
+
+        if (!\is_int($iteration) || !\is_int($maxIterations)) {
+            return;
+        }
+
+        $this->iterationLabel = \sprintf('iteration %d/%d', $iteration, $maxIterations);
+        $this->updateMessage();
+    }
+
+    /** @param array<string, mixed> $context */
+    private function onAttackerChunkStarted(array $context): void
+    {
+        $chunk = $context['chunk'] ?? null;
+        $totalChunks = $context['total_chunks'] ?? null;
+
+        if (!\is_int($chunk) || !\is_int($totalChunks)) {
+            return;
+        }
+
+        $this->updateMessage(\sprintf('attacker chunk %d/%d', $chunk, $totalChunks));
+    }
+
+    /** @param array<string, mixed> $context */
+    private function onReviewStarted(array $context): void
+    {
+        $findings = $context['findings'] ?? null;
+
+        if (!\is_int($findings)) {
+            return;
+        }
+
+        $this->updateMessage(\sprintf('reviewing %d finding(s)', $findings));
+    }
+
+    private function updateMessage(string $detail = ''): void
+    {
+        $parts = array_filter(
+            [$this->stageName, $this->iterationLabel, $detail],
+            static fn (string $part): bool => '' !== $part,
+        );
+
+        $this->progressBar?->setMessage(implode(' · ', $parts));
         $this->progressBar?->display();
     }
 

--- a/src/Command/AuditCommand.php
+++ b/src/Command/AuditCommand.php
@@ -99,6 +99,7 @@ final readonly class AuditCommand
             $this->auditPresenter->runningSection($symfonyStyle);
 
             if (!$auditCommandInput->isMachineReadableToStdout()) {
+                $this->auditPresenter->longRunNotice($symfonyStyle);
                 $this->progressReporterHolder->setDelegate(new ConsoleProgressReporter($symfonyStyle));
             }
 

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -78,6 +78,11 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         $symfonyStyle->section('Running audit pipeline...');
     }
 
+    public function longRunNotice(SymfonyStyle $symfonyStyle): void
+    {
+        $symfonyStyle->note('The audit stage makes many LLM calls and typically takes several minutes — 20+ minutes on large projects. The progress bar below shows the current activity.');
+    }
+
     public function estimatingSection(SymfonyStyle $symfonyStyle): void
     {
         $symfonyStyle->section('Estimating audit cost (dry run)...');

--- a/src/Command/AuditPresenterInterface.php
+++ b/src/Command/AuditPresenterInterface.php
@@ -28,6 +28,8 @@ interface AuditPresenterInterface
 
     public function runningSection(SymfonyStyle $symfonyStyle): void;
 
+    public function longRunNotice(SymfonyStyle $symfonyStyle): void;
+
     public function estimatingSection(SymfonyStyle $symfonyStyle): void;
 
     public function dryRunResult(SymfonyStyle $symfonyStyle, AuditReport $auditReport): void;

--- a/src/SymfonySecurityAuditorBundle.php
+++ b/src/SymfonySecurityAuditorBundle.php
@@ -37,6 +37,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerCacheInterfac
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AttackerPromptBuilderInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CodeSlicerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ReviewerCacheInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\SecretScrubberInterface;
@@ -600,6 +601,7 @@ final class SymfonySecurityAuditorBundle extends AbstractBundle
                     null,
                     service(RecordVulnerabilityToolFactoryInterface::class),
                     $bundleConfiguration->audit->structuredCollection,
+                    service(ProgressReporterInterface::class),
                 ]);
 
             $services->set(EscalatingAttackerAgent::class)

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -351,13 +351,13 @@ final class AuditCommandEndToEndTest extends TestCase
 
     private function makeCommandTesterWithLLM(LLMClientInterface $attackerLLM, LLMClientInterface $reviewerLLM, bool $secretScrubbingEnabled = true): CommandTester
     {
+        $progressReporterHolder = new ProgressReporterHolder();
         $auditOrchestrator = new AuditOrchestrator(
-            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger()),
+            new AttackerAgent($attackerLLM, new AttackerPromptBuilder(), new VulnerabilityFactory(new NullLogger(), Validation::createValidator()), new NullAttackerCache(), new NullLogger(), progressReporter: $progressReporterHolder),
             new ReviewerAgent($reviewerLLM, new ReviewerPromptBuilder(), new NullLogger()),
             new NullLogger(),
+            progressReporter: $progressReporterHolder,
         );
-
-        $progressReporterHolder = new ProgressReporterHolder();
         $auditPipeline = new AuditPipeline(
             [
                 new IngestionStage(new ProjectFileScanner(new NullLogger()), new NullLogger()),
@@ -489,6 +489,39 @@ final class AuditCommandEndToEndTest extends TestCase
         ]);
 
         self::assertStringNotContainsString('3/3', $commandTester->getDisplay());
+    }
+
+    public function test_command_shows_audit_iteration_progress_in_console_format(): void
+    {
+        $this->createProjectDir();
+
+        $commandTester = $this->makeCommandTester('[]', '{}');
+        $commandTester->execute(['project-path' => $this->fixtureDir]);
+
+        self::assertStringContainsString('audit · iteration 1/3', $commandTester->getDisplay());
+    }
+
+    public function test_command_shows_long_run_notice_in_console_format(): void
+    {
+        $this->createProjectDir();
+
+        $commandTester = $this->makeCommandTester('[]', '{}');
+        $commandTester->execute(['project-path' => $this->fixtureDir]);
+
+        self::assertStringContainsString('20+ minutes', $commandTester->getDisplay());
+    }
+
+    public function test_command_suppresses_long_run_notice_in_machine_readable_stdout(): void
+    {
+        $this->createProjectDir();
+
+        $commandTester = $this->makeCommandTester('[]', '{}');
+        $commandTester->execute([
+            'project-path' => $this->fixtureDir,
+            '--format' => 'json',
+        ]);
+
+        self::assertStringNotContainsString('20+ minutes', $commandTester->getDisplay());
     }
 
     public function test_dry_run_with_machine_readable_json_format_suppresses_success_message(): void

--- a/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
@@ -54,6 +54,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\NullAttacker
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\TransientLLMFailureException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\AttackerPromptBuilder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool\RecordVulnerabilityTool;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Pipeline\Fixture\RecordingProgressReporter;
 
 #[AllowMockObjectsWithoutExpectations]
 final class AttackerAgentTest extends TestCase
@@ -1884,6 +1885,39 @@ final class AttackerAgentTest extends TestCase
         $this->callAnalyze($attackerAgent, $files, SymfonyMapping::create(), $coverageRecorder);
 
         self::assertSame([['stage' => 'attacker', 'file' => 'src/Controller/UserController.php', 'status' => 'analyzed']], $coverageRecorder->records);
+    }
+
+    public function test_it_reports_chunk_progress_for_each_chunk(): void
+    {
+        $files = [
+            $this->makeFile('src/Controller/A.php'),
+            $this->makeFile('src/Controller/B.php'),
+        ];
+
+        $llmClient = self::createStub(LLMClientInterface::class);
+        $llmClient->method('complete')->willReturn(LLMResponse::create('[]', 0, 0, 'claude', 'end_turn'));
+
+        $recordingProgressReporter = new RecordingProgressReporter();
+        $attackerAgent = new AttackerAgent(
+            llmClient: $llmClient,
+            attackerPromptBuilder: new AttackerPromptBuilder(),
+            vulnerabilityFactory: new VulnerabilityFactory(new NullLogger(), Validation::createValidator()),
+            attackerCache: new NullAttackerCache(),
+            logger: new NullLogger(),
+            fileChunker: new FileChunker(ChunkingStrategy::Type, 1),
+            useStructuredCollection: false,
+            progressReporter: $recordingProgressReporter,
+        );
+
+        $this->callAnalyze($attackerAgent, $files, SymfonyMapping::create(), new NullCoverageRecorder());
+
+        self::assertSame(
+            [
+                ['attacker.chunk.started', ['chunk' => 1, 'total_chunks' => 2]],
+                ['attacker.chunk.started', ['chunk' => 2, 'total_chunks' => 2]],
+            ],
+            $recordingProgressReporter->events,
+        );
     }
 
     private function makeStructuredCollectionAttackerAgent(LLMClientInterface $llmClient, ?AttackerCacheInterface $attackerCache = null): AttackerAgent

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -34,6 +34,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\NullAttacker
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\AttackerPromptBuilder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\ReviewerPromptBuilder;
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent\Fixture\RecordingAttackerAgent;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Pipeline\Fixture\RecordingProgressReporter;
 
 /**
  * Drives the orchestrator end-to-end via real AttackerAgent + ReviewerAgent,
@@ -742,12 +743,64 @@ final class AuditOrchestratorTest extends TestCase
         rmdir($this->tmpDir);
     }
 
+    public function test_it_reports_each_iteration_start_with_iteration_counts(): void
+    {
+        $attackerLlm = self::createStub(LLMClientInterface::class);
+        $reviewerLlm = self::createStub(LLMClientInterface::class);
+        $attackerLlm->method('complete')->willReturnOnConsecutiveCalls(
+            $this->attackerResponse([$this->vulnPayload(title: 'Vuln v1')]),
+            $this->emptyResponse(),
+        );
+        $reviewerLlm->method('complete')->willReturn($this->reviewerAcceptResponse());
+        $recordingProgressReporter = new RecordingProgressReporter();
+        $auditOrchestrator = $this->makeOrchestrator($attackerLlm, $reviewerLlm, recordingProgressReporter: $recordingProgressReporter);
+
+        $auditOrchestrator->orchestrate($this->makeContextWithMapping());
+
+        self::assertSame(
+            [
+                ['audit.iteration.started', ['iteration' => 1, 'max_iterations' => 3]],
+                ['audit.iteration.started', ['iteration' => 2, 'max_iterations' => 3]],
+            ],
+            array_values(array_filter(
+                $recordingProgressReporter->events,
+                static fn (array $event): bool => 'audit.iteration.started' === $event[0],
+            )),
+        );
+    }
+
+    public function test_it_reports_review_start_with_finding_count(): void
+    {
+        $attackerLlm = self::createStub(LLMClientInterface::class);
+        $reviewerLlm = self::createStub(LLMClientInterface::class);
+        $attackerLlm->method('complete')->willReturnOnConsecutiveCalls(
+            $this->attackerResponse([$this->vulnPayload(title: 'Vuln v1')]),
+            $this->emptyResponse(),
+        );
+        $reviewerLlm->method('complete')->willReturn($this->reviewerAcceptResponse());
+        $recordingProgressReporter = new RecordingProgressReporter();
+        $auditOrchestrator = $this->makeOrchestrator($attackerLlm, $reviewerLlm, recordingProgressReporter: $recordingProgressReporter);
+
+        $auditOrchestrator->orchestrate($this->makeContextWithMapping());
+
+        self::assertSame(
+            [
+                ['review.started', ['findings' => 1]],
+            ],
+            array_values(array_filter(
+                $recordingProgressReporter->events,
+                static fn (array $event): bool => 'review.started' === $event[0],
+            )),
+        );
+    }
+
     private function makeOrchestrator(
         LLMClientInterface $attackerLlm,
         LLMClientInterface $reviewerLlm,
         ?LoggerInterface $logger = null,
         int $maxIterations = AuditOrchestrator::DEFAULT_MAX_ITERATIONS,
         float $minConfidence = AuditOrchestrator::DEFAULT_MIN_CONFIDENCE,
+        ?RecordingProgressReporter $recordingProgressReporter = null,
     ): AuditOrchestrator {
         return new AuditOrchestrator(
             attackerAgent: new AttackerAgent(
@@ -765,6 +818,7 @@ final class AuditOrchestratorTest extends TestCase
             logger: $logger ?? new NullLogger(),
             maxIterations: $maxIterations,
             minConfidence: $minConfidence,
+            progressReporter: $recordingProgressReporter,
         );
     }
 

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -70,6 +70,19 @@ final class AuditPresenterTest extends TestCase
         self::assertStringContainsString('Unexpected error: Disk full', $display);
     }
 
+    public function test_long_run_notice_warns_that_the_audit_can_take_a_while(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->longRunNotice($symfonyStyle);
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('[NOTE]', $display);
+        self::assertStringContainsString('many LLM calls', $display);
+        self::assertStringContainsString('20+ minutes', $display);
+    }
+
     public function test_header_includes_project_path(): void
     {
         $bufferedOutput = new BufferedOutput();

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
@@ -129,6 +129,83 @@ final class ConsoleProgressReporterTest extends TestCase
         self::assertNotEmpty($rendered);
     }
 
+    public function test_audit_iteration_event_shows_iteration_in_bar_message(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['ingestion', 'mapping', 'audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('audit.iteration.started', ['iteration' => 1, 'max_iterations' => 3]);
+
+        self::assertStringContainsString('audit · iteration 1/3', $this->bufferedOutput->fetch());
+    }
+
+    public function test_attacker_chunk_event_shows_chunk_progress_in_bar_message(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('audit.iteration.started', ['iteration' => 2, 'max_iterations' => 3]);
+        $this->consoleProgressReporter->report('attacker.chunk.started', ['chunk' => 4, 'total_chunks' => 12]);
+
+        self::assertStringContainsString('audit · iteration 2/3 · attacker chunk 4/12', $this->bufferedOutput->fetch());
+    }
+
+    public function test_review_event_shows_finding_count_in_bar_message(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('audit.iteration.started', ['iteration' => 1, 'max_iterations' => 3]);
+        $this->consoleProgressReporter->report('review.started', ['findings' => 4]);
+
+        self::assertStringContainsString('audit · iteration 1/3 · reviewing 4 finding(s)', $this->bufferedOutput->fetch());
+    }
+
+    public function test_next_stage_clears_stale_iteration_label(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit', 'poc_synthesis']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('audit.iteration.started', ['iteration' => 1, 'max_iterations' => 3]);
+        $this->consoleProgressReporter->report('stage.completed');
+
+        $this->bufferedOutput->fetch();
+
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'poc_synthesis']);
+
+        $rendered = $this->bufferedOutput->fetch();
+        self::assertStringContainsString('poc_synthesis', $rendered);
+        self::assertStringNotContainsString('iteration', $rendered);
+    }
+
+    public function test_chunk_event_without_prior_iteration_omits_iteration_segment(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('attacker.chunk.started', ['chunk' => 1, 'total_chunks' => 2]);
+
+        self::assertStringContainsString('audit · attacker chunk 1/2', $this->bufferedOutput->fetch());
+    }
+
+    public function test_detail_events_with_malformed_context_keep_previous_message(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+
+        $this->bufferedOutput->fetch();
+
+        $this->consoleProgressReporter->report('audit.iteration.started', ['iteration' => 'one']);
+        $this->consoleProgressReporter->report('attacker.chunk.started', ['chunk' => 1]);
+        $this->consoleProgressReporter->report('review.started', []);
+
+        self::assertSame('', $this->bufferedOutput->fetch());
+    }
+
+    public function test_detail_events_before_pipeline_started_are_no_ops(): void
+    {
+        $this->consoleProgressReporter->report('audit.iteration.started', ['iteration' => 1, 'max_iterations' => 3]);
+        $this->consoleProgressReporter->report('attacker.chunk.started', ['chunk' => 1, 'total_chunks' => 2]);
+        $this->consoleProgressReporter->report('review.started', ['findings' => 2]);
+
+        self::assertSame('', $this->bufferedOutput->fetch());
+    }
+
     protected function setUp(): void
     {
         $this->bufferedOutput = new BufferedOutput();


### PR DESCRIPTION
Closes #39

## What

During the audit stage — by far the longest — the progress bar sat frozen at the same percentage for many minutes with no sign the run was still alive. This PR addresses both asks from the issue:

1. **Long-run notice above the progress bar.** `AuditCommand` now calls a new `AuditPresenter::longRunNotice()` (console mode only) before the bar starts: a `[NOTE]` that the audit typically takes several minutes, 20+ on large projects.
2. **Live progress during the audit stage.** The bar message now updates continuously with the current activity:

   ```
   2/3 [████████████░░░░░] 66% — audit · iteration 1/3 · attacker chunk 4/12
   2/3 [████████████░░░░░] 66% — audit · iteration 1/3 · reviewing 4 finding(s)
   ```

## How

Three new wire-format events on the existing `ProgressReporterInterface` port (no new seam):

- `audit.iteration.started` — emitted by `AuditOrchestrator` at the top of each attacker/reviewer iteration (`iteration`, `max_iterations`)
- `attacker.chunk.started` — emitted by `AttackerAgent` per chunk (`chunk`, `total_chunks`)
- `review.started` — emitted by `AuditOrchestrator` before the reviewer runs (`findings`)

`ConsoleProgressReporter` composes the bar message from `stage · iteration · detail`, clears stale iteration labels when the next stage starts, ignores malformed contexts, and stays a no-op before `pipeline.started`. Both agents take an optional `ProgressReporterInterface` defaulting to `NullProgressReporter` (same pattern as `AuditPipeline`), wired to the `ProgressReporterHolder` in `config/services.php` and in the escalation path's cheap attacker (`SymfonySecurityAuditorBundle`). Machine-readable stdout (`--format=json|sarif` without `--output`) stays clean — neither the notice nor the bar is emitted there (covered by E2E tests).

## Notes

- SemVer: **MINOR** — new behavior only; `ProgressEvent` gains cases (the existing event values are unchanged), all touched classes are `@internal`, and the agents' new constructor parameter is optional. `CHANGELOG.md` entry added under `## [Unreleased]` → `### Added`.
- Rebased onto `main` after #46/#49/#50/#54 landed; the only conflict was the reviewer call in `AuditOrchestrator` (new `bypassCache` argument), resolved keeping both changes.

## Verification

All quality gates re-run locally on the rebased branch:

- PHPUnit: 1850 tests green (new: reporter message composition/reset/malformed-context tests, orchestrator + attacker emission tests, presenter notice test, 3 E2E tests incl. suppression in machine-readable stdout)
- Infection: **100% MSI** (full run, 14m01s, `minMsi`/`minCoveredMsi` 100 enforced)
- PHPStan (max), PHP CS Fixer, Rector: clean
- Prettier + markdownlint + composer normalize: clean
- commitlint: header validated

https://claude.ai/code/session_01BGtQEBPhVatT5LZtqCQ976