### PR TITLE
ci: raise Infection per-mutant timeout to stop flaky mutation failures

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -6,7 +6,7 @@
         ]
     },
     "tmpDir": "var/infection",
-    "timeout": 60,
+    "timeout": 120,
     "maxTimeouts": 0,
     "timeoutsAsEscaped": true,
     "threads": 4,


### PR DESCRIPTION
## What

Raises Infection's per-mutant `timeout` from **60s → 120s** in `infection.json5`.

## Why

`main`'s CI (the #58 merge, run #248) failed the **Tests + Mutation (PHP 8.3, Symfony ^8.0)** cell at **MSI 99%** with **2 timed-out mutants**, both on the `max_tool_iterations` config node's `->min(1)` in `SymfonySecurityAuditorBundle.php`:

```
1) ...SymfonySecurityAuditorBundle.php:199  [M] DecrementInteger  → ->min(0)   (timed out)
2) ...SymfonySecurityAuditorBundle.php:199  [M] IncrementInteger  → ->min(2)   (timed out)
```

Those mutants are **killable** — `test_bundle_rejects_max_tool_iterations_below_one` and `test_bundle_accepts_max_tool_iterations_at_one` catch them, and they were killed on the PR runner. The failure is a **flaky timeout**: that config line is "covered" by every kernel-booting integration test, so for this mutant Infection runs the whole slow boot set, and under `--threads=max` contention on a slow runner it exceeds the 60s per-mutant cap. With `timeoutsAsEscaped: true`, a timeout counts against MSI → the run drops to 99% and fails.

## Why this is not a gate weakening

`minMsi` and `minCoveredMsi` stay at **100**, `timeoutsAsEscaped` stays **true**, and **no mutator is disabled or ignored**. Only the wall-clock budget for an individual mutant's (legitimately slow) covering tests is increased. Per the project's "never silence quality gates" rule, this is not a suppression — every mutant must still be killed; they just get enough time to run.

## SemVer / changelog

CI/tooling-only change → changelog-exempt.

## Follow-up (not in this PR)

If timeouts recur, the deeper fix is to make the config-boundary tests validate the tree via Symfony's `Processor` instead of full kernel boots, which would shrink each covered mutant's runtime from ~dozens of boots to milliseconds. Out of scope here — this PR just unblocks `main`.

https://claude.ai/code/session_01AgjEZA97se6Cth51y9xDTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgjEZA97se6Cth51y9xDTo)_