### PR TITLE
chore: release 1.10.1 - Encore 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.10.1] — 2026-06-15 — Encore
+
+A packaging-only republish of **1.10.0 — Lookout**. The `1.10.0` tag was first
+pushed to an incomplete commit and indexed by Packagist; moving the tag to the
+finished release commit was then refused by
+[Packagist's stable-version immutability rule](https://packagist.org/about#version-immutability)
+("Upstream re-tag blocked — Packagist's stored snapshot may no longer match what
+is currently in git"), which locks a published version's source/dist reference
+forever. This release republishes the full, intended Lookout contents under a
+fresh, unblocked version so
+`composer require vinceamstoutz/symfony-security-auditor` resolves the complete
+release. **There are no source changes relative to the intended 1.10.0** — see
+the [1.10.0](#1100--2026-06-15--lookout) entry below for the actual features and
+fixes. The config-schema URL and GitHub Action `uses:` pins move from `1.10.0`
+to `1.10.1` accordingly.
+
 ## [1.10.0] — 2026-06-15 — Lookout
 
 A reporting-and-CI release. Audits gain a self-contained, HTML-escaped report
@@ -1508,6 +1524,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.10.1]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.10.1
 [1.10.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.10.0
 [1.9.0]:

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ the recipe automates:
   findings fail CI.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.10.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.10.1`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **Zero-config CVE feed** — `lookup_advisory` is backed by `composer audit`

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -224,7 +224,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.10.0
+        uses: vinceamstoutz/symfony-security-auditor@1.10.1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,14 +55,14 @@ following keys:
 > config file:
 >
 > ```yaml
-> # yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.0/resources/schema.json
+> # yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
 > symfony_security_auditor:
 >     model: "claude-opus-4-8"
 > ```
 >
 > This gives key completion, type checking, and inline docs as you edit. The
 > example files under [`examples/configs/`](../examples/configs/) include the
-> modeline. The URL is pinned to the release tag (`…/1.10.0/…`) so the schema
+> modeline. The URL is pinned to the release tag (`…/1.10.1/…`) so the schema
 > matches the version you have installed — bump it when you upgrade the bundle.
 
 ### Top-level

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -84,7 +84,7 @@ is a `MAJOR` change.
   `MINOR`; renaming or removing one is a `MAJOR`. The Marketplace `name`
   (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.10.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.10.1` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/examples/configs/ci-optimized.yaml
+++ b/examples/configs/ci-optimized.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.0/resources/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
 # Scheduled CI run — split-model, cache + prompt caching enabled.
 #
 # Target: accuracy on a medium-to-large Symfony codebase, run nightly.

--- a/examples/configs/cost-aware.yaml
+++ b/examples/configs/cost-aware.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.0/resources/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
 # Triage scan — single small model, single iteration, tools disabled.
 #
 # Target: smallest possible bill for an initial pass on a large monorepo.

--- a/examples/configs/dev-fast.yaml
+++ b/examples/configs/dev-fast.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.0/resources/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
 # Local development scan — Ollama backend, no spend, exploratory recall.
 #
 # Pair with the following in config/packages/ai.yaml:

--- a/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
+++ b/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.0/resources/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
 symfony_security_auditor:
     attacker_model: 'claude-opus-4-7'
     reviewer_model: 'claude-haiku-4-5-20251001'

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",


### PR DESCRIPTION
## Why

The `1.10.0` tag was first pushed to an incomplete commit and indexed by Packagist. Moving the tag to the finished release commit (`753eadb`) was then **refused by [Packagist's stable-version immutability rule](https://packagist.org/about#version-immutability)** — "Upstream re-tag blocked — Packagist's stored snapshot may no longer match what is currently in git." A published stable version's source/dist reference is locked forever, so the corrected `1.10.0` can never reach `composer require`.

Packagist's own remedy is to **publish a new version**. This republishes the full, intended **Lookout** contents as `1.10.1 — Encore`.

## What's in it

**No source changes.** This is packaging/docs only:

- `CHANGELOG.md` — new `## [1.10.1] — 2026-06-15 — Encore` section explaining the republish (with a back-reference to the `1.10.0` entry for the actual features/fixes) + link reference.
- Version pins bumped `1.10.0` → `1.10.1` per the `.claude/rules/changelog.md` release step: `resources/schema.json` `$id`, the `# yaml-language-server` modelines (`examples/configs/*.yaml`, `examples/vulnerable-app/...`), `docs/configuration.md`, `docs/versioning.md`, the GitHub Action `uses:` in `docs/ci.md`, and `README.md`.

The GitHub Action (`uses: …@1.10.0`) and the raw schema URL are served from GitHub and already worked at `1.10.0`; only `composer require` was blocked. After this merges and `1.10.1` is tagged, every pin resolves consistently.

## Verification

- `resources/schema.json` parses as valid JSON; Prettier (`**/*.md`) and markdownlint clean. No PHP touched.

## Release steps (after merge)

1. Tag **`1.10.1`** from the merge commit (no `v` prefix). Packagist will crawl it as a fresh, unblocked version.
2. Re-publish the GitHub release / Marketplace listing pointing at `1.10.1`.
3. Leave `1.10.0` as-is (blocked/grayed on Packagist) — it's now superseded.

Going forward: tag only *after* the final merge commit exists, so a published tag never needs to move.

https://claude.ai/code/session_01AgjEZA97se6Cth51y9xDTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgjEZA97se6Cth51y9xDTo)_