### PR TITLE
docs: refresh stale model identifiers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -675,7 +675,7 @@ root key `symfony_security_auditor`. Top-level scalars:
 
 | Key              | Default             | Purpose                                         |
 | ---------------- | ------------------- | ----------------------------------------------- |
-| `model`          | `'claude-opus-4-7'` | Model name for both Attacker and Reviewer roles |
+| `model`          | `'claude-opus-4-8'` | Model name for both Attacker and Reviewer roles |
 | `attacker_model` | `null`              | Override: dedicated model for the Attacker role |
 | `reviewer_model` | `null`              | Override: dedicated model for the Reviewer role |
 
@@ -702,14 +702,14 @@ Minimal configuration:
 
 ```yaml
 symfony_security_auditor:
-    model: 'claude-opus-4-7'
+    model: 'claude-opus-4-8'
 ```
 
 Split-model configuration (larger model for attacking, faster for reviewing):
 
 ```yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-7'
+    attacker_model: 'claude-opus-4-8'
     reviewer_model: 'claude-haiku-4-5-20251001'
 ```
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -44,7 +44,7 @@ Use a powerful model for discovery and a cheap/fast model for validation:
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-7'   # deep reasoning for vulnerability discovery
+    attacker_model: 'claude-opus-4-8'   # deep reasoning for vulnerability discovery
     reviewer_model: 'claude-haiku-4-5-20251001'  # ~20× cheaper for false-positive filtering
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,7 +196,7 @@ rather than charging every input token at the full rate.
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    model: 'claude-opus-4-7'
+    model: 'claude-opus-4-8'
 ```
 
 ### Split mode — separate models per role
@@ -204,7 +204,7 @@ symfony_security_auditor:
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-7'   # powerful model for discovery
+    attacker_model: 'claude-opus-4-8'   # powerful model for discovery
     reviewer_model: 'claude-haiku-4-5-20251001'  # faster model for validation
 ```
 
@@ -213,7 +213,7 @@ symfony_security_auditor:
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-7'
+    attacker_model: 'claude-opus-4-8'
     reviewer_model: 'claude-haiku-4-5-20251001'
     scan:
         included_paths:
@@ -350,7 +350,7 @@ through the model name using either of the two syntaxes supported by
 
 ```yaml
 symfony_security_auditor:
-    model: 'claude-opus-4-7?temperature=0.2'
+    model: 'claude-opus-4-8?temperature=0.2'
 ```
 
 ### Expanded syntax
@@ -358,7 +358,7 @@ symfony_security_auditor:
 ```yaml
 symfony_security_auditor:
     model:
-        name: 'claude-opus-4-7'
+        name: 'claude-opus-4-8'
         options:
             temperature: 0.2
 ```
@@ -390,7 +390,7 @@ ai:
 
 ```yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-7'   # deep reasoning for vuln discovery
+    attacker_model: 'claude-opus-4-8'   # deep reasoning for vuln discovery
     reviewer_model: 'claude-haiku-4-5-20251001'  # fast + cheap for false-positive filtering
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -135,10 +135,10 @@ No. We recommend the layered approach:
 
 ### How accurate is it?
 
-Accuracy depends on the LLM model. Stronger models (Claude Opus, GPT-4o, Gemini
-2.5 Pro) produce fewer false positives and catch deeper flaws. The Reviewer
-agent filters Attacker output — only `reviewer_validated` findings appear in the
-final report.
+Accuracy depends on the LLM model. Stronger models (Claude Opus, GPT-5.4, Gemini
+3 Pro) produce fewer false positives and catch deeper flaws. The Reviewer agent
+filters Attacker output — only `reviewer_validated` findings appear in the final
+report.
 
 Tune `audit.min_confidence` (default `0.6`) to trade precision for recall. CI
 gating: try `0.8`. Discovery scan: try `0.3`.
@@ -184,7 +184,7 @@ prompt caching enabled (default):
 | Claude Fable 5 only                 | $6 – $16             |
 | Claude Opus only                    | $3 – $8              |
 | Claude Opus + Haiku (split-model)   | $0.50 – $2           |
-| GPT-4o only                         | $2 – $6              |
+| GPT-5.4 only                        | $3 – $8              |
 | DeepSeek / Mistral / Ollama (local) | ~$0 / $0             |
 
 Tips: set `profile: fast` (one attacker iteration, lean pre-scan, code slicing,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -229,7 +229,7 @@ on the model:
 ```yaml
 symfony_security_auditor:
     model:
-        name: 'claude-opus-4-7'
+        name: 'claude-opus-4-8'
         options:
             temperature: 0.0
 ```

--- a/examples/configs/ci-optimized.yaml
+++ b/examples/configs/ci-optimized.yaml
@@ -6,7 +6,7 @@
 # Drop in as: config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
     # Heavyweight model finds the bugs; lightweight model filters false positives.
-    attacker_model: 'claude-opus-4-7'
+    attacker_model: 'claude-opus-4-8'
     reviewer_model: 'claude-haiku-4-5-20251001'
 
     scan:

--- a/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
+++ b/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-7'
+    attacker_model: 'claude-opus-4-8'
     reviewer_model: 'claude-haiku-4-5-20251001'
     audit:
         min_confidence: 0.6


### PR DESCRIPTION
Documentation-only refresh (no code, no `CHANGELOG` entry per the changelog rule's docs-only exemption).

## What

- **`claude-opus-4-7` → `claude-opus-4-8`** across every example in `docs/` and `examples/`. The default model became `claude-opus-4-8` in 1.9.0, but the canonical snippets still showed `4-7` — including `docs/architecture.md`, which documented the **default** as `4-7` (a real inaccuracy). The intentional "pin `claude-opus-4-7` to keep the previous default" note in `CHANGELOG.md` is historical and left untouched.
- **`docs/faq.md` dated model names:** the accuracy section's "GPT-4o, Gemini 2.5 Pro" → "GPT-5.4, Gemini 3 Pro", and the cost table's "GPT-4o only" row → "GPT-5.4 only" ($3–$8, consistent with its `$2.50/$15` per-MTok rate in `StaticPricingProvider`).

## Token-estimator spot-check (no change needed)

The plan flagged verifying that the new default resolves to a real estimator. Confirmed: `AnthropicTokenEstimator::supports()` matches the `claude-` prefix, so `claude-opus-4-8` resolves to it at the standard 3.5 chars/token — not a creative-prefix ratio or the generic fallback. No code change required.

## Gates

Prettier + markdownlint clean. No PHP changed, so the test/mutation/static suites are unaffected.

https://claude.ai/code/session_01UkELx3QdRfntXiYBdXsYEH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkELx3QdRfntXiYBdXsYEH)_