### PR TITLE
feat(prompt): sharper attacker methodology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.11.0] — 2026-06-15 — Tracer
+
+A gating, suppression, reporting, and detection release. Audits can now fail CI
+at a chosen severity (`audit.fail_on` / `--fail-on`, default `critical`) and
+mute whole finding classes without per-finding baselines (`audit.excluded_types`
+/ `audit.included_types`). SARIF output gained stable `partialFingerprints` so
+GitHub Code Scanning tracks findings across runs, plus per-rule OWASP `helpUri`s
+(with `authenticator_bypass` and `missing_signature_verification` re-mapped to
+A07/A08), and a new `--format=markdown` renders a report for pull-request
+comments and job summaries. The attacker prompt now traces each finding
+source→sink, sweeps the STRIDE categories per entry point, and weights severity
+by exposure.
+
 ### Added
 
 - **Type-level finding suppression — the `audit.excluded_types` and
@@ -1615,6 +1628,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.11.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.11.0
 [1.10.1]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.10.1
 [1.10.0]:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `ReportWriter` a `markdown` arm. Public API per `docs/versioning.md` (the
   `--format` value `markdown`).
 
+### Changed
+
+- **The attacker prompt now applies an explicit source→sink methodology, a
+  STRIDE sweep, and exposure-weighted severity.** `AttackerPromptBuilder`
+  (`src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php`) gained an
+  "Analysis methodology" section that tells the model to trace each
+  attacker-controlled value from its trust-boundary source through to a
+  dangerous sink and to verify that no guard, validator, parameterization,
+  escaping, `access_control`, or voter neutralizes the path before recording a
+  finding; to sweep the STRIDE categories (Spoofing, Tampering, Repudiation,
+  Information disclosure, Denial of service, Elevation of privilege) per entry
+  point so no class is skipped; and to calibrate severity by reachability and
+  exposure (risk ≈ likelihood × impact) rather than bug class alone. Informed by
+  standard threat-modeling practice (STRIDE, trust boundaries, risk-based
+  prioritization). `PROMPT_VERSION` is bumped `8` → `9`, invalidating
+  previously-cached attacker responses so the new guidance takes effect.
+
 ### Fixed
 
 - **Corrected two OWASP Top 10 categorizations surfaced by the new per-rule

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ the recipe automates:
   findings fail CI.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.10.1`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.11.0`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **Zero-config CVE feed** — `lookup_advisory` is backed by `composer audit`

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -224,7 +224,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.10.1
+        uses: vinceamstoutz/symfony-security-auditor@1.11.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,14 +55,14 @@ following keys:
 > config file:
 >
 > ```yaml
-> # yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
+> # yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.11.0/resources/schema.json
 > symfony_security_auditor:
 >     model: "claude-opus-4-8"
 > ```
 >
 > This gives key completion, type checking, and inline docs as you edit. The
 > example files under [`examples/configs/`](../examples/configs/) include the
-> modeline. The URL is pinned to the release tag (`…/1.10.1/…`) so the schema
+> modeline. The URL is pinned to the release tag (`…/1.11.0/…`) so the schema
 > matches the version you have installed — bump it when you upgrade the bundle.
 
 ### Top-level

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -96,7 +96,7 @@ is a `MAJOR` change.
   `MINOR`; renaming or removing one is a `MAJOR`. The Marketplace `name`
   (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.10.1` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.11.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/examples/configs/ci-optimized.yaml
+++ b/examples/configs/ci-optimized.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.11.0/resources/schema.json
 # Scheduled CI run — split-model, cache + prompt caching enabled.
 #
 # Target: accuracy on a medium-to-large Symfony codebase, run nightly.

--- a/examples/configs/cost-aware.yaml
+++ b/examples/configs/cost-aware.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.11.0/resources/schema.json
 # Triage scan — single small model, single iteration, tools disabled.
 #
 # Target: smallest possible bill for an initial pass on a large monorepo.

--- a/examples/configs/dev-fast.yaml
+++ b/examples/configs/dev-fast.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.11.0/resources/schema.json
 # Local development scan — Ollama backend, no spend, exploratory recall.
 #
 # Pair with the following in config/packages/ai.yaml:

--- a/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
+++ b/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.11.0/resources/schema.json
 symfony_security_auditor:
     attacker_model: 'claude-opus-4-8'
     reviewer_model: 'claude-haiku-4-5-20251001'

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.10.1/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.11.0/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -27,7 +27,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 8;
+    public const int PROMPT_VERSION = 9;
 
     public const bool DEFAULT_STRUCTURED_COLLECTION = true;
 
@@ -358,6 +358,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             .$this->outputFormatSection()
             .$this->severityAndConfidenceRubrics()
             .$this->fileNumberingAndScope()
+            .$this->analysisMethodology()
             .$this->exampleFinding()
             .$this->rulesAndToolDiscipline();
     }
@@ -455,6 +456,8 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             - low: reflected XSS in low-impact contexts, information disclosure of non-sensitive metadata, weak crypto on already-public data, missing security headers.
             - info: defense-in-depth opportunities, hardening suggestions, deprecated patterns with no current exploit path.
 
+            Exposure weighting: severity is risk (roughly likelihood times impact), not bug class alone. Raise severity when the vulnerable path is reachable by an unauthenticated or low-privilege actor (public route, anonymous firewall, pre-auth handler, webhook); lower it when reachable only behind strong authentication or by trusted/admin roles. Weigh exploitability and the sensitivity of the affected data rather than a generic CVSS guess.
+
             Confidence rubric (filtered downstream — entries below 0.6 are dropped before reviewer):
             - 0.9-1.0: tainted source traced to dangerous sink with concrete payload.
             - 0.7-0.89: clear vulnerable pattern matched, exploitation plausible without a full PoC.
@@ -474,6 +477,27 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             Scope:
             - Only report findings in the source files provided below. Ignore code under `vendor/`, `var/cache/`, `var/log/`, any path containing `.generated.` or `.cache.`, and obvious build artifacts.
             - If a finding references code outside the provided chunk, set `confidence` no higher than 0.7 and explain the cross-file dependency in `attack_vector`.
+
+
+            PROMPT;
+    }
+
+    private function analysisMethodology(): string
+    {
+        return <<<'PROMPT'
+            Analysis methodology — apply to every candidate before recording it:
+            - Source (trust boundary): identify the attacker-controlled entry point the value crosses from — route/path parameter, query string, request body, header, cookie, uploaded file, or webhook/queue payload (and anything derived from them).
+            - Flow: trace that value through each assignment, transformation, and cross-file call to the sink, noting any sanitizer, validator, parameterized query, escaping, or access-control check on the path.
+            - Sink: confirm it reaches a dangerous operation (SQL/DQL, shell/process, file path, Twig, redirect, deserialization, reflected/stored output, or a privileged state change) with no mitigating control in between.
+            - Verify before recording: record ONLY when the value is genuinely attacker-controlled, reaches the sink on a reachable path, and nothing on the path (guard clause, validator, parameterization, escaping, `access_control`, voter) neutralizes it. Otherwise do not record — or lower `confidence` and state the missing link in `attack_vector`. Always name the concrete source, sink, and path.
+
+            For each entry point, sweep the STRIDE categories so no class is skipped:
+            - Spoofing: authentication or identity-check bypass (authenticator flaws, forgeable or replayable tokens).
+            - Tampering: mass assignment, unvalidated writes, parameter binding to privileged fields.
+            - Repudiation: privileged or balance-affecting actions with no audit trail or idempotency key.
+            - Information disclosure: IDOR, over-permissive serializer groups, verbose errors, sensitive data in logs.
+            - Denial of service: unbounded loops/uploads/recursion, missing rate limiting on costly or auth endpoints.
+            - Elevation of privilege: missing `#[IsGranted]` / `denyAccessUnlessGranted()`, broken voter, role escalation.
 
 
             PROMPT;

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -915,6 +915,21 @@ final class AttackerPromptBuilderTest extends TestCase
         self::assertStringContainsString('Exposure weighting', $prompt);
     }
 
+    public function test_analysis_methodology_appears_after_the_scope_and_before_the_example(): void
+    {
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt();
+
+        $scopePosition = strpos($prompt, 'File-numbering protocol');
+        $methodologyPosition = strpos($prompt, 'Analysis methodology');
+        $examplePosition = strpos($prompt, 'Example finding');
+
+        self::assertIsInt($scopePosition);
+        self::assertIsInt($methodologyPosition);
+        self::assertIsInt($examplePosition);
+        self::assertGreaterThan($scopePosition, $methodologyPosition);
+        self::assertLessThan($examplePosition, $methodologyPosition);
+    }
+
     #[DataProvider('vulnerabilityTypeValues')]
     public function test_base_prompt_lists_every_vulnerability_type_as_valid(string $typeValue): void
     {

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -889,7 +889,30 @@ final class AttackerPromptBuilderTest extends TestCase
 
     public function test_prompt_version_is_bumped_when_modern_symfony_skill_blocks_are_added(): void
     {
-        self::assertSame(8, AttackerPromptBuilder::PROMPT_VERSION);
+        self::assertSame(9, AttackerPromptBuilder::PROMPT_VERSION);
+    }
+
+    public function test_base_prompt_includes_the_source_to_sink_analysis_methodology(): void
+    {
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString('Analysis methodology', $prompt);
+        self::assertStringContainsString('Verify before recording', $prompt);
+    }
+
+    public function test_base_prompt_includes_the_stride_category_sweep(): void
+    {
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString('sweep the STRIDE categories', $prompt);
+        self::assertStringContainsString('Elevation of privilege', $prompt);
+    }
+
+    public function test_base_prompt_calibrates_severity_by_exposure(): void
+    {
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt();
+
+        self::assertStringContainsString('Exposure weighting', $prompt);
     }
 
     #[DataProvider('vulnerabilityTypeValues')]


### PR DESCRIPTION
Informed by standard threat-modeling practice (the three cybersecurity-skills references shared converge on this), `AttackerPromptBuilder` gains an **Analysis methodology** section:

- **Source→sink data-flow** — trace each attacker-controlled value from its trust-boundary source (route/body/header/upload/queue) to a dangerous sink, noting any sanitizer/validator/parameterization/escaping/`access_control` on the path.
- **Verify before recording** — record only when the value is genuinely attacker-controlled, reaches the sink on a reachable path, and nothing neutralizes it; otherwise drop or lower confidence and explain the gap.
- **STRIDE sweep** per entry point (Spoofing/Tampering/Repudiation/Information disclosure/DoS/Elevation) so no class is skipped.
- **Exposure-weighted severity** — severity is risk (≈ likelihood × impact): raise it for unauthenticated/low-privilege-reachable paths, lower it behind strong auth, rather than scoring by bug class alone.

`PROMPT_VERSION` 8 → 9 (invalidates cached attacker responses). Prompt-content tests assert each addition; detection gain itself is unmeasured (the benchmark was set aside).

## Gates

PHPUnit (2108), PHPStan max, CS-Fixer, Rector, Prettier, markdownlint all green locally; mutation verified via CI (my local pcov-based Infection diverges, as seen on #66). The tag + GitHub release are a post-merge step — release-notes text is ready.