### PR TITLE
fix(command): clarify dry-run warning for local models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Changed
+
+- **The `--dry-run` "no pricing data" warning no longer reads like an error for
+  local models.** When a configured model is absent from the bundled
+  `StaticPricingProvider` price table,
+  `AuditPresenter::unsupportedModelWarnings()`
+  (`src/Command/AuditPresenter.php`) prints a stderr notice and the estimate
+  shows `$0.00`. The previous copy — _"No pricing data for the configured
+  model(s): … and may be inaccurate. Check the model name(s) …"_ — framed the
+  legitimate local/self-hosted case (Ollama, LM Studio), where `$0.00` is the
+  correct estimate, as a likely misconfiguration. The notice now states that
+  `$0.00` is correct for a local or self-hosted model and can be ignored, and
+  only flags a typo or an unlisted model as the problem case. Unchanged: the
+  notice stays stderr-only (so `--format=json` / `--format=sarif` stdout is
+  untouched) and token counts remain accurate.
+
 ## [1.11.0] — 2026-06-15 — Tracer
 
 A gating, suppression, reporting, and detection release. Audits can now fail CI

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -287,8 +287,10 @@ model `symfony/ai` supports but the table does not yet list — its price resolv
 to `0.0` and the dry run now prints a stderr warning:
 
 ```text
-No pricing data for the configured model(s): <model>. The dry-run cost estimate
-shows $0.00 for these and may be inaccurate. Check the model name(s) in your
+No published pricing for the configured model(s): <model>. The dry-run cost
+estimate shows $0.00 for these. If you are running a local or self-hosted model
+(e.g. Ollama, LM Studio), $0.00 is correct — you can ignore this notice.
+Otherwise the name is likely a typo or an unlisted model: check it in your
 symfony_security_auditor configuration against the models supported by your
 symfony/ai platform.
 ```

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -61,7 +61,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         }
 
         $symfonyStyle->getErrorStyle()->warning(\sprintf(
-            'No pricing data for the configured model(s): %s. The dry-run cost estimate shows $0.00 for these and may be inaccurate. Check the model name(s) in your symfony_security_auditor configuration against the models supported by your symfony/ai platform.',
+            'No published pricing for the configured model(s): %s. The dry-run cost estimate shows $0.00 for these. If you are running a local or self-hosted model (e.g. Ollama, LM Studio), $0.00 is correct — you can ignore this notice. Otherwise the name is likely a typo or an unlisted model: check it in your symfony_security_auditor configuration against the models supported by your symfony/ai platform.',
             implode(', ', $unsupportedModels),
         ));
     }

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -696,7 +696,7 @@ final class AuditCommandEndToEndTest extends TestCase
             '--dry-run' => true,
         ]);
 
-        self::assertStringContainsString('No pricing data', $commandTester->getDisplay());
+        self::assertStringContainsString('No published pricing', $commandTester->getDisplay());
     }
 
     public function test_dry_run_model_warning_is_emitted_on_stderr_for_machine_readable_output(): void
@@ -713,8 +713,8 @@ final class AuditCommandEndToEndTest extends TestCase
             ['capture_stderr_separately' => true],
         );
 
-        self::assertStringContainsString('No pricing data', $commandTester->getErrorOutput());
-        self::assertStringNotContainsString('No pricing data', $commandTester->getDisplay());
+        self::assertStringContainsString('No published pricing', $commandTester->getErrorOutput());
+        self::assertStringNotContainsString('No published pricing', $commandTester->getDisplay());
     }
 
     public function test_command_renders_progress_bar_in_console_format(): void


### PR DESCRIPTION
## Summary

Improves the messaging of the `--dry-run` "no pricing data" warning to clarify that `$0.00` is the correct estimate for local or self-hosted models (Ollama, LM Studio, etc.), reducing false alarm perception. The notice now distinguishes between legitimate local model cases and actual misconfiguration (typos or unlisted models).

## Type of change

- [x] Bug fix


## Changes

- **`src/Command/AuditPresenter.php`**: Updated `unsupportedModelWarnings()` message from "No pricing data for the configured model(s)…and may be inaccurate" to "No published pricing for the configured model(s)…If you are running a local or self-hosted model (e.g. Ollama, LM Studio), $0.00 is correct — you can ignore this notice. Otherwise the name is likely a typo or an unlisted model…"
- **`docs/troubleshooting.md`**: Updated example warning text to match new message and clarify the local model case
- **`tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php`**: Updated test assertions to match new "No published pricing" wording

The warning remains stderr-only (unaffected by `--format=json`/`--format=sarif`), and token counts remain accurate.

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)