### PR TITLE
ci: allow deps-dev scope for dependabot

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -36,6 +36,7 @@ export default {
                 'bundle',
                 'config',
                 'deps',
+                'deps-dev',
                 'ci',
                 'docs',
                 'tests',


### PR DESCRIPTION
## Summary

Dependabot emits `chore(deps-dev):` for `require-dev` updates, but the commitlint `scope-enum` only allowed `deps` — so every dev-dependency Dependabot PR (e.g. #79) failed the Commit Lint check. This adds `deps-dev` to the allowed scopes in `commitlint.config.mjs`.

## Type of change

- [x] Bug fix

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)