### PR TITLE
ci: drop run-cancelling concurrency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   prettier:
     name: Prettier Check


### PR DESCRIPTION
## Summary

Removes the `concurrency` / `cancel-in-progress` block from the CI workflow.

Its only real benefit is saving CI minutes by killing superseded runs — but **public repos get unlimited free Actions minutes**, so that motivation doesn't apply here. In exchange it caused noise: a cancelled run reports as cancelled (not green), and a push to `main` landing while a previous `main` run was still going would cancel it and turn the CI badge red.

Dropping it: every push and PR run completes on its own. No cancelled-run noise, honest badge. The trade-off (no auto-cancel of superseded runs on rapid fixups) is negligible at this project's volume.

## Type of change

- [x] CI configuration

## Checklist

- [x] Workflow still valid (only the `concurrency:` block removed)
