### PR TITLE
ci: fix unset secret blocking mutation report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,6 +167,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
+          INFECTION_DASHBOARD_API_KEY: ${{ secrets.INFECTION_DASHBOARD_API_KEY }}
         run: |
           ARGS="--configuration=infection.json5 --threads=max --coverage=build/coverage --skip-initial-tests --min-msi=100 --min-covered-msi=100"
           if [[ "$EVENT_NAME" == "pull_request" ]]; then


### PR DESCRIPTION
## Problem

CI logs the warning:

```
Warning:  Dashboard report has not been sent: The Stryker API key needs to be configured using one of the environment variables "INFECTION_DASHBOARD_API_KEY" or "STRYKER_DASHBOARD_API_KEY", but could not find any of these.
```

Infection's `StrykerApiKeyResolver` looks for the dashboard key in the **process environment** under one of `INFECTION_BADGE_API_KEY` (deprecated), `INFECTION_DASHBOARD_API_KEY`, or `STRYKER_DASHBOARD_API_KEY`. The Infection step never exposed any of them, so the resolver found nothing and skipped publishing.

## Fix

Map the `INFECTION_DASHBOARD_API_KEY` repository secret into the Infection step's `env:` block, matching the secret already configured in repo settings.

## Required setup

Repository secret `INFECTION_DASHBOARD_API_KEY` must exist (Settings → Secrets and variables → Actions → Repository secrets). Already configured.

Note: secrets are not exposed to PRs from forks, so the dashboard report still only publishes for same-repo branches — consistent with the documented behavior.