### PR TITLE
ci: tighten PHPStan with stricter opt-in checks

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -7,9 +7,13 @@ parameters:
     checkUninitializedProperties: true
     checkImplicitMixed: true
     checkBenevolentUnionTypes: true
+    checkMissingOverrideMethodAttribute: true
     exceptions:
         check:
+            missingCheckedExceptionInThrows: true
             tooWideThrowType: true
+        checkedExceptionRegexes:
+            - '#^VinceAmstoutz\\SymfonySecurityAuditor\\.+\\Exception\\#'
     paths:
         - bin/
         - config/

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -14,6 +14,8 @@ parameters:
     reportAnyTypeWideningInVarTag: true
     reportAlwaysTrueInLastCondition: true
     reportPossiblyNonexistentConstantArrayOffset: true
+    featureToggles:
+        checkPrintfParameterTypes: true
     exceptions:
         check:
             missingCheckedExceptionInThrows: true

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -4,10 +4,14 @@ includes:
 parameters:
     level: max
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    checkTooWideParameterOutInProtectedAndPublicMethods: true
+    checkTooWideThrowTypesInProtectedAndPublicMethods: true
     checkUninitializedProperties: true
     checkImplicitMixed: true
     checkBenevolentUnionTypes: true
     checkMissingOverrideMethodAttribute: true
+    reportAnyTypeWideningInVarTag: true
+    reportAlwaysTrueInLastCondition: true
     exceptions:
         check:
             missingCheckedExceptionInThrows: true

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -3,6 +3,13 @@ includes:
 
 parameters:
     level: max
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    checkUninitializedProperties: true
+    checkImplicitMixed: true
+    checkBenevolentUnionTypes: true
+    exceptions:
+        check:
+            tooWideThrowType: true
     paths:
         - bin/
         - config/

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -10,12 +10,15 @@ parameters:
     checkImplicitMixed: true
     checkBenevolentUnionTypes: true
     checkMissingOverrideMethodAttribute: true
+    checkMissingCallableSignature: true
     reportAnyTypeWideningInVarTag: true
     reportAlwaysTrueInLastCondition: true
+    reportPossiblyNonexistentConstantArrayOffset: true
     exceptions:
         check:
             missingCheckedExceptionInThrows: true
             tooWideThrowType: true
+            tooWideImplicitThrowType: true
         checkedExceptionRegexes:
             - '#^VinceAmstoutz\\SymfonySecurityAuditor\\.+\\Exception\\#'
     paths:

--- a/src/Audit/Application/Agent/AttackerAgent.php
+++ b/src/Audit/Application/Agent/AttackerAgent.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunk\AttackerChunkCache;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunk\ChunkContextFactory;
@@ -20,6 +21,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunk\ChunkCove
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunk\ConcurrentChunkAnalyzer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunk\SequentialChunkAnalyzer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunking\FileChunker;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\LLMProviderException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskMarker;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
@@ -126,7 +129,11 @@ final readonly class AttackerAgent implements AttackerAgentInterface
 
     /**
      * @return list<Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
+    #[Override]
     public function analyze(AttackerAnalysisRequest $attackerAnalysisRequest, CoverageRecorderInterface $coverageRecorder): array
     {
         $files = $attackerAnalysisRequest->files;

--- a/src/Audit/Application/Agent/AuditOrchestrator.php
+++ b/src/Audit/Application/Agent/AuditOrchestrator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProgressEvent;
@@ -40,6 +41,7 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
         $this->progressReporter = $progressReporter ?? new NullProgressReporter();
     }
 
+    #[Override]
     public function orchestrate(AuditContext $auditContext): void
     {
         $mapping = $auditContext->mapping();

--- a/src/Audit/Application/Agent/Chunk/ConcurrentChunkAnalyzer.php
+++ b/src/Audit/Application/Agent/Chunk/ConcurrentChunkAnalyzer.php
@@ -56,6 +56,9 @@ final readonly class ConcurrentChunkAnalyzer
      * @param list<list<ProjectFile>> $chunks
      *
      * @return array{0: list<Vulnerability>, 1: array<string, int>}
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     public function analyze(array $chunks, AttackerAnalysisRequest $attackerAnalysisRequest, CoverageRecorderInterface $coverageRecorder, RiskMarkerIndex $riskMarkerIndex): array
     {
@@ -185,6 +188,9 @@ final readonly class ConcurrentChunkAnalyzer
     /**
      * @param list<array{system: string, user: string, tools: ToolRegistry}>                                                      $requests
      * @param array<int, array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, collector: VulnerabilityCollector}> $pending
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     private function dispatch(array $requests, array $pending, CoverageRecorderInterface $coverageRecorder): void
     {

--- a/src/Audit/Application/Agent/Chunk/SequentialChunkAnalyzer.php
+++ b/src/Audit/Application/Agent/Chunk/SequentialChunkAnalyzer.php
@@ -60,6 +60,9 @@ final readonly class SequentialChunkAnalyzer
      * @param list<list<ProjectFile>> $chunks
      *
      * @return array{0: list<Vulnerability>, 1: array<string, int>}
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     public function analyze(array $chunks, AttackerAnalysisRequest $attackerAnalysisRequest, CoverageRecorderInterface $coverageRecorder, ?ToolRegistry $toolRegistry, RiskMarkerIndex $riskMarkerIndex): array
     {
@@ -100,6 +103,9 @@ final readonly class SequentialChunkAnalyzer
 
     /**
      * @param list<ProjectFile> $chunk
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     private function analyzeChunk(array $chunk, AttackerAnalysisRequest $attackerAnalysisRequest, CoverageRecorderInterface $coverageRecorder, ?ToolRegistry $toolRegistry, RiskMarkerIndex $riskMarkerIndex): VulnerabilityHydrationResult
     {

--- a/src/Audit/Application/Agent/EscalatingAttackerAgent.php
+++ b/src/Audit/Application/Agent/EscalatingAttackerAgent.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
@@ -50,6 +51,7 @@ final readonly class EscalatingAttackerAgent implements AttackerAgentInterface
         private LoggerInterface $logger,
     ) {}
 
+    #[Override]
     public function analyze(AttackerAnalysisRequest $attackerAnalysisRequest, CoverageRecorderInterface $coverageRecorder): array
     {
         $files = $attackerAnalysisRequest->files;

--- a/src/Audit/Application/Agent/PoCSynthesizer.php
+++ b/src/Audit/Application/Agent/PoCSynthesizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
@@ -39,6 +40,11 @@ final readonly class PoCSynthesizer implements PoCSynthesizerInterface
         private VulnerabilitySeverity $vulnerabilitySeverity = VulnerabilitySeverity::HIGH,
     ) {}
 
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
+    #[Override]
     public function synthesize(array $vulnerabilities): array
     {
         if ([] === $vulnerabilities) {
@@ -85,6 +91,10 @@ final readonly class PoCSynthesizer implements PoCSynthesizerInterface
             && $vulnerability->severity()->score() >= $this->vulnerabilitySeverity->score();
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     private function synthesizeOne(Vulnerability $vulnerability): ?string
     {
         $systemPrompt = $this->buildSystemPrompt();

--- a/src/Audit/Application/Agent/Review/BatchReviewAnalyzer.php
+++ b/src/Audit/Application/Agent/Review/BatchReviewAnalyzer.php
@@ -57,6 +57,9 @@ final readonly class BatchReviewAnalyzer
      * @param list<ProjectFile>   $projectFiles
      *
      * @return list<Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     public function analyze(array $vulnerabilities, array $projectFiles, ReviewBatchSettings $reviewBatchSettings): array
     {
@@ -107,6 +110,9 @@ final readonly class BatchReviewAnalyzer
      * @param list<int>                 $missIndexes
      *
      * @return array<int, Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     private function reviewMissesInBatches(array $reviewed, array $misses, array $missIndexes, ReviewBatchSettings $reviewBatchSettings, ReviewCacheBuckets $reviewCacheBuckets): array
     {
@@ -145,6 +151,9 @@ final readonly class BatchReviewAnalyzer
      * @param array<string, string> $cacheContexts
      *
      * @return list<Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     private function reviewBatch(array $batch, array $codeContexts, array $cacheContexts, CoverageRecorderInterface $coverageRecorder, ?ToolRegistry $toolRegistry): array
     {
@@ -186,6 +195,9 @@ final readonly class BatchReviewAnalyzer
      * @param array<string, string> $cacheContexts
      *
      * @return list<Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     private function reviewBatchViaStructuredCollection(array $batch, array $codeContexts, array $cacheContexts, CoverageRecorderInterface $coverageRecorder): array
     {

--- a/src/Audit/Application/Agent/Review/ConcurrentStructuredReviewAnalyzer.php
+++ b/src/Audit/Application/Agent/Review/ConcurrentStructuredReviewAnalyzer.php
@@ -52,6 +52,9 @@ final readonly class ConcurrentStructuredReviewAnalyzer
      * @param list<ProjectFile>   $projectFiles
      *
      * @return list<Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     public function analyze(array $vulnerabilities, array $projectFiles, CoverageRecorderInterface $coverageRecorder, bool $bypassCache): array
     {
@@ -103,6 +106,9 @@ final readonly class ConcurrentStructuredReviewAnalyzer
      * @param array<int, Vulnerability> $reviewed
      *
      * @return array<int, Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     private function dispatchPending(ConcurrentReviewBatch $concurrentReviewBatch, CoverageRecorderInterface $coverageRecorder, bool $bypassCache, array $reviewed): array
     {

--- a/src/Audit/Application/Agent/Review/SequentialReviewAnalyzer.php
+++ b/src/Audit/Application/Agent/Review/SequentialReviewAnalyzer.php
@@ -44,6 +44,9 @@ final readonly class SequentialReviewAnalyzer
      * @param list<ProjectFile>   $projectFiles
      *
      * @return list<Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     public function analyze(array $vulnerabilities, array $projectFiles, CoverageRecorderInterface $coverageRecorder, ?ToolRegistry $toolRegistry, bool $bypassCache): array
     {
@@ -57,6 +60,9 @@ final readonly class SequentialReviewAnalyzer
 
     /**
      * @param list<ProjectFile> $projectFiles
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     private function reviewSingle(Vulnerability $vulnerability, array $projectFiles, CoverageRecorderInterface $coverageRecorder, ?ToolRegistry $toolRegistry, bool $bypassCache): Vulnerability
     {

--- a/src/Audit/Application/Agent/Review/StructuredReviewAnalyzer.php
+++ b/src/Audit/Application/Agent/Review/StructuredReviewAnalyzer.php
@@ -49,6 +49,9 @@ final readonly class StructuredReviewAnalyzer
      * @param list<ProjectFile>   $projectFiles
      *
      * @return list<Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     public function analyze(array $vulnerabilities, array $projectFiles, CoverageRecorderInterface $coverageRecorder, bool $bypassCache): array
     {
@@ -62,6 +65,9 @@ final readonly class StructuredReviewAnalyzer
 
     /**
      * @param list<ProjectFile> $projectFiles
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
     private function reviewSingle(Vulnerability $vulnerability, array $projectFiles, CoverageRecorderInterface $coverageRecorder, bool $bypassCache): Vulnerability
     {

--- a/src/Audit/Application/Agent/ReviewerAgent.php
+++ b/src/Audit/Application/Agent/ReviewerAgent.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Review\BatchReviewAnalyzer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Review\BatchVerdictApplier;
@@ -24,6 +25,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Review\ReviewOu
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Review\SequentialReviewAnalyzer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Review\StructuredReviewAnalyzer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Review\VerdictApplier;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\LLMProviderException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\CoverageRecorderInterface;
@@ -145,7 +148,11 @@ final readonly class ReviewerAgent implements ReviewerAgentInterface
      * @param list<ProjectFile>   $projectFiles
      *
      * @return list<Vulnerability>
+     *
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
      */
+    #[Override]
     public function review(array $vulnerabilities, array $projectFiles, CoverageRecorderInterface $coverageRecorder, bool $bypassCache = false): array
     {
         if ([] === $vulnerabilities) {

--- a/src/Audit/Application/Agent/VulnerabilityFactory.php
+++ b/src/Audit/Application/Agent/VulnerabilityFactory.php
@@ -17,6 +17,8 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Throwable;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityClassification;
@@ -148,6 +150,9 @@ final readonly class VulnerabilityFactory
 
     /**
      * @param array<array-key, mixed> $data
+     *
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
      */
     private function buildVulnerability(array $data): Vulnerability
     {

--- a/src/Audit/Application/Budget/BudgetTracker.php
+++ b/src/Audit/Application/Budget/BudgetTracker.php
@@ -51,6 +51,9 @@ final class BudgetTracker
         );
     }
 
+    /**
+     * @throws BudgetExceededException
+     */
     public function assertWithinBudget(): void
     {
         $maxTokens = $this->auditBudget->maxTokens();

--- a/src/Audit/Application/Pipeline/AuditPipeline.php
+++ b/src/Audit/Application/Pipeline/AuditPipeline.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProgressEvent;
@@ -46,6 +47,7 @@ final readonly class AuditPipeline implements PipelineInterface
         $this->progressReporter = $progressReporter ?? new NullProgressReporter();
     }
 
+    #[Override]
     public function process(AuditContext $auditContext): void
     {
         $stageNames = array_map(static fn (StageInterface $stage): string => $stage->name(), $this->stages);

--- a/src/Audit/Application/Pipeline/Stage/AuditStage.php
+++ b/src/Audit/Application/Pipeline/Stage/AuditStage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AuditOrchestratorInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
@@ -28,11 +29,13 @@ final readonly class AuditStage implements StageInterface
         private LoggerInterface $logger,
     ) {}
 
+    #[Override]
     public function name(): string
     {
         return BuiltInStageName::Audit->value;
     }
 
+    #[Override]
     public function process(AuditContext $auditContext): void
     {
         if ([] === $auditContext->projectFiles()) {

--- a/src/Audit/Application/Pipeline/Stage/IngestionStage.php
+++ b/src/Audit/Application/Pipeline/Stage/IngestionStage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Scan\ScanPathFilter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
@@ -31,11 +32,13 @@ final readonly class IngestionStage implements StageInterface
         private ?GitChangedFilesResolverInterface $gitChangedFilesResolver = null,
     ) {}
 
+    #[Override]
     public function name(): string
     {
         return BuiltInStageName::Ingestion->value;
     }
 
+    #[Override]
     public function process(AuditContext $auditContext): void
     {
         $this->logger->info('Ingesting project files', [

--- a/src/Audit/Application/Pipeline/Stage/MappingStage.php
+++ b/src/Audit/Application/Pipeline/Stage/MappingStage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AccessControlMap;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
@@ -53,11 +54,13 @@ final readonly class MappingStage implements StageInterface
         $this->formBindingParser = $formBindingParser ?? new NullFormBindingParser();
     }
 
+    #[Override]
     public function name(): string
     {
         return BuiltInStageName::Mapping->value;
     }
 
+    #[Override]
     public function process(AuditContext $auditContext): void
     {
         $files = $auditContext->projectFiles();

--- a/src/Audit/Application/Pipeline/Stage/PoCSynthesisStage.php
+++ b/src/Audit/Application/Pipeline/Stage/PoCSynthesisStage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\PoCSynthesizerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
@@ -28,11 +29,13 @@ final readonly class PoCSynthesisStage implements StageInterface
         private bool $enabled = false,
     ) {}
 
+    #[Override]
     public function name(): string
     {
         return BuiltInStageName::PoCSynthesis->value;
     }
 
+    #[Override]
     public function process(AuditContext $auditContext): void
     {
         if (!$this->enabled) {

--- a/src/Audit/Application/UseCase/RunAuditUseCase.php
+++ b/src/Audit/Application/UseCase/RunAuditUseCase.php
@@ -43,6 +43,8 @@ final readonly class RunAuditUseCase
      * @param ?string      $diffSinceRef when set, only files changed against
      *                                   this git ref are audited; null audits
      *                                   every file in scope
+     *
+     * @throws AuditAbortedByBudgetException
      */
     public function execute(string $projectPath, array $scanPaths = [], bool $bypassCache = false, ?string $diffSinceRef = null): AuditReport
     {

--- a/src/Audit/Domain/Model/AuditContext.php
+++ b/src/Audit/Domain/Model/AuditContext.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\CoverageRecorderInterface;
 
 final class AuditContext implements CoverageRecorderInterface
@@ -183,6 +184,7 @@ final class AuditContext implements CoverageRecorderInterface
         );
     }
 
+    #[Override]
     public function recordCoverage(string $stage, string $filePath, string $status): void
     {
         $this->coverage[] = ['stage' => $stage, 'file' => $filePath, 'status' => $status];

--- a/src/Audit/Domain/Model/CodeLocation.php
+++ b/src/Audit/Domain/Model/CodeLocation.php
@@ -17,6 +17,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocat
 
 final readonly class CodeLocation
 {
+    /**
+     * @throws InvalidCodeLocationException
+     */
     public function __construct(
         private string $filePath,
         private int $lineStart,

--- a/src/Audit/Domain/Model/Vulnerability.php
+++ b/src/Audit/Domain/Model/Vulnerability.php
@@ -15,6 +15,8 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 
 final readonly class Vulnerability
 {
@@ -64,6 +66,9 @@ final readonly class Vulnerability
 
     /**
      * @deprecated since 1.13, use {@see self::of()} with a VulnerabilityClassification, CodeLocation and VulnerabilityNarrative instead.
+     *
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
      */
     public static function create(
         VulnerabilityType $vulnerabilityType,

--- a/src/Audit/Domain/Model/VulnerabilityClassification.php
+++ b/src/Audit/Domain/Model/VulnerabilityClassification.php
@@ -17,6 +17,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabi
 
 final readonly class VulnerabilityClassification
 {
+    /**
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function __construct(
         private VulnerabilityType $vulnerabilityType,
         private VulnerabilitySeverity $vulnerabilitySeverity,

--- a/src/Audit/Domain/Pipeline/NullCoverageRecorder.php
+++ b/src/Audit/Domain/Pipeline/NullCoverageRecorder.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline;
 
+use Override;
+
 final readonly class NullCoverageRecorder implements CoverageRecorderInterface
 {
+    #[Override]
     public function recordCoverage(string $stage, string $filePath, string $status): void
     {
         // intentionally noop

--- a/src/Audit/Domain/Port/NullCodeSlicer.php
+++ b/src/Audit/Domain/Port/NullCodeSlicer.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class NullCodeSlicer implements CodeSlicerInterface
 {
+    #[Override]
     public function slice(ProjectFile $projectFile): string
     {
         return $projectFile->content();

--- a/src/Audit/Domain/Port/NullControllerAccessControlParser.php
+++ b/src/Audit/Domain/Port/NullControllerAccessControlParser.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class NullControllerAccessControlParser implements ControllerAccessControlParserInterface
 {
+    #[Override]
     public function parse(ProjectFile $projectFile): array
     {
         return [];

--- a/src/Audit/Domain/Port/NullFormBindingParser.php
+++ b/src/Audit/Domain/Port/NullFormBindingParser.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class NullFormBindingParser implements FormBindingParserInterface
 {
+    #[Override]
     public function parse(ProjectFile $projectFile): array
     {
         return [];

--- a/src/Audit/Domain/Port/NullProgressReporter.php
+++ b/src/Audit/Domain/Port/NullProgressReporter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
 
+use Override;
+
 /**
  * Default reporter — discards every event. Used when the host has not
  * registered a custom reporter, so the pipeline can emit events
@@ -22,6 +24,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
  */
 final readonly class NullProgressReporter implements ProgressReporterInterface
 {
+    #[Override]
     public function report(string $event, array $context = []): void
     {
         // no-op

--- a/src/Audit/Domain/Port/NullStaticPreScanner.php
+++ b/src/Audit/Domain/Port/NullStaticPreScanner.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
 
+use Override;
+
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class NullStaticPreScanner implements StaticPreScannerInterface
 {
+    #[Override]
     public function scan(array $files): array
     {
         return [];

--- a/src/Audit/Domain/Port/NullVoterCapabilityParser.php
+++ b/src/Audit/Domain/Port/NullVoterCapabilityParser.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VoterCapability;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class NullVoterCapabilityParser implements VoterCapabilityParserInterface
 {
+    #[Override]
     public function parse(ProjectFile $projectFile): ?VoterCapability
     {
         return null;

--- a/src/Audit/Infrastructure/Advisory/ComposerAuditAdvisoryDatabase.php
+++ b/src/Audit/Infrastructure/Advisory/ComposerAuditAdvisoryDatabase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory;
 
 use JsonException;
+use Override;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AdvisoryDatabaseInterface;
@@ -48,6 +49,7 @@ final readonly class ComposerAuditAdvisoryDatabase implements AdvisoryDatabaseIn
         $this->entriesByPackage = $this->load($composerAuditRunner, $projectPath, $logger);
     }
 
+    #[Override]
     public function lookup(string $packageName, string $installedVersion): array
     {
         return $this->entriesByPackage[$packageName] ?? [];
@@ -91,6 +93,8 @@ final readonly class ComposerAuditAdvisoryDatabase implements AdvisoryDatabaseIn
 
     /**
      * @return array<string, list<array{cve: ?string, title: string, summary: string, affected_versions: string, link: ?string}>>
+     *
+     * @throws MalformedAdvisoryPayloadException
      */
     private function parse(string $json): array
     {

--- a/src/Audit/Infrastructure/Advisory/InMemoryAdvisoryDatabase.php
+++ b/src/Audit/Infrastructure/Advisory/InMemoryAdvisoryDatabase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AdvisoryDatabaseInterface;
 
 /**
@@ -34,6 +35,7 @@ final readonly class InMemoryAdvisoryDatabase implements AdvisoryDatabaseInterfa
      */
     public function __construct(private array $entriesByPackage = []) {}
 
+    #[Override]
     public function lookup(string $packageName, string $installedVersion): array
     {
         return $this->entriesByPackage[$packageName] ?? [];

--- a/src/Audit/Infrastructure/Advisory/LockfileHashedAdvisoryCache.php
+++ b/src/Audit/Infrastructure/Advisory/LockfileHashedAdvisoryCache.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -42,6 +43,7 @@ final readonly class LockfileHashedAdvisoryCache implements ComposerAuditRunnerI
         private LoggerInterface $logger,
     ) {}
 
+    #[Override]
     public function run(string $projectPath): string
     {
         $lockfileHash = $this->lockfileHash($projectPath);

--- a/src/Audit/Infrastructure/Advisory/SymfonyProcessComposerAuditRunner.php
+++ b/src/Audit/Infrastructure/Advisory/SymfonyProcessComposerAuditRunner.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory;
 
 use Closure;
+use Override;
 use Symfony\Component\Process\Exception\ExceptionInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -51,6 +52,7 @@ final readonly class SymfonyProcessComposerAuditRunner implements ComposerAuditR
         );
     }
 
+    #[Override]
     public function run(string $projectPath): string
     {
         $builder = $this->processBuilder ?? self::defaultProcessBuilder();

--- a/src/Audit/Infrastructure/Cache/FilesystemAttackerCache.php
+++ b/src/Audit/Infrastructure/Cache/FilesystemAttackerCache.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache;
 
 use JsonException;
+use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -27,6 +28,9 @@ use function Symfony\Component\String\u;
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class FilesystemAttackerCache implements ContextAwareAttackerCacheInterface
 {
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function __construct(
         private string $cacheDir,
         private Filesystem $filesystem,
@@ -38,16 +42,19 @@ final readonly class FilesystemAttackerCache implements ContextAwareAttackerCach
         }
     }
 
+    #[Override]
     public function get(array $chunk): ?array
     {
         return $this->getForContext($chunk, '');
     }
 
+    #[Override]
     public function store(array $chunk, array $rawVulnerabilities): void
     {
         $this->storeForContext($chunk, '', $rawVulnerabilities);
     }
 
+    #[Override]
     public function getForContext(array $chunk, string $contextKey): ?array
     {
         $path = $this->pathForChunk($chunk, $contextKey);
@@ -84,6 +91,7 @@ final readonly class FilesystemAttackerCache implements ContextAwareAttackerCach
         }
     }
 
+    #[Override]
     public function storeForContext(array $chunk, string $contextKey, array $rawVulnerabilities): void
     {
         $path = $this->pathForChunk($chunk, $contextKey);

--- a/src/Audit/Infrastructure/Cache/FilesystemReviewerCache.php
+++ b/src/Audit/Infrastructure/Cache/FilesystemReviewerCache.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache;
 
 use JsonException;
+use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -42,6 +43,9 @@ final readonly class FilesystemReviewerCache implements ReviewerCacheInterface
      */
     public const int CACHE_VERSION = 1;
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function __construct(
         private string $cacheDir,
         private Filesystem $filesystem,
@@ -53,6 +57,7 @@ final readonly class FilesystemReviewerCache implements ReviewerCacheInterface
         }
     }
 
+    #[Override]
     public function get(Vulnerability $vulnerability, string $codeContext): ?array
     {
         $path = $this->pathFor($vulnerability, $codeContext);
@@ -87,6 +92,7 @@ final readonly class FilesystemReviewerCache implements ReviewerCacheInterface
         }
     }
 
+    #[Override]
     public function store(Vulnerability $vulnerability, string $codeContext, array $review): void
     {
         $path = $this->pathFor($vulnerability, $codeContext);

--- a/src/Audit/Infrastructure/Cache/NullAttackerCache.php
+++ b/src/Audit/Infrastructure/Cache/NullAttackerCache.php
@@ -13,26 +13,31 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ContextAwareAttackerCacheInterface;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class NullAttackerCache implements ContextAwareAttackerCacheInterface
 {
+    #[Override]
     public function get(array $chunk): ?array
     {
         return null;
     }
 
+    #[Override]
     public function store(array $chunk, array $rawVulnerabilities): void
     {
         // intentionally noop
     }
 
+    #[Override]
     public function getForContext(array $chunk, string $contextKey): ?array
     {
         return null;
     }
 
+    #[Override]
     public function storeForContext(array $chunk, string $contextKey, array $rawVulnerabilities): void
     {
         // intentionally noop

--- a/src/Audit/Infrastructure/Cache/NullReviewerCache.php
+++ b/src/Audit/Infrastructure/Cache/NullReviewerCache.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ReviewerCacheInterface;
 
@@ -24,10 +25,12 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ReviewerCacheInterfac
  */
 final readonly class NullReviewerCache implements ReviewerCacheInterface
 {
+    #[Override]
     public function get(Vulnerability $vulnerability, string $codeContext): ?array
     {
         return null;
     }
 
+    #[Override]
     public function store(Vulnerability $vulnerability, string $codeContext, array $review): void {}
 }

--- a/src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php
+++ b/src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Diff;
 
+use Override;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -45,6 +46,10 @@ final readonly class ProcessGitChangedFilesResolver implements GitChangedFilesRe
         private Filesystem $filesystem = new Filesystem(),
     ) {}
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
+    #[Override]
     public function changedSince(string $projectPath, string $ref): array
     {
         if (!$this->filesystem->exists($projectPath.'/.git') && !$this->isInsideGitTree($projectPath)) {
@@ -81,6 +86,8 @@ final readonly class ProcessGitChangedFilesResolver implements GitChangedFilesRe
      * @param list<string> $argv
      *
      * @return list<string>
+     *
+     * @throws GitChangedFilesUnavailableException
      */
     private function runGit(string $projectPath, array $argv): array
     {

--- a/src/Audit/Infrastructure/FileSystem/NullSecretScrubber.php
+++ b/src/Audit/Infrastructure/FileSystem/NullSecretScrubber.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\SecretScrubberInterface;
 
 /**
@@ -22,6 +23,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\SecretScrubberInterfa
  */
 final readonly class NullSecretScrubber implements SecretScrubberInterface
 {
+    #[Override]
     public function scrub(string $content): string
     {
         return $content;

--- a/src/Audit/Infrastructure/FileSystem/ProjectFileScanner.php
+++ b/src/Audit/Infrastructure/FileSystem/ProjectFileScanner.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem;
 
 use Closure;
+use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
@@ -66,6 +67,7 @@ final readonly class ProjectFileScanner implements ProjectFileScannerInterface
     /**
      * @return list<ProjectFile>
      */
+    #[Override]
     public function scan(string $projectPath): array
     {
         $this->logger->info('Scanning project', ['path' => $projectPath]);

--- a/src/Audit/Infrastructure/FileSystem/RegexSecretScrubber.php
+++ b/src/Audit/Infrastructure/FileSystem/RegexSecretScrubber.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SecretPatternLabel;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\SecretScrubberInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\Exception\SecretScrubberConfigurationException;
@@ -57,6 +58,8 @@ final readonly class RegexSecretScrubber implements SecretScrubberInterface
      * @param list<string> $additionalPatterns extra PCRE patterns merged with the defaults.
      *                                         Each pattern is given a synthetic label
      *                                         `custom_<index>` for redaction reporting.
+     *
+     * @throws SecretScrubberConfigurationException
      */
     public function __construct(array $additionalPatterns = [])
     {
@@ -73,6 +76,7 @@ final readonly class RegexSecretScrubber implements SecretScrubberInterface
         $this->patterns = $patterns;
     }
 
+    #[Override]
     public function scrub(string $content): string
     {
         foreach ($this->patterns as $label => $pattern) {

--- a/src/Audit/Infrastructure/LLM/BackoffSchedule.php
+++ b/src/Audit/Infrastructure/LLM/BackoffSchedule.php
@@ -22,6 +22,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\Inva
  */
 final readonly class BackoffSchedule
 {
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function __construct(
         public int $maxAttempts = RetryPolicy::DEFAULT_MAX_ATTEMPTS,
         public int $initialDelayMs = RetryPolicy::DEFAULT_INITIAL_DELAY_MS,

--- a/src/Audit/Infrastructure/LLM/BatchWindowResolver.php
+++ b/src/Audit/Infrastructure/LLM/BatchWindowResolver.php
@@ -53,6 +53,9 @@ final readonly class BatchWindowResolver
      * @param list<array{system: string, user: string}> $window
      *
      * @return list<LLMResponse>
+     *
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
      */
     public function resolveWindow(array $window): array
     {
@@ -85,6 +88,8 @@ final readonly class BatchWindowResolver
 
     /**
      * @param array{system: string, user: string} $request
+     *
+     * @throws BudgetExceededException
      */
     private function resolveOne(?DeferredResult $deferredResult, array $request): LLMResponse
     {

--- a/src/Audit/Infrastructure/LLM/Delay/UsleepSleeper.php
+++ b/src/Audit/Infrastructure/LLM/Delay/UsleepSleeper.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay;
 
 use Closure;
+use Override;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class UsleepSleeper implements SleeperInterface
@@ -29,6 +30,7 @@ final readonly class UsleepSleeper implements SleeperInterface
         $this->usleep = $usleep ?? usleep(...);
     }
 
+    #[Override]
     public function sleep(int $milliseconds): void
     {
         if ($milliseconds <= 0) {

--- a/src/Audit/Infrastructure/LLM/RateLimit/NullRateLimiter.php
+++ b/src/Audit/Infrastructure/LLM/RateLimit/NullRateLimiter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RateLimit;
 
 use DateTimeImmutable;
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
 
 /**
@@ -24,16 +25,19 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
  */
 final readonly class NullRateLimiter implements RateLimiterInterface
 {
+    #[Override]
     public function acquire(int $estimatedInputTokens): void
     {
         // No throttle configured — let the call through immediately.
     }
 
+    #[Override]
     public function record(int $inputTokens, int $outputTokens): void
     {
         // Nothing to reconcile when no bucket exists.
     }
 
+    #[Override]
     public function pauseUntil(DateTimeImmutable $until): void
     {
         // No bucket to freeze.

--- a/src/Audit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiter.php
+++ b/src/Audit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiter.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RateLimi
 
 use DateTimeImmutable;
 use InvalidArgumentException;
+use Override;
 use Psr\Clock\ClockInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Configuration\RateLimitConfiguration;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
@@ -73,6 +74,10 @@ final class TokenBucketRateLimiter implements RateLimiterInterface
         $this->windowStart = $this->floorToMinute($this->clock->now());
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
+    #[Override]
     public function acquire(int $estimatedInputTokens): void
     {
         $this->assertAcceptableEstimate($estimatedInputTokens);
@@ -94,6 +99,9 @@ final class TokenBucketRateLimiter implements RateLimiterInterface
         }
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     private function assertAcceptableEstimate(int $estimatedInputTokens): void
     {
         if ($estimatedInputTokens < 0) {
@@ -131,6 +139,7 @@ final class TokenBucketRateLimiter implements RateLimiterInterface
         return true;
     }
 
+    #[Override]
     public function record(int $inputTokens, int $outputTokens): void
     {
         $this->inputTokensUsed = $this->inputTokensUsed - $this->pendingInputEstimate + $inputTokens;
@@ -138,6 +147,7 @@ final class TokenBucketRateLimiter implements RateLimiterInterface
         $this->outputTokensUsed += $outputTokens;
     }
 
+    #[Override]
     public function pauseUntil(DateTimeImmutable $until): void
     {
         $this->pausedUntil = $until;

--- a/src/Audit/Infrastructure/LLM/RateLimitBackoff.php
+++ b/src/Audit/Infrastructure/LLM/RateLimitBackoff.php
@@ -22,6 +22,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\Inva
  */
 final readonly class RateLimitBackoff
 {
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function __construct(
         public int $initialDelayMs = RetryPolicy::DEFAULT_RATE_LIMIT_DELAY_MS,
         public int $maxDelayMs = RetryPolicy::DEFAULT_RATE_LIMIT_MAX_DELAY_MS,

--- a/src/Audit/Infrastructure/LLM/RetryingPlatformInvoker.php
+++ b/src/Audit/Infrastructure/LLM/RetryingPlatformInvoker.php
@@ -48,7 +48,14 @@ final readonly class RetryingPlatformInvoker
         private RetryAfterHeaderParser $retryAfterHeaderParser,
     ) {}
 
-    /** @param array<string, mixed> $options */
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws EmptyLLMResponseException
+     * @throws NonTransientLLMFailureException
+     */
     public function invoke(MessageBag $messageBag, array $options, int $estimatedInputTokens): DeferredResult
     {
         $platform = $this->platform ?? throw MissingAiPlatformException::create();
@@ -78,6 +85,10 @@ final readonly class RetryingPlatformInvoker
         }
     }
 
+    /**
+     * @throws EmptyLLMResponseException
+     * @throws NonTransientLLMFailureException
+     */
     private function rethrowWhenNonTransient(Throwable $throwable): void
     {
         if ($this->transientFailureClassifier->isEmptyContent($throwable)) {

--- a/src/Audit/Infrastructure/LLM/SequentialToolLoop.php
+++ b/src/Audit/Infrastructure/LLM/SequentialToolLoop.php
@@ -19,11 +19,15 @@ use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\ToolCallMessage;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\BudgetTracker;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\TokenUsageSnapshot;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\EmptyLLMResponseException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\MissingAiPlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\NonTransientLLMFailureException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\TransientLLMFailureException;
 
 /**
  * Drives one autonomous tool-using conversation sequentially: invokes the
@@ -46,6 +50,12 @@ final readonly class SequentialToolLoop
         private PromptTokenEstimator $promptTokenEstimator,
     ) {}
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function run(string $systemPrompt, string $userMessage, ToolRegistry $toolRegistry, int $maxToolIterations): LLMResponse
     {
         \assert('' !== $this->model, 'Model must be a non-empty string');

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -13,16 +13,21 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\BudgetTracker;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\TokenUsageSnapshot;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ToolBatchCapableLLMClientInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\EmptyLLMResponseException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\MissingAiPlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\NonTransientLLMFailureException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\TransientLLMFailureException;
 
 /**
  * Implements the Domain LLM ports on top of the symfony/ai platform. The
@@ -126,6 +131,13 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         );
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
+    #[Override]
     public function complete(string $systemPrompt, string $userMessage): LLMResponse
     {
         $this->logger->debug('Invoking symfony/ai platform', [
@@ -171,6 +183,11 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         return $llmResponse;
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
+    #[Override]
     public function completeBatch(array $requests, int $maxConcurrent): array
     {
         \assert('' !== $this->model, 'Model must be a non-empty string');
@@ -187,6 +204,11 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         return $responses;
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
+    #[Override]
     public function completeBatchWithTools(array $requests, int $maxConcurrent, int $maxToolIterations): array
     {
         \assert('' !== $this->model, 'Model must be a non-empty string');
@@ -203,6 +225,13 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         return $responses;
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
+    #[Override]
     public function completeWithTools(
         string $systemPrompt,
         string $userMessage,
@@ -212,6 +241,7 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         return $this->sequentialToolLoop->run($systemPrompt, $userMessage, $toolRegistry, $maxToolIterations);
     }
 
+    #[Override]
     public function model(): string
     {
         return $this->model;

--- a/src/Audit/Infrastructure/LLM/TokenEstimator/AnthropicTokenEstimator.php
+++ b/src/Audit/Infrastructure/LLM/TokenEstimator/AnthropicTokenEstimator.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TokenEstimator;
 
+use Override;
+
 use function Symfony\Component\String\u;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
@@ -27,11 +29,13 @@ final readonly class AnthropicTokenEstimator implements ProviderTokenEstimatorIn
 
     public function __construct(private CharacterRatioCounter $characterRatioCounter = new CharacterRatioCounter()) {}
 
+    #[Override]
     public function supports(string $model): bool
     {
         return u($model)->startsWith('claude-');
     }
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         return $this->characterRatioCounter->estimate($text, $this->charsPerToken($model));

--- a/src/Audit/Infrastructure/LLM/TokenEstimator/DeepSeekTokenEstimator.php
+++ b/src/Audit/Infrastructure/LLM/TokenEstimator/DeepSeekTokenEstimator.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TokenEstimator;
 
+use Override;
+
 use function Symfony\Component\String\u;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
@@ -22,11 +24,13 @@ final readonly class DeepSeekTokenEstimator implements ProviderTokenEstimatorInt
 
     public function __construct(private CharacterRatioCounter $characterRatioCounter = new CharacterRatioCounter()) {}
 
+    #[Override]
     public function supports(string $model): bool
     {
         return u($model)->startsWith('deepseek-');
     }
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         return $this->characterRatioCounter->estimate($text, self::CHARS_PER_TOKEN);

--- a/src/Audit/Infrastructure/LLM/TokenEstimator/GeminiTokenEstimator.php
+++ b/src/Audit/Infrastructure/LLM/TokenEstimator/GeminiTokenEstimator.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TokenEstimator;
 
+use Override;
+
 use function Symfony\Component\String\u;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
@@ -22,11 +24,13 @@ final readonly class GeminiTokenEstimator implements ProviderTokenEstimatorInter
 
     public function __construct(private CharacterRatioCounter $characterRatioCounter = new CharacterRatioCounter()) {}
 
+    #[Override]
     public function supports(string $model): bool
     {
         return u($model)->startsWith('gemini-');
     }
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         return $this->characterRatioCounter->estimate($text, self::CHARS_PER_TOKEN);

--- a/src/Audit/Infrastructure/LLM/TokenEstimator/LlamaTokenEstimator.php
+++ b/src/Audit/Infrastructure/LLM/TokenEstimator/LlamaTokenEstimator.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TokenEstimator;
 
+use Override;
+
 use function Symfony\Component\String\u;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
@@ -25,6 +27,7 @@ final readonly class LlamaTokenEstimator implements ProviderTokenEstimatorInterf
 
     public function __construct(private CharacterRatioCounter $characterRatioCounter = new CharacterRatioCounter()) {}
 
+    #[Override]
     public function supports(string $model): bool
     {
         foreach (self::PREFIXES as $prefix) {
@@ -36,6 +39,7 @@ final readonly class LlamaTokenEstimator implements ProviderTokenEstimatorInterf
         return false;
     }
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         return $this->characterRatioCounter->estimate($text, self::CHARS_PER_TOKEN);

--- a/src/Audit/Infrastructure/LLM/TokenEstimator/MistralTokenEstimator.php
+++ b/src/Audit/Infrastructure/LLM/TokenEstimator/MistralTokenEstimator.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TokenEstimator;
 
+use Override;
+
 use function Symfony\Component\String\u;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
@@ -25,6 +27,7 @@ final readonly class MistralTokenEstimator implements ProviderTokenEstimatorInte
 
     public function __construct(private CharacterRatioCounter $characterRatioCounter = new CharacterRatioCounter()) {}
 
+    #[Override]
     public function supports(string $model): bool
     {
         foreach (self::PREFIXES as $prefix) {
@@ -36,6 +39,7 @@ final readonly class MistralTokenEstimator implements ProviderTokenEstimatorInte
         return false;
     }
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         return $this->characterRatioCounter->estimate($text, self::CHARS_PER_TOKEN);

--- a/src/Audit/Infrastructure/LLM/TokenEstimator/OpenAiTokenEstimator.php
+++ b/src/Audit/Infrastructure/LLM/TokenEstimator/OpenAiTokenEstimator.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TokenEstimator;
 
+use Override;
+
 use function Symfony\Component\String\u;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
@@ -25,6 +27,7 @@ final readonly class OpenAiTokenEstimator implements ProviderTokenEstimatorInter
 
     public function __construct(private CharacterRatioCounter $characterRatioCounter = new CharacterRatioCounter()) {}
 
+    #[Override]
     public function supports(string $model): bool
     {
         foreach (self::PREFIXES as $prefix) {
@@ -36,6 +39,7 @@ final readonly class OpenAiTokenEstimator implements ProviderTokenEstimatorInter
         return false;
     }
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         return $this->characterRatioCounter->estimate($text, self::CHARS_PER_TOKEN);

--- a/src/Audit/Infrastructure/LLM/TokenEstimator/ResolvingTokenEstimator.php
+++ b/src/Audit/Infrastructure/LLM/TokenEstimator/ResolvingTokenEstimator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TokenEstimator;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\TokenEstimatorInterface;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
@@ -34,6 +35,7 @@ final readonly class ResolvingTokenEstimator implements TokenEstimatorInterface
         private float $fallbackCharsPerToken = self::CHARS_PER_TOKEN_DEFAULT,
     ) {}
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         foreach ($this->providerEstimators as $providerEstimator) {

--- a/src/Audit/Infrastructure/LLM/ToolConversationWavefront.php
+++ b/src/Audit/Infrastructure/LLM/ToolConversationWavefront.php
@@ -63,6 +63,9 @@ final readonly class ToolConversationWavefront
      * @param list<array{system: string, user: string, tools: ToolRegistry}> $window
      *
      * @return list<LLMResponse>
+     *
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
      */
     public function resolveToolWindow(array $window, int $maxToolIterations): array
     {
@@ -108,6 +111,8 @@ final readonly class ToolConversationWavefront
      * @param list<array{system: string, user: string, tools: ToolRegistry}>                                                                                                             $window
      *
      * @return array<int, array{bag: MessageBag, options: array<string, mixed>, input: int, output: int, cacheRead: int, cacheCreation: int, toolsRan: bool, response: LLMResponse|null}>
+     *
+     * @throws BudgetExceededException
      */
     private function runWavefrontRound(PlatformInterface $platform, array $states, array $window, int $maxToolIterations): array
     {
@@ -178,6 +183,8 @@ final readonly class ToolConversationWavefront
      * @param array{system: string, user: string, tools: ToolRegistry}                                                                                                       $request
      *
      * @return array{bag: MessageBag, options: array<string, mixed>, input: int, output: int, cacheRead: int, cacheCreation: int, toolsRan: bool, response: LLMResponse|null}
+     *
+     * @throws BudgetExceededException
      */
     private function advanceConversation(array $state, ?DeferredResult $deferredResult, array $request, int $maxToolIterations): array
     {

--- a/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
+++ b/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
@@ -16,6 +16,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Pricing;
 use Composer\InstalledVersions;
 use JsonException;
 use OutOfBoundsException;
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CacheAwarePricingProviderInterface;
 
@@ -55,26 +56,31 @@ final class ModelsDevPricingProvider implements CacheAwarePricingProviderInterfa
         private readonly string $catalogPackage = self::CATALOG_PACKAGE,
     ) {}
 
+    #[Override]
     public function pricePerMillionInputTokens(string $model): float
     {
         return $this->priced($model)->input;
     }
 
+    #[Override]
     public function pricePerMillionOutputTokens(string $model): float
     {
         return $this->priced($model)->output;
     }
 
+    #[Override]
     public function cacheReadPricePerMillionTokens(string $model): float
     {
         return $this->priced($model)->cacheRead;
     }
 
+    #[Override]
     public function cacheCreationPricePerMillionTokens(string $model): float
     {
         return $this->priced($model)->cacheCreation;
     }
 
+    #[Override]
     public function hasModel(string $model): bool
     {
         return $this->lookup($model) instanceof ModelPrice;

--- a/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress;
 
+use Override;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProgressEvent;
@@ -55,6 +56,7 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function report(string $event, array $context = []): void
     {
         match (ProgressEvent::tryFrom($event)) {

--- a/src/Audit/Infrastructure/Progress/LoggerProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/LoggerProgressReporter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
@@ -32,6 +33,7 @@ final readonly class LoggerProgressReporter implements ProgressReporterInterface
 {
     public function __construct(private LoggerInterface $logger) {}
 
+    #[Override]
     public function report(string $event, array $context = []): void
     {
         try {

--- a/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress;
 
+use Override;
 use Symfony\Component\Console\Output\OutputInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProgressEvent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
@@ -34,6 +35,7 @@ final readonly class PlainProgressReporter implements ProgressReporterInterface
     /**
      * {@inheritDoc}
      */
+    #[Override]
     public function report(string $event, array $context = []): void
     {
         match (ProgressEvent::tryFrom($event)) {

--- a/src/Audit/Infrastructure/Progress/ProgressContext.php
+++ b/src/Audit/Infrastructure/Progress/ProgressContext.php
@@ -54,6 +54,6 @@ final readonly class ProgressContext
             return '';
         }
 
-        return \sprintf(' (%ds)', round($value));
+        return \sprintf(' (%ds)', (int) round($value));
     }
 }

--- a/src/Audit/Infrastructure/Progress/ProgressReporterHolder.php
+++ b/src/Audit/Infrastructure/Progress/ProgressReporterHolder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\NullProgressReporter;
@@ -50,6 +51,7 @@ final class ProgressReporterHolder implements ProgressReporterInterface
         $this->progressReporter = $progressReporter;
     }
 
+    #[Override]
     public function report(string $event, array $context = []): void
     {
         try {

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
@@ -296,6 +297,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
     /**
      * @param list<ProjectFile> $files
      */
+    #[Override]
     public function buildSystemPrompt(array $files = []): string
     {
         $base = $this->basePrompt();
@@ -312,6 +314,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
     /**
      * @param list<ProjectFile> $files
      */
+    #[Override]
     public function buildUserMessage(array $files, SymfonyMapping $symfonyMapping): string
     {
         $context = NumberedFileContextRenderer::render($files);

--- a/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/ReviewerPromptBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ReviewerPromptBuilderInterface;
 
@@ -143,6 +144,7 @@ final readonly class ReviewerPromptBuilder implements ReviewerPromptBuilderInter
         private bool $useStructuredCollection = self::DEFAULT_STRUCTURED_COLLECTION,
     ) {}
 
+    #[Override]
     public function buildSystemPrompt(): string
     {
         if ($this->useStructuredCollection) {
@@ -166,6 +168,7 @@ final readonly class ReviewerPromptBuilder implements ReviewerPromptBuilderInter
         ]);
     }
 
+    #[Override]
     public function buildBatchSystemPrompt(): string
     {
         $batchPreamble = 'You will receive SEVERAL vulnerability reports in a single batch and must validate each one.';
@@ -200,6 +203,7 @@ final readonly class ReviewerPromptBuilder implements ReviewerPromptBuilderInter
         ]);
     }
 
+    #[Override]
     public function buildBatchUserMessage(array $vulnerabilities, array $codeContexts): string
     {
         $sections = [];
@@ -271,6 +275,7 @@ final readonly class ReviewerPromptBuilder implements ReviewerPromptBuilderInter
         return "\n\nReturn a JSON array of reviews — one entry per finding above. Each entry's \"id\" must match the input; we re-key by id on parse, so a misordered array with correct ids will still be accepted.";
     }
 
+    #[Override]
     public function buildUserMessage(Vulnerability $vulnerability, string $codeContext): string
     {
         $data = $vulnerability->toArray();

--- a/src/Audit/Infrastructure/Scan/PhpParserControllerAccessControlParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserControllerAccessControlParser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
 
+use Override;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
@@ -43,6 +44,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ControllerAccessContr
  */
 final readonly class PhpParserControllerAccessControlParser implements ControllerAccessControlParserInterface
 {
+    #[Override]
     public function parse(ProjectFile $projectFile): array
     {
         if (ProjectFileType::CONTROLLER !== $projectFile->fileType()) {

--- a/src/Audit/Infrastructure/Scan/PhpParserFormBindingParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserFormBindingParser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
 
+use Override;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
@@ -43,6 +44,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\FormBindingParserInte
  */
 final readonly class PhpParserFormBindingParser implements FormBindingParserInterface
 {
+    #[Override]
     public function parse(ProjectFile $projectFile): array
     {
         if (ProjectFileType::CONTROLLER !== $projectFile->fileType()) {

--- a/src/Audit/Infrastructure/Scan/PhpParserVoterCapabilityParser.php
+++ b/src/Audit/Infrastructure/Scan/PhpParserVoterCapabilityParser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
 
+use Override;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Name;
@@ -41,6 +42,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParser
  */
 final readonly class PhpParserVoterCapabilityParser implements VoterCapabilityParserInterface
 {
+    #[Override]
     public function parse(ProjectFile $projectFile): ?VoterCapability
     {
         if (ProjectFileType::VOTER !== $projectFile->fileType()) {

--- a/src/Audit/Infrastructure/Scan/RegexCodeSlicer.php
+++ b/src/Audit/Infrastructure/Scan/RegexCodeSlicer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CodeSlicerInterface;
 
@@ -149,6 +150,7 @@ final readonly class RegexCodeSlicer implements CodeSlicerInterface
         private int $minLinesBeforeSlicing = self::DEFAULT_MIN_LINES_BEFORE_SLICING,
     ) {}
 
+    #[Override]
     public function slice(ProjectFile $projectFile): string
     {
         if (!$this->shouldSlice($projectFile)) {

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskMarker;
@@ -236,6 +237,7 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      *
      * @return list<RiskMarker>
      */
+    #[Override]
     public function scan(array $files): array
     {
         $markers = [];

--- a/src/Audit/Infrastructure/Tool/GrepTool.php
+++ b/src/Audit/Infrastructure/Tool/GrepTool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolDefinition;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
@@ -34,6 +35,7 @@ final readonly class GrepTool implements ToolInterface
      */
     public function __construct(private array $files) {}
 
+    #[Override]
     public function definition(): ToolDefinition
     {
         return new ToolDefinition(
@@ -56,6 +58,7 @@ final readonly class GrepTool implements ToolInterface
         );
     }
 
+    #[Override]
     public function execute(array $arguments): string
     {
         $pattern = $arguments['pattern'] ?? null;

--- a/src/Audit/Infrastructure/Tool/ListFilesTool.php
+++ b/src/Audit/Infrastructure/Tool/ListFilesTool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolDefinition;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
@@ -31,6 +32,7 @@ final readonly class ListFilesTool implements ToolInterface
      */
     public function __construct(private array $files) {}
 
+    #[Override]
     public function definition(): ToolDefinition
     {
         return new ToolDefinition(
@@ -48,6 +50,7 @@ final readonly class ListFilesTool implements ToolInterface
         );
     }
 
+    #[Override]
     public function execute(array $arguments): string
     {
         $rawFileType = $arguments['file_type'] ?? null;

--- a/src/Audit/Infrastructure/Tool/LookupAdvisoryTool.php
+++ b/src/Audit/Infrastructure/Tool/LookupAdvisoryTool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AdvisoryDatabaseInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolDefinition;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
@@ -28,6 +29,7 @@ final readonly class LookupAdvisoryTool implements ToolInterface
 {
     public function __construct(private AdvisoryDatabaseInterface $advisoryDatabase) {}
 
+    #[Override]
     public function definition(): ToolDefinition
     {
         return new ToolDefinition(
@@ -50,6 +52,7 @@ final readonly class LookupAdvisoryTool implements ToolInterface
         );
     }
 
+    #[Override]
     public function execute(array $arguments): string
     {
         $package = $arguments['package'] ?? null;

--- a/src/Audit/Infrastructure/Tool/ReadFileTool.php
+++ b/src/Audit/Infrastructure/Tool/ReadFileTool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolDefinition;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
@@ -46,6 +47,7 @@ final readonly class ReadFileTool implements ToolInterface
         $this->filesByPath = $byPath;
     }
 
+    #[Override]
     public function definition(): ToolDefinition
     {
         return new ToolDefinition(
@@ -64,6 +66,7 @@ final readonly class ReadFileTool implements ToolInterface
         );
     }
 
+    #[Override]
     public function execute(array $arguments): string
     {
         $rawPath = $arguments['relative_path'] ?? null;

--- a/src/Audit/Infrastructure/Tool/RecordReviewTool.php
+++ b/src/Audit/Infrastructure/Tool/RecordReviewTool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewCollector;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
@@ -35,6 +36,7 @@ final readonly class RecordReviewTool implements ToolInterface
         private ReviewCollector $reviewCollector,
     ) {}
 
+    #[Override]
     public function definition(): ToolDefinition
     {
         return new ToolDefinition(
@@ -44,6 +46,7 @@ final readonly class RecordReviewTool implements ToolInterface
         );
     }
 
+    #[Override]
     public function execute(array $arguments): string
     {
         $this->reviewCollector->add($arguments);

--- a/src/Audit/Infrastructure/Tool/RecordReviewToolFactory.php
+++ b/src/Audit/Infrastructure/Tool/RecordReviewToolFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\RecordReviewToolFactoryInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewCollector;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
@@ -20,6 +21,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class RecordReviewToolFactory implements RecordReviewToolFactoryInterface
 {
+    #[Override]
     public function create(ReviewCollector $reviewCollector): ToolInterface
     {
         return new RecordReviewTool($reviewCollector);

--- a/src/Audit/Infrastructure/Tool/RecordVulnerabilityTool.php
+++ b/src/Audit/Infrastructure/Tool/RecordVulnerabilityTool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityCollector;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
@@ -34,6 +35,7 @@ final readonly class RecordVulnerabilityTool implements ToolInterface
         private VulnerabilityCollector $vulnerabilityCollector,
     ) {}
 
+    #[Override]
     public function definition(): ToolDefinition
     {
         return new ToolDefinition(
@@ -43,6 +45,7 @@ final readonly class RecordVulnerabilityTool implements ToolInterface
         );
     }
 
+    #[Override]
     public function execute(array $arguments): string
     {
         $this->vulnerabilityCollector->add($arguments);

--- a/src/Audit/Infrastructure/Tool/RecordVulnerabilityToolFactory.php
+++ b/src/Audit/Infrastructure/Tool/RecordVulnerabilityToolFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\RecordVulnerabilityToolFactoryInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityCollector;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
@@ -20,6 +21,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class RecordVulnerabilityToolFactory implements RecordVulnerabilityToolFactoryInterface
 {
+    #[Override]
     public function create(VulnerabilityCollector $vulnerabilityCollector): ToolInterface
     {
         return new RecordVulnerabilityTool($vulnerabilityCollector);

--- a/src/Audit/Infrastructure/Tool/SymfonyToolRegistryFactory.php
+++ b/src/Audit/Infrastructure/Tool/SymfonyToolRegistryFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Tool;
 
+use Override;
 use Psr\Log\LoggerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\AdvisoryDatabaseInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
@@ -32,6 +33,7 @@ final readonly class SymfonyToolRegistryFactory implements ToolRegistryFactoryIn
         private AdvisoryDatabaseInterface $advisoryDatabase,
     ) {}
 
+    #[Override]
     public function forProjectFiles(array $projectFiles): ToolRegistry
     {
         return new ToolRegistry(

--- a/src/Command/AuditCommand.php
+++ b/src/Command/AuditCommand.php
@@ -27,6 +27,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskLevel;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ConsoleProgressReporter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\PlainProgressReporter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ProgressReporterHolder;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\WorkingDirectoryUnavailableException;
 
 #[AsCommand(
     name: 'audit:run',
@@ -55,6 +56,9 @@ final readonly class AuditCommand
         private RiskLevel $riskLevel = RiskLevel::Critical,
     ) {}
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function __invoke(
         InputInterface $input,
         SymfonyStyle $symfonyStyle,

--- a/src/Command/AuditCommandInput.php
+++ b/src/Command/AuditCommandInput.php
@@ -68,6 +68,8 @@ final class AuditCommandInput
 
     /**
      * @param ?callable(): (string|false) $cwdResolver defaults to PHP's getcwd; tests inject a stub
+     *
+     * @throws WorkingDirectoryUnavailableException
      */
     public function resolvedProjectPath(?callable $cwdResolver = null): string
     {

--- a/src/Command/AuditExitCodeResolver.php
+++ b/src/Command/AuditExitCodeResolver.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskLevel;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditExitCodeResolver implements AuditExitCodeResolverInterface
 {
+    #[Override]
     public function resolve(AuditReport $auditReport, RiskLevel $riskLevel): int
     {
         return $auditReport->riskLevelEnum()->isAtLeast($riskLevel)

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
 use InvalidArgumentException;
+use Override;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
@@ -27,6 +28,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
 {
     public function __construct(private PricingProviderInterface $pricingProvider) {}
 
+    #[Override]
     public function header(SymfonyStyle $symfonyStyle, string $projectPath): void
     {
         $symfonyStyle->title('Symfony LLM Security Auditor');
@@ -40,6 +42,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
     /**
      * @param list<string> $configNotices
      */
+    #[Override]
     public function preflightWarnings(SymfonyStyle $symfonyStyle, bool $secretScrubbingEnabled, array $configNotices = []): void
     {
         foreach ($configNotices as $configNotice) {
@@ -53,6 +56,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         $symfonyStyle->getErrorStyle()->warning('Secret scrubbing is disabled. File contents will be sent verbatim to the configured LLM provider. If that provider runs in the cloud, credentials in committed configs or .env.dist files may be exposed. Re-enable scan.secret_scrubbing.enabled (the default) or confirm you are using a local provider.');
     }
 
+    #[Override]
     public function unsupportedModelWarnings(SymfonyStyle $symfonyStyle, AuditReport $auditReport): void
     {
         $unsupportedModels = $this->unsupportedModels($auditReport->cost());
@@ -81,11 +85,13 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         return $unsupportedModels;
     }
 
+    #[Override]
     public function runningSection(SymfonyStyle $symfonyStyle): void
     {
         $symfonyStyle->section('Running audit pipeline...');
     }
 
+    #[Override]
     public function longRunNotice(SymfonyStyle $symfonyStyle): void
     {
         $symfonyStyle->writeln([
@@ -95,11 +101,13 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         ]);
     }
 
+    #[Override]
     public function estimatingSection(SymfonyStyle $symfonyStyle): void
     {
         $symfonyStyle->section('Estimating audit cost (dry run)...');
     }
 
+    #[Override]
     public function dryRunResult(SymfonyStyle $symfonyStyle, AuditReport $auditReport): void
     {
         $cost = $auditReport->cost();
@@ -133,6 +141,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         $symfonyStyle->success('Dry run complete.');
     }
 
+    #[Override]
     public function scannedFiles(SymfonyStyle $symfonyStyle, array $projectFiles): void
     {
         if ([] === $projectFiles) {
@@ -151,6 +160,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         $symfonyStyle->success(\sprintf('%d file(s) in scope.', \count($projectFiles)));
     }
 
+    #[Override]
     public function scannedFilesHint(SymfonyStyle $symfonyStyle, int $fileCount): void
     {
         $symfonyStyle->writeln(\sprintf(
@@ -174,6 +184,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         return $byType;
     }
 
+    #[Override]
     public function error(SymfonyStyle $symfonyStyle, Throwable $throwable): void
     {
         $message = $throwable instanceof InvalidArgumentException
@@ -183,6 +194,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         $symfonyStyle->error($message);
     }
 
+    #[Override]
     public function result(SymfonyStyle $symfonyStyle, AuditReport $auditReport, int $exitCode): void
     {
         if (Command::FAILURE === $exitCode) {
@@ -201,6 +213,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         ));
     }
 
+    #[Override]
     public function baselineGenerated(SymfonyStyle $symfonyStyle, string $path, int $fingerprintCount): void
     {
         $symfonyStyle->success(\sprintf(
@@ -210,6 +223,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         ));
     }
 
+    #[Override]
     public function baselineApplied(SymfonyStyle $symfonyStyle, int $suppressedCount): void
     {
         if ($suppressedCount < 1) {

--- a/src/Command/Baseline.php
+++ b/src/Command/Baseline.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
 use JsonException;
+use Override;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedBaselineFileException;
 
@@ -28,6 +29,10 @@ final readonly class Baseline implements BaselineInterface
         private Filesystem $filesystem = new Filesystem(),
     ) {}
 
+    /**
+     * @throws MalformedBaselineFileException
+     */
+    #[Override]
     public function load(string $path): array
     {
         if (!$this->filesystem->exists($path)) {
@@ -56,6 +61,7 @@ final readonly class Baseline implements BaselineInterface
         return $fingerprints;
     }
 
+    #[Override]
     public function save(string $path, array $fingerprints): void
     {
         $this->filesystem->dumpFile(

--- a/src/Command/BaselineProcessor.php
+++ b/src/Command/BaselineProcessor.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 
 /**
@@ -29,6 +30,7 @@ final readonly class BaselineProcessor implements BaselineProcessorInterface
         private ?string $configuredBaseline = null,
     ) {}
 
+    #[Override]
     public function generate(AuditReport $auditReport, string $path): int
     {
         $fingerprints = $auditReport->fingerprints();
@@ -37,6 +39,7 @@ final readonly class BaselineProcessor implements BaselineProcessorInterface
         return \count($fingerprints);
     }
 
+    #[Override]
     public function apply(AuditReport $auditReport, ?string $cliBaseline): BaselineResult
     {
         $baselinePath = $cliBaseline ?? $this->configuredBaseline;

--- a/src/Command/FindingTypeFilter.php
+++ b/src/Command/FindingTypeFilter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 
@@ -35,6 +36,7 @@ final readonly class FindingTypeFilter implements FindingTypeFilterInterface
         $this->excludedTypes = array_map(VulnerabilityType::from(...), $excludedTypeValues);
     }
 
+    #[Override]
     public function apply(AuditReport $auditReport): AuditReport
     {
         return $auditReport->filteredByTypes($this->includedTypes, $this->excludedTypes);

--- a/src/Command/ReportWriter.php
+++ b/src/Command/ReportWriter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
+use Override;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
@@ -26,6 +27,7 @@ final readonly class ReportWriter implements ReportWriterInterface
         private Filesystem $filesystem,
     ) {}
 
+    #[Override]
     public function write(AuditReport $auditReport, OutputFormat $outputFormat, ?string $outputFile, SymfonyStyle $symfonyStyle): void
     {
         $content = match ($outputFormat) {

--- a/src/Command/UnpricedModelBudgetGuard.php
+++ b/src/Command/UnpricedModelBudgetGuard.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
+use Override;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\PricingProviderInterface;
@@ -27,6 +28,7 @@ final readonly class UnpricedModelBudgetGuard implements UnpricedModelBudgetGuar
         private ?float $maxCostUsd = null,
     ) {}
 
+    #[Override]
     public function permitsRun(InputInterface $input, SymfonyStyle $symfonyStyle): bool
     {
         $unpricedModels = $this->unpricedModels();

--- a/src/SymfonySecurityAuditorBundle.php
+++ b/src/SymfonySecurityAuditorBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor;
 
 use JsonException;
+use Override;
 use Psr\Clock\ClockInterface;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -82,6 +83,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
  */
 final class SymfonySecurityAuditorBundle extends AbstractBundle
 {
+    #[Override]
     public function configure(DefinitionConfigurator $definition): void
     {
         $definition->rootNode()
@@ -421,6 +423,7 @@ final class SymfonySecurityAuditorBundle extends AbstractBundle
      *
      * @throws JsonException
      */
+    #[Override]
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $container->import('../config/services.php');

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -1095,7 +1095,12 @@ final class AuditCommandEndToEndTest extends TestCase
             return;
         }
 
-        foreach (scandir($dir) as $item) {
+        $items = scandir($dir);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
             if ('.' === $item) {
                 continue;
             }

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\EndToEnd;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use RuntimeException;
@@ -622,11 +623,13 @@ final class AuditCommandEndToEndTest extends TestCase
         return (string) json_encode($vulns);
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->fixtureDir = sys_get_temp_dir().'/cmd_e2e_'.uniqid('', true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->rmdirRecursive($this->fixtureDir);
@@ -940,11 +943,13 @@ final class AuditCommandEndToEndTest extends TestCase
         file_put_contents($this->fixtureDir.'/src/Controller/UserController.php', '<?php class UserController { public function indexAction() {} }');
 
         $throwingLLM = new class implements LLMClientInterface {
+            #[Override]
             public function complete(string $systemPrompt, string $userMessage): LLMResponse
             {
                 throw new RuntimeException('platform must not be invoked during --dry-run');
             }
 
+            #[Override]
             public function completeWithTools(
                 string $systemPrompt,
                 string $userMessage,
@@ -954,6 +959,7 @@ final class AuditCommandEndToEndTest extends TestCase
                 throw new RuntimeException('platform must not be invoked during --dry-run');
             }
 
+            #[Override]
             public function model(): string
             {
                 return 'stub';
@@ -1068,11 +1074,13 @@ final class AuditCommandEndToEndTest extends TestCase
     private function throwingLLMClient(): LLMClientInterface
     {
         return new class implements LLMClientInterface {
+            #[Override]
             public function complete(string $systemPrompt, string $userMessage): LLMResponse
             {
                 throw new RuntimeException('the LLM platform must not be invoked for --show-scanned');
             }
 
+            #[Override]
             public function completeWithTools(
                 string $systemPrompt,
                 string $userMessage,
@@ -1082,6 +1090,7 @@ final class AuditCommandEndToEndTest extends TestCase
                 throw new RuntimeException('the LLM platform must not be invoked for --show-scanned');
             }
 
+            #[Override]
             public function model(): string
             {
                 return 'stub';

--- a/tests/Phpunit/EndToEnd/FullAuditEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/FullAuditEndToEndTest.php
@@ -268,7 +268,12 @@ final class FullAuditEndToEndTest extends TestCase
             return;
         }
 
-        foreach (scandir($dir) as $item) {
+        $items = scandir($dir);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
             if ('.' === $item) {
                 continue;
             }

--- a/tests/Phpunit/EndToEnd/FullAuditEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/FullAuditEndToEndTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\EndToEnd;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Validator\Validation;
@@ -26,6 +27,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgentCollaborators;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerModeConfiguration;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityFactory;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByBudgetException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\AuditPipeline;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage\AuditStage;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage\IngestionStage;
@@ -50,6 +52,9 @@ final class FullAuditEndToEndTest extends TestCase
 {
     private string $fixtureProjectDir;
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_audit_of_unprotected_symfony_project_produces_critical_report(): void
     {
         $this->createSymfonyProjectFixture(secure: false);
@@ -81,6 +86,9 @@ final class FullAuditEndToEndTest extends TestCase
         self::assertGreaterThan(0, $auditReport->riskScore());
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_audit_of_secured_project_produces_safe_report(): void
     {
         $this->createSymfonyProjectFixture(secure: true);
@@ -99,6 +107,9 @@ final class FullAuditEndToEndTest extends TestCase
         self::assertSame(0, $auditReport->riskScore());
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_audit_report_vulnerability_has_correct_owasp_type(): void
     {
         $this->createSymfonyProjectFixture(secure: false);
@@ -118,6 +129,9 @@ final class FullAuditEndToEndTest extends TestCase
         self::assertCount(1, $auditReport->vulnerabilitiesByType(VulnerabilityType::SQL_INJECTION));
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_audit_report_serialises_to_valid_json(): void
     {
         $this->createSymfonyProjectFixture(secure: false);
@@ -143,12 +157,14 @@ final class FullAuditEndToEndTest extends TestCase
         self::assertIsString(json_encode($data));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->fixtureProjectDir = sys_get_temp_dir().'/e2e_project_'.uniqid('', true);
         mkdir($this->fixtureProjectDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->rmdirRecursive($this->fixtureProjectDir);

--- a/tests/Phpunit/Integration/Advisory/Fixture/RecordingComposerAuditRunner.php
+++ b/tests/Phpunit/Integration/Advisory/Fixture/RecordingComposerAuditRunner.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Advisory\Fixture;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditRunnerInterface;
 
 /**
@@ -27,6 +28,7 @@ final class RecordingComposerAuditRunner implements ComposerAuditRunnerInterface
 
     public function __construct(public string $payload) {}
 
+    #[Override]
     public function run(string $projectPath): string
     {
         ++$this->callCount;

--- a/tests/Phpunit/Integration/Advisory/Fixture/RecordingComposerAuditRunner.php
+++ b/tests/Phpunit/Integration/Advisory/Fixture/RecordingComposerAuditRunner.php
@@ -28,6 +28,9 @@ final class RecordingComposerAuditRunner implements ComposerAuditRunnerInterface
 
     public function __construct(public string $payload) {}
 
+    /**
+     * @throws void
+     */
     #[Override]
     public function run(string $projectPath): string
     {

--- a/tests/Phpunit/Integration/Advisory/Fixture/ThrowingComposerAuditRunner.php
+++ b/tests/Phpunit/Integration/Advisory/Fixture/ThrowingComposerAuditRunner.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Advisory\Fixture;
 
+use Override;
 use RuntimeException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditRunnerInterface;
 
@@ -23,6 +24,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerA
  */
 final class ThrowingComposerAuditRunner implements ComposerAuditRunnerInterface
 {
+    #[Override]
     public function run(string $projectPath): string
     {
         throw new RuntimeException('inner exploded');

--- a/tests/Phpunit/Integration/Advisory/Fixture/ThrowingComposerAuditRunner.php
+++ b/tests/Phpunit/Integration/Advisory/Fixture/ThrowingComposerAuditRunner.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Advisory\Fixture;
 
 use Override;
-use RuntimeException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditRunnerInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\Exception\AdvisorySourceUnavailableException;
 
 /**
  * Test fake — always throws to verify cache writes never happen on failure.
@@ -27,6 +27,6 @@ final class ThrowingComposerAuditRunner implements ComposerAuditRunnerInterface
     #[Override]
     public function run(string $projectPath): string
     {
-        throw new RuntimeException('inner exploded');
+        throw AdvisorySourceUnavailableException::forFailedProcess($projectPath, 'inner exploded');
     }
 }

--- a/tests/Phpunit/Integration/Advisory/LockfileHashedAdvisoryCacheTest.php
+++ b/tests/Phpunit/Integration/Advisory/LockfileHashedAdvisoryCacheTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Advisory;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -20,6 +21,7 @@ use RuntimeException;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditRunnerInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\Exception\AdvisorySourceUnavailableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\LockfileHashedAdvisoryCache;
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Advisory\Fixture\RecordingComposerAuditRunner;
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Advisory\Fixture\ThrowingComposerAuditRunner;
@@ -30,6 +32,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
 
     private string $cacheDir;
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_runs_inner_and_persists_result_on_first_call(): void
     {
         $this->writeLockfile('{"lock": "v1"}');
@@ -45,6 +50,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertGreaterThan(0, \count(false !== $cacheFiles ? $cacheFiles : []));
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_missing_lockfile_does_not_emit_an_unreadable_warning(): void
     {
         $warnings = [];
@@ -67,6 +75,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame([], $warnings);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_returns_cached_payload_without_invoking_inner(): void
     {
         $this->writeLockfile('{"lock": "v1"}');
@@ -81,6 +92,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame(1, $recordingComposerAuditRunner->callCount, 'second call must be served from cache');
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_cache_hit_emits_advisory_cache_hit_debug_log_with_lockfile_hash_context(): void
     {
         $lockfileContent = '{"lock": "v1"}';
@@ -116,6 +130,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame($expectedHash, $hitLogs[0][1]['lockfile_hash']);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_different_lockfile_contents_produce_distinct_cache_entries(): void
     {
         $this->writeLockfile('{"lock": "v1"}');
@@ -133,6 +150,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame(2, $recordingComposerAuditRunner->callCount, 'lock content change must miss the cache');
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_falls_back_to_inner_when_no_lockfile_exists(): void
     {
         // No composer.lock written intentionally
@@ -149,6 +169,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame([], false !== $cacheFiles ? $cacheFiles : []);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_does_not_persist_when_inner_throws(): void
     {
         $this->writeLockfile('{"lock": "v1"}');
@@ -166,6 +189,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         }
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_falls_back_to_live_audit_when_lockfile_read_throws_io_exception(): void
     {
         $this->writeLockfile('{"lock": "v1"}');
@@ -206,6 +232,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame('permission denied', $unreadableLogs[0][1]['error']);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_cache_miss_when_existing_entry_is_unreadable_and_falls_back_to_inner(): void
     {
         $this->writeLockfile('{"lock": "v1"}');
@@ -262,6 +291,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame('cache entry unreadable', $unreadableLogs[0][1]['error'] ?? null);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_cache_file_is_written_at_two_char_shard_directory_under_full_hash_filename(): void
     {
         $lockfileContent = '{"lock": "v1"}';
@@ -284,6 +316,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame($expectedPath, $files[0]);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_cache_dir_with_trailing_slash_is_normalized_before_assembling_path(): void
     {
         $this->writeLockfile('{"lock": "v1"}');
@@ -312,6 +347,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertStringNotContainsString('//', $capturedDumpPaths[0]);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_write_failure_is_logged_and_does_not_propagate(): void
     {
         $this->writeLockfile('{"lock": "v1"}');
@@ -357,6 +395,9 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame('cache dir unwritable', $failureLogs[0][1]['error'] ?? null);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_successful_cache_write_emits_advisory_cache_stored_debug_log_with_lockfile_hash(): void
     {
         $lockfileContent = '{"lock": "v1"}';
@@ -387,6 +428,7 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         self::assertSame($expectedHash, $storedLogs[0][1]['lockfile_hash'] ?? null);
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->projectDir = sys_get_temp_dir().'/advisory_cache_'.uniqid('', true);
@@ -394,6 +436,7 @@ final class LockfileHashedAdvisoryCacheTest extends TestCase
         mkdir($this->projectDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $filesystem = new Filesystem();

--- a/tests/Phpunit/Integration/Advisory/SymfonyProcessComposerAuditRunnerTest.php
+++ b/tests/Phpunit/Integration/Advisory/SymfonyProcessComposerAuditRunnerTest.php
@@ -20,6 +20,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\SymfonyPr
 
 final class SymfonyProcessComposerAuditRunnerTest extends TestCase
 {
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_it_returns_stdout_when_process_emits_json(): void
     {
         $symfonyProcessComposerAuditRunner = new SymfonyProcessComposerAuditRunner(
@@ -32,6 +35,9 @@ final class SymfonyProcessComposerAuditRunnerTest extends TestCase
         self::assertSame('{"advisories":{}}', $output);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_it_throws_advisory_unavailable_when_stdout_is_empty(): void
     {
         $symfonyProcessComposerAuditRunner = new SymfonyProcessComposerAuditRunner(
@@ -84,6 +90,9 @@ final class SymfonyProcessComposerAuditRunnerTest extends TestCase
         self::assertStringContainsString("'--no-interaction'", $commandLine);
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_it_throws_when_stdout_is_only_whitespace(): void
     {
         $symfonyProcessComposerAuditRunner = new SymfonyProcessComposerAuditRunner(
@@ -95,6 +104,9 @@ final class SymfonyProcessComposerAuditRunnerTest extends TestCase
         $symfonyProcessComposerAuditRunner->run('/some/path');
     }
 
+    /**
+     * @throws AdvisorySourceUnavailableException
+     */
     public function test_it_wraps_process_exception_as_binary_not_found_when_setup_throws(): void
     {
         $symfonyProcessComposerAuditRunner = new SymfonyProcessComposerAuditRunner(

--- a/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
+++ b/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Bundle;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -1018,12 +1019,14 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
         self::assertSame(1, $containerBuilder->getParameter('symfony_security_auditor.audit.max_tool_iterations'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/bundle_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         if ($this->bootedKernel instanceof Kernel) {
@@ -1090,12 +1093,14 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
             /**
              * @return iterable<FrameworkBundle|SymfonySecurityAuditorBundle>
              */
+            #[Override]
             public function registerBundles(): iterable
             {
                 yield new FrameworkBundle();
                 yield new SymfonySecurityAuditorBundle();
             }
 
+            #[Override]
             public function registerContainerConfiguration(LoaderInterface $loader): void
             {
                 $bundleConfig = $this->bundleConfig;
@@ -1119,16 +1124,19 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
                 });
             }
 
+            #[Override]
             public function getProjectDir(): string
             {
                 return $this->tmpDir;
             }
 
+            #[Override]
             public function getCacheDir(): string
             {
                 return $this->tmpDir.'/cache';
             }
 
+            #[Override]
             public function getLogDir(): string
             {
                 return $this->tmpDir.'/log';

--- a/tests/Phpunit/Integration/Cache/FilesystemAttackerCacheTest.php
+++ b/tests/Phpunit/Integration/Cache/FilesystemAttackerCacheTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Cache;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -35,6 +36,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertNull($this->filesystemAttackerCache->get($chunk));
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_get_returns_null_and_skips_read_when_no_entry_exists(): void
     {
         $chunk = [ProjectFile::create('a.php', '/app/a.php', '<?php')];
@@ -176,12 +180,18 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertNull($this->filesystemAttackerCache->get($chunk));
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_constructor_rejects_empty_cache_dir(): void
     {
         $this->expectException(InvalidCacheConfigurationException::class);
         new FilesystemAttackerCache('   ', new Filesystem(), new NullLogger());
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_get_returns_null_when_filesystem_read_throws_io_exception(): void
     {
         $filesystem = self::createStub(Filesystem::class);
@@ -193,6 +203,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertNull($filesystemAttackerCache->get([ProjectFile::create('a.php', '/app/a.php', '<?php')]));
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_get_logs_warning_with_path_and_error_keys_when_filesystem_read_throws_io_exception(): void
     {
         $filesystem = self::createStub(Filesystem::class);
@@ -234,6 +247,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertSame([['type' => 'sql_injection', 'severity' => 'high']], $entries);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_get_logs_warning_when_cache_entry_is_unreadable_json(): void
     {
         $chunk = [ProjectFile::create('a.php', '/app/a.php', '<?php')];
@@ -296,6 +312,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertSame([['type' => 'sql_injection', 'title' => 'b-finding']], $this->filesystemAttackerCache->get([$b]));
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_distinct_key_salts_produce_distinct_cache_entries(): void
     {
         $chunk = [ProjectFile::create('src/A.php', '/app/src/A.php', 'X')];
@@ -310,6 +329,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertNull($gptCache->get($chunk), 'switching the salt must invalidate the cache for the same chunk');
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_same_key_salt_yields_same_cache_entry_across_instances(): void
     {
         $chunk = [ProjectFile::create('src/A.php', '/app/src/A.php', 'X')];
@@ -335,6 +357,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertFileExists($expectedPath);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_salted_key_concatenates_salt_null_byte_and_signatures_in_that_order(): void
     {
         $projectFile = ProjectFile::create('src/A.php', '/app/src/A.php', 'X');
@@ -348,6 +373,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertFileExists($expectedPath);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_dump_path_has_trailing_slash_stripped_from_cache_dir(): void
     {
         $capturedPath = '';
@@ -366,6 +394,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertStringNotContainsString('//', $capturedPath);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_get_logs_debug_cache_hit_with_path(): void
     {
         $chunk = [ProjectFile::create('a.php', '/app/a.php', '<?php')];
@@ -392,6 +423,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertArrayHasKey('path', $hitLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_store_logs_debug_stored_with_path(): void
     {
         $debugLogs = [];
@@ -414,6 +448,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertArrayHasKey('path', $storedLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_store_failure_warning_includes_path_and_error_keys(): void
     {
         $warnings = [];
@@ -439,6 +476,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertNotSame('', $failureLogs[0][1]['error']);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_get_failure_warning_includes_path_and_error_keys(): void
     {
         $chunk = [ProjectFile::create('a.php', '/app/a.php', '<?php')];
@@ -471,6 +511,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertNotSame('', $unreadableLogs[0][1]['error']);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_store_calls_mkdir_to_create_shard_directory(): void
     {
         $filesystem = $this->createMock(Filesystem::class);
@@ -481,6 +524,9 @@ final class FilesystemAttackerCacheTest extends TestCase
         $filesystemAttackerCache->store([ProjectFile::create('a.php', '/app/a.php', '<?php')], [['type' => 'sql_injection']]);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_store_with_unwritable_dir_logs_warning_and_does_not_throw(): void
     {
         $warnings = [];
@@ -500,12 +546,17 @@ final class FilesystemAttackerCacheTest extends TestCase
         self::assertContains('Failed to write attacker cache entry', $warnings);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
+    #[Override]
     protected function setUp(): void
     {
         $this->cacheDir = sys_get_temp_dir().'/attacker_cache_'.uniqid('', true);
         $this->filesystemAttackerCache = new FilesystemAttackerCache($this->cacheDir, new Filesystem(), new NullLogger());
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $filesystem = new Filesystem();

--- a/tests/Phpunit/Integration/Cache/FilesystemReviewerCacheTest.php
+++ b/tests/Phpunit/Integration/Cache/FilesystemReviewerCacheTest.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Cache;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityClassification;
@@ -33,11 +36,20 @@ final class FilesystemReviewerCacheTest extends TestCase
 
     private FilesystemReviewerCache $filesystemReviewerCache;
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_returns_null_when_no_entry_exists(): void
     {
         self::assertNull($this->filesystemReviewerCache->get($this->makeVulnerability('src/A.php'), 'code'));
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_skips_read_when_no_entry_exists(): void
     {
         $filesystem = $this->createMock(Filesystem::class);
@@ -49,6 +61,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNull($filesystemReviewerCache->get($this->makeVulnerability('src/A.php'), 'code'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_round_trip_store_and_get_returns_same_review(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -59,6 +75,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertSame($review, $this->filesystemReviewerCache->get($vulnerability, 'code-context'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_returns_null_when_finding_content_differs(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php', title: 'original');
@@ -69,6 +89,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNull($this->filesystemReviewerCache->get($changed, 'code'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_returns_null_when_code_context_differs(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -78,6 +102,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNull($this->filesystemReviewerCache->get($vulnerability, 'context two'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_hits_for_a_distinct_finding_object_with_identical_content(): void
     {
         // Two separately-created findings with identical content reuse the same
@@ -92,6 +120,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertSame($review, $this->filesystemReviewerCache->get($twin, 'code'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_returns_null_when_cache_file_is_invalid_json(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -105,6 +137,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNull($this->filesystemReviewerCache->get($vulnerability, 'code'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_returns_null_when_cache_file_contains_non_array_json(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -117,12 +153,20 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNull($this->filesystemReviewerCache->get($vulnerability, 'code'));
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
     public function test_constructor_rejects_empty_cache_dir(): void
     {
         $this->expectException(InvalidCacheConfigurationException::class);
         new FilesystemReviewerCache('   ', new Filesystem(), new NullLogger());
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_returns_null_when_filesystem_read_throws_io_exception(): void
     {
         $filesystem = self::createStub(Filesystem::class);
@@ -134,6 +178,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNull($filesystemReviewerCache->get($this->makeVulnerability('src/A.php'), 'code'));
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_logs_warning_with_path_and_error_when_read_throws_io_exception(): void
     {
         $filesystem = self::createStub(Filesystem::class);
@@ -158,6 +207,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertSame('permission denied', $warnings[0][1]['error']);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_logs_warning_when_cache_entry_is_unreadable_json(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -186,6 +240,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNotSame('', $warnings[0][1]['error']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_store_creates_nested_shard_directory_from_key_prefix(): void
     {
         $this->filesystemReviewerCache->store($this->makeVulnerability('src/A.php'), 'code', ['accepted' => true]);
@@ -197,6 +255,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertMatchesRegularExpression('#^[a-f0-9]{2}/[a-f0-9]{64}\.json$#', $relative);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_store_calls_mkdir_to_create_shard_directory(): void
     {
         $filesystem = $this->createMock(Filesystem::class);
@@ -207,6 +270,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         $filesystemReviewerCache->store($this->makeVulnerability('src/A.php'), 'code', ['accepted' => true]);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_key_is_sha256_of_salt_null_byte_finding_without_id_and_code_context(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -224,6 +292,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertFileExists($expectedPath);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_distinct_key_salts_produce_distinct_cache_entries(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -238,6 +311,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNull($opus->get($vulnerability, 'code'), 'switching the salt must invalidate the cache');
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_empty_salt_keeps_unprefixed_key(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -253,6 +330,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertFileExists($expectedPath);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_dump_path_has_trailing_slash_stripped_from_cache_dir(): void
     {
         $capturedPath = '';
@@ -269,6 +351,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertStringNotContainsString('//', $capturedPath);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_logs_debug_cache_hit_with_path(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -290,6 +377,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertArrayHasKey('path', $hitLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_store_logs_debug_stored_with_path(): void
     {
         $debugLogs = [];
@@ -308,6 +400,11 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertArrayHasKey('path', $storedLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_store_failure_logs_warning_with_path_and_error(): void
     {
         $warnings = [];
@@ -329,6 +426,10 @@ final class FilesystemReviewerCacheTest extends TestCase
         self::assertNotSame('', $failures[0][1]['error']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(string $filePath, string $title = 'Finding'): Vulnerability
     {
         return Vulnerability::of(
@@ -339,12 +440,17 @@ final class FilesystemReviewerCacheTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCacheConfigurationException
+     */
+    #[Override]
     protected function setUp(): void
     {
         $this->cacheDir = sys_get_temp_dir().'/reviewer_cache_'.uniqid('', true);
         $this->filesystemReviewerCache = new FilesystemReviewerCache($this->cacheDir, new Filesystem(), new NullLogger());
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $filesystem = new Filesystem();

--- a/tests/Phpunit/Integration/Diff/ProcessGitChangedFilesResolverTest.php
+++ b/tests/Phpunit/Integration/Diff/ProcessGitChangedFilesResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Diff;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
@@ -25,6 +26,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
 
     private Filesystem $filesystem;
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_throws_when_directory_is_not_a_git_tree(): void
     {
         $this->expectException(GitChangedFilesUnavailableException::class);
@@ -33,6 +37,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         (new ProcessGitChangedFilesResolver())->changedSince($this->tmpDir, 'main');
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_throws_when_ref_does_not_exist_in_repo(): void
     {
         $this->initRepo();
@@ -43,6 +50,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         (new ProcessGitChangedFilesResolver())->changedSince($this->tmpDir, 'does-not-exist');
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_merged_committed_and_uncommitted_paths_are_sorted(): void
     {
         $this->initRepo();
@@ -58,6 +68,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         self::assertSame(['src/A.php', 'src/B.php'], $srcChanged);
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_a_path_changed_in_both_committed_and_uncommitted_diffs_is_deduplicated(): void
     {
         $this->initRepo();
@@ -73,6 +86,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         self::assertSame(['src/Shared.php'], $shared);
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_returns_files_changed_against_ref(): void
     {
         $this->initRepo();
@@ -86,6 +102,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         self::assertNotContains('src/Foo.php', $changed);
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_includes_uncommitted_changes_against_head(): void
     {
         $this->initRepo();
@@ -98,6 +117,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         self::assertContains('src/Bar.php', $changed);
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_returned_paths_are_sorted_for_determinism(): void
     {
         $this->initRepo();
@@ -112,6 +134,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         self::assertSame(['src/A.php', 'src/M.php'], $changedFiltered);
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_resolves_from_a_subdirectory_where_dot_git_is_not_present(): void
     {
         $this->initRepo();
@@ -127,6 +152,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         self::assertContains('src/sub/Bar.php', $changed);
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_relies_on_rev_parse_when_a_dot_git_path_exists_but_is_not_a_repo(): void
     {
         $this->filesystem->mkdir($this->tmpDir.'/.git');
@@ -137,6 +165,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         (new ProcessGitChangedFilesResolver())->changedSince($this->tmpDir, 'main');
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_throws_for_a_path_inside_the_git_directory_not_the_work_tree(): void
     {
         $this->initRepo();
@@ -148,6 +179,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         (new ProcessGitChangedFilesResolver())->changedSince($this->tmpDir.'/.git', 'main');
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_diffs_branch_commits_since_merge_base_not_the_raw_ref_diff(): void
     {
         $this->initRepo();
@@ -164,6 +198,9 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         self::assertNotContains('src/Foo.php', $changed);
     }
 
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_wraps_a_git_diff_process_failure_when_the_ref_resolves_but_has_no_merge_base(): void
     {
         $this->initRepo();
@@ -177,6 +214,7 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         (new ProcessGitChangedFilesResolver())->changedSince($this->tmpDir, 'main');
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/git_diff_resolver_test_'.uniqid('', true);
@@ -184,6 +222,7 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
         $this->filesystem = new Filesystem();
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->filesystem->remove($this->tmpDir);

--- a/tests/Phpunit/Integration/FileSystem/ProjectFileScannerTest.php
+++ b/tests/Phpunit/Integration/FileSystem/ProjectFileScannerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\FileSystem;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -20,6 +21,7 @@ use RuntimeException;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Process\Process;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\Exception\SecretScrubberConfigurationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\NullSecretScrubber;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\ProjectFileScanner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\RegexSecretScrubber;
@@ -422,6 +424,9 @@ final class ProjectFileScannerTest extends TestCase
         self::assertSame('public/index.php', $files[0]->relativePath());
     }
 
+    /**
+     * @throws SecretScrubberConfigurationException
+     */
     public function test_it_scrubs_secrets_from_file_content_when_scrubber_is_injected(): void
     {
         $stripeShape = self::STRIPE_LIVE_PREFIX.'_4eC39HqLyjWDarjtT1zdp7dc';
@@ -509,6 +514,7 @@ final class ProjectFileScannerTest extends TestCase
         self::assertSame('disk read error', $error);
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/scanner_int_'.uniqid('', true);
@@ -516,6 +522,7 @@ final class ProjectFileScannerTest extends TestCase
         $this->projectFileScanner = new ProjectFileScanner(new NullLogger());
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->rmdirRecursive($this->tmpDir);

--- a/tests/Phpunit/Integration/FileSystem/ProjectFileScannerTest.php
+++ b/tests/Phpunit/Integration/FileSystem/ProjectFileScannerTest.php
@@ -527,7 +527,12 @@ final class ProjectFileScannerTest extends TestCase
             return;
         }
 
-        foreach (scandir($dir) as $item) {
+        $items = scandir($dir);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
             if ('.' === $item) {
                 continue;
             }

--- a/tests/Phpunit/Integration/LLM/Fixture/FakeRateLimiter.php
+++ b/tests/Phpunit/Integration/LLM/Fixture/FakeRateLimiter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture;
 
 use DateTimeImmutable;
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
 
 final class FakeRateLimiter implements RateLimiterInterface
@@ -27,16 +28,19 @@ final class FakeRateLimiter implements RateLimiterInterface
     /** @var list<DateTimeImmutable> */
     public array $paused = [];
 
+    #[Override]
     public function acquire(int $estimatedInputTokens): void
     {
         $this->acquired[] = $estimatedInputTokens;
     }
 
+    #[Override]
     public function record(int $inputTokens, int $outputTokens): void
     {
         $this->recorded[] = [$inputTokens, $outputTokens];
     }
 
+    #[Override]
     public function pauseUntil(DateTimeImmutable $until): void
     {
         $this->paused[] = $until;

--- a/tests/Phpunit/Integration/LLM/Fixture/FakeSleeper.php
+++ b/tests/Phpunit/Integration/LLM/Fixture/FakeSleeper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Delay\SleeperInterface;
 
 final class FakeSleeper implements SleeperInterface
@@ -20,6 +21,7 @@ final class FakeSleeper implements SleeperInterface
     /** @var list<int> */
     public array $durations = [];
 
+    #[Override]
     public function sleep(int $milliseconds): void
     {
         $this->durations[] = $milliseconds;

--- a/tests/Phpunit/Integration/LLM/Fixture/FixedTokenEstimator.php
+++ b/tests/Phpunit/Integration/LLM/Fixture/FixedTokenEstimator.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\TokenEstimatorInterface;
 
 final class FixedTokenEstimator implements TokenEstimatorInterface
 {
     public function __construct(private readonly int $tokensPerCall) {}
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         return $this->tokensPerCall;

--- a/tests/Phpunit/Integration/LLM/Fixture/ThrowingConverter.php
+++ b/tests/Phpunit/Integration/LLM/Fixture/ThrowingConverter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture;
 
+use Override;
 use RuntimeException;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\Result\RawResultInterface;
@@ -24,16 +25,19 @@ final class ThrowingConverter implements ResultConverterInterface
 {
     public function __construct(private readonly RuntimeException $runtimeException) {}
 
+    #[Override]
     public function supports(Model $model): bool
     {
         return true;
     }
 
+    #[Override]
     public function convert(RawResultInterface $result, array $options = []): ResultInterface
     {
         throw $this->runtimeException;
     }
 
+    #[Override]
     public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
     {
         return null;

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM;
 
 use Closure;
 use DateTimeImmutable;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -53,6 +54,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolDefinition;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\BackoffSchedule;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\InvalidRetryConfigurationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\MissingAiPlatformException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\NonTransientLLMFailureException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\TransientLLMFailureException;
@@ -73,6 +75,12 @@ use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture\ThrowingC
 
 final class SymfonyAiLLMClientTest extends TestCase
 {
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_returns_text_from_platform_invoke(): void
     {
         $platform = $this->scriptedPlatform([new TextResult('Hello from LLM')]);
@@ -87,6 +95,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0, $llmResponse->outputTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_logs_debug_with_prompt_lengths_and_temperature(): void
     {
         $platform = $this->scriptedPlatform([new TextResult('ok')]);
@@ -109,6 +123,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0.42, $startLog[1]['temperature']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_logs_debug_response_with_content_length(): void
     {
         $platform = $this->scriptedPlatform([new TextResult('twelve-chars')]);
@@ -133,6 +153,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(12, $respondedLogs[0][1]['content_length']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_passes_temperature_via_options(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -146,6 +172,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('cache_control', $invocationOptionsCapture->options);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_omits_temperature_when_left_at_default(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -158,6 +190,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('temperature', $invocationOptionsCapture->options);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_never_sends_cache_control_even_for_anthropic_model(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -170,6 +208,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('cache_control', $invocationOptionsCapture->options);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_passes_provider_json_mode_response_format_for_anthropic_model(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -182,6 +226,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(['type' => 'json_object'], $invocationOptionsCapture->options['response_format']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_omits_response_format_for_non_anthropic_model_even_when_json_mode_enabled(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -194,6 +244,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('response_format', $invocationOptionsCapture->options);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_passes_all_anthropic_options_together_when_multiple_flags_enabled(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -212,6 +268,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('cache_control', $invocationOptionsCapture->options);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_omits_response_format_when_provider_json_mode_disabled(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -224,6 +286,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('response_format', $invocationOptionsCapture->options);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_passes_max_output_tokens_via_options_for_anthropic_model(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -238,6 +306,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(4096, $invocationOptionsCapture->options['max_tokens']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_omits_max_output_tokens_for_non_anthropic_model_even_when_configured(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -252,6 +326,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('max_tokens', $invocationOptionsCapture->options);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_still_sends_temperature_for_non_anthropic_model(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -264,6 +344,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0.7, $invocationOptionsCapture->options['temperature']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_omits_max_output_tokens_when_left_at_default(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -276,6 +362,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayNotHasKey('max_tokens', $invocationOptionsCapture->options);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_passes_max_output_tokens_via_options_for_anthropic_model(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -301,6 +393,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('claude-test', $symfonyAiLLMClient->model());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_throws_when_no_ai_platform_is_configured(): void
     {
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding(null, 'test-model', new NullLogger()));
@@ -311,6 +409,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         $symfonyAiLLMClient->complete('sys', 'usr');
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_throws_when_no_ai_platform_is_configured(): void
     {
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding(null, 'test-model', new NullLogger()));
@@ -322,6 +426,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         $symfonyAiLLMClient->completeWithTools('sys', 'usr', $toolRegistry, 3);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_throws_when_no_ai_platform_is_configured(): void
     {
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding(null, 'test-model', new NullLogger()));
@@ -332,6 +440,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         $symfonyAiLLMClient->completeBatch([['system' => 's', 'user' => 'u']], 2);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_returns_empty_for_no_requests(): void
     {
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding(new InMemoryPlatform('x'), 'm', new NullLogger()));
@@ -339,6 +451,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([], $symfonyAiLLMClient->completeBatch([], 4));
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_returns_one_response_per_request_in_order(): void
     {
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding(new InMemoryPlatform('batched'), 'm', new NullLogger()));
@@ -355,6 +471,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('batched', $responses[2]->content());
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_processes_more_requests_than_window_size(): void
     {
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding(new InMemoryPlatform('ok'), 'm', new NullLogger()));
@@ -369,6 +489,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertCount(5, $responses);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_clamps_non_positive_window_to_one(): void
     {
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding(new InMemoryPlatform('ok'), 'm', new NullLogger()));
@@ -381,6 +505,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertCount(2, $responses);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_records_token_usage_per_response(): void
     {
         $platform = $this->scriptedPlatformWithTokenUsage(
@@ -405,6 +533,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(7, $responses[1]->outputTokens());
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_acquires_rate_limit_for_each_request(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
@@ -423,6 +555,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([246, 246, 246], $fakeRateLimiter->acquired);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_falls_back_to_the_sequential_complete_path_when_dispatch_throws(): void
     {
         $platform = $this->flakyPlatform([
@@ -440,6 +576,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('recovered-sequentially', $responses[0]->content());
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_resolves_each_conversation_against_its_own_registry(): void
     {
         $firstToolCalls = 0;
@@ -476,6 +616,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0, $secondToolCalls);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_returns_empty_list_for_empty_requests(): void
     {
         $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding(new InMemoryPlatform('ok'), 'm', new NullLogger()));
@@ -483,6 +627,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([], $symfonyAiLLMClient->completeBatchWithTools([], 4, 3));
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_caps_iterations_and_warns(): void
     {
         $toolRegistry = new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger());
@@ -522,6 +670,11 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(2, $capLogs[0][1]['max_iterations']);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_falls_back_to_the_sequential_path_when_dispatch_fails_before_tools_ran(): void
     {
         $toolRegistry = new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger());
@@ -543,6 +696,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('end_turn', $responses[0]->stopReason());
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_falls_back_to_the_sequential_path_when_resolution_fails_before_tools_ran(): void
     {
         $toolRegistry = new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger());
@@ -550,21 +707,25 @@ final class SymfonyAiLLMClientTest extends TestCase
         $platform = new class implements PlatformInterface {
             private int $invocations = 0;
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 ++$this->invocations;
                 $converter = 1 === $this->invocations
                     ? new class implements ResultConverterInterface {
+                        #[Override]
                         public function supports(Model $model): bool
                         {
                             return true;
                         }
 
+                        #[Override]
                         public function convert(RawResultInterface $result, array $options = []): ResultInterface
                         {
                             throw new RuntimeException('resolution exploded');
                         }
 
+                        #[Override]
                         public function getTokenUsageExtractor(): ?TokenUsageExtractorInterface
                         {
                             return null;
@@ -575,6 +736,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 return new DeferredResult($converter, new InMemoryRawResult(['text' => ''], [], (object) []), $options);
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -591,6 +753,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('end_turn', $responses[0]->stopReason());
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_finalizes_as_empty_content_when_failing_after_tools_ran(): void
     {
         $toolCalls = 0;
@@ -634,6 +800,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertArrayHasKey('output_tokens', $failureLogs[0][1]);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_accumulates_tokens_across_rounds(): void
     {
         $toolRegistry = new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger());
@@ -661,6 +831,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(3, $responses[0]->cacheCreationTokens());
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_records_rate_limit_for_each_round(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
@@ -682,6 +856,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertCount(2, $fakeRateLimiter->recorded);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_appends_assistant_then_tool_call_message_between_rounds(): void
     {
         $tool = $this->makeTool('record', 'd', static fn (array $args): string => 'tool-output');
@@ -717,22 +895,29 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertTrue($hasToolCall, 'Second round should receive a ToolCallMessage carrying the tool execution result');
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_dispatches_one_window_at_a_time_when_concurrency_is_one(): void
     {
         $rateLimiter = new class implements RateLimiterInterface {
             /** @var list<string> */
             public array $events = [];
 
+            #[Override]
             public function acquire(int $estimatedInputTokens): void
             {
                 $this->events[] = 'acquire';
             }
 
+            #[Override]
             public function record(int $inputTokens, int $outputTokens): void
             {
                 $this->events[] = 'record';
             }
 
+            #[Override]
             public function pauseUntil(DateTimeImmutable $until): void {}
         };
 
@@ -749,6 +934,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(['acquire', 'record', 'acquire', 'record'], $rateLimiter->events);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_keeps_dispatching_later_conversations_after_an_earlier_one_finishes(): void
     {
         $firstRegistry = new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger());
@@ -773,6 +962,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('end_turn', $responses[1]->stopReason());
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_records_budget_and_aborts_when_a_response_exceeds_it(): void
     {
         $toolRegistry = new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger());
@@ -796,6 +989,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         ], 4, 3);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_with_tools_acquires_rate_limit_for_each_dispatch(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
@@ -814,6 +1011,10 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([246, 246], $fakeRateLimiter->acquired);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_records_budget_and_aborts_when_a_response_exceeds_it(): void
     {
         $platform = $this->scriptedPlatformWithTokenUsage(
@@ -834,22 +1035,29 @@ final class SymfonyAiLLMClientTest extends TestCase
         $symfonyAiLLMClient->completeBatch([['system' => 's', 'user' => 'u']], 4);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_dispatches_one_request_per_window_when_concurrency_is_one(): void
     {
         $rateLimiter = new class implements RateLimiterInterface {
             /** @var list<string> */
             public array $events = [];
 
+            #[Override]
             public function acquire(int $estimatedInputTokens): void
             {
                 $this->events[] = 'acquire';
             }
 
+            #[Override]
             public function record(int $inputTokens, int $outputTokens): void
             {
                 $this->events[] = 'record';
             }
 
+            #[Override]
             public function pauseUntil(DateTimeImmutable $until): void {}
         };
 
@@ -868,11 +1076,16 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(['acquire', 'record', 'acquire', 'record'], $rateLimiter->events);
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
     public function test_complete_batch_falls_back_to_complete_when_resolving_a_response_throws(): void
     {
         $platform = new class implements PlatformInterface {
             private int $calls = 0;
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 if ($this->calls >= 2) {
@@ -886,6 +1099,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 return new DeferredResult($converter, new InMemoryRawResult(['text' => ''], [], (object) []), $options);
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -899,12 +1113,16 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('recovered', $responses[0]->content());
     }
 
+    /**
+     * @throws MissingAiPlatformException
+     */
     public function test_complete_batch_rethrows_budget_exceeded_without_falling_back_to_complete(): void
     {
         $platformInvocationLog = new PlatformInvocationLog();
         $platform = new class($platformInvocationLog) implements PlatformInterface {
             public function __construct(private readonly PlatformInvocationLog $platformInvocationLog) {}
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 ++$this->platformInvocationLog->invocations;
@@ -918,6 +1136,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 return $deferredResult;
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -944,6 +1163,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(1, $platformInvocationLog->invocations);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_returns_text_when_platform_emits_no_tool_calls(): void
     {
         $platform = $this->scriptedPlatform([
@@ -961,6 +1186,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0, $llmResponse->outputTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_executes_tool_calls_then_returns_final_text(): void
     {
         $tool = $this->makeTool('lookup', 'looks things up', static fn (array $args): string => 'tool-result');
@@ -978,6 +1209,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('end_turn', $llmResponse->stopReason());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_stops_at_iteration_cap_and_warns(): void
     {
         $tool = $this->makeTool('lookup', 'lookup');
@@ -1015,6 +1252,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(2, $capLogs[0][1]['max_iterations']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_invokes_platform_exact_max_iterations_times_when_all_iterations_return_tool_calls(): void
     {
         $tool = $this->makeTool('lookup', 'lookup');
@@ -1036,6 +1279,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(2, $platformInvocationLog->invocations);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_logs_loop_ended_debug_with_iterations_count_and_content_length(): void
     {
         $toolRegistry = new ToolRegistry([$this->makeTool('lookup', 'lookup')], new NullLogger());
@@ -1067,6 +1316,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(12, $endedLogs[0][1]['content_length']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_appends_assistant_message_then_tool_call_message_between_iterations(): void
     {
         $tool = $this->makeTool('lookup', 'lookup', static fn (array $args): string => 'tool-output');
@@ -1103,6 +1358,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertTrue($hasToolCall, 'Second invoke should receive a ToolCallMessage carrying the tool execution result');
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_logs_tool_invocation_with_tool_name_and_iteration_number(): void
     {
         $tool = $this->makeTool('lookup', 'lookup', static fn (array $args): string => 'ok');
@@ -1135,6 +1396,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(1, $toolInvokedLogs[0][1]['iteration']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_passes_tool_definitions_in_options(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -1183,6 +1450,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('', $properties['malformed_type']['description']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_handles_bare_tool_call_result_not_wrapped_in_multipart(): void
     {
         $tool = $this->makeTool('lookup', 'lookup', static fn (array $args): string => 'ok');
@@ -1199,6 +1472,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('final', $llmResponse->content());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_handles_bare_text_result_not_wrapped_in_multipart(): void
     {
         $tool = $this->makeTool('lookup', 'lookup');
@@ -1212,6 +1491,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('plain text', $llmResponse->content());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_falls_back_to_empty_text_when_platform_returns_unknown_result_type(): void
     {
         $tool = $this->makeTool('lookup', 'lookup');
@@ -1219,6 +1504,7 @@ final class SymfonyAiLLMClientTest extends TestCase
 
         $unknownResult = new class extends BaseResult {
             /** @return list<never> */
+            #[Override]
             public function getContent(): array
             {
                 return [];
@@ -1234,6 +1520,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('end_turn', $llmResponse->stopReason());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_normalize_schema_tolerates_missing_properties_and_required(): void
     {
         $invocationOptionsCapture = new InvocationOptionsCapture();
@@ -1265,6 +1557,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([], $parameters['required']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_populates_input_and_output_tokens_from_platform_metadata(): void
     {
         $tokenUsageRecorder = new TokenUsageRecorder();
@@ -1286,6 +1584,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(30, $tokenUsageRecorder->snapshot()->outputTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_populates_cache_tokens_from_platform_metadata(): void
     {
         $tokenUsageRecorder = new TokenUsageRecorder();
@@ -1306,6 +1610,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(40, $tokenUsageRecorder->snapshot()->cacheCreationTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_defaults_cache_tokens_to_zero_when_token_usage_omits_them(): void
     {
         $platform = $this->scriptedPlatformWithTokenUsage(
@@ -1320,6 +1630,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0, $llmResponse->cacheCreationTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_returns_zero_tokens_when_platform_metadata_omits_token_usage(): void
     {
         $tokenUsageRecorder = new TokenUsageRecorder();
@@ -1338,6 +1654,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0, $tokenUsageRecorder->snapshot()->totalTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_returns_zero_tokens_when_token_usage_prompt_and_completion_are_null(): void
     {
         $tokenUsageRecorder = new TokenUsageRecorder();
@@ -1357,6 +1679,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0, $tokenUsageRecorder->snapshot()->totalTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_consecutive_complete_calls_accumulate_in_shared_recorder(): void
     {
         $tokenUsageRecorder = new TokenUsageRecorder();
@@ -1379,6 +1707,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(15, $snapshot->outputTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_aborts_mid_loop_when_budget_exceeded(): void
     {
         $tokenUsageRecorder = new TokenUsageRecorder();
@@ -1411,6 +1745,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         );
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_records_budget_call_and_aborts_when_exceeded(): void
     {
         $tokenUsageRecorder = new TokenUsageRecorder();
@@ -1440,16 +1780,19 @@ final class SymfonyAiLLMClientTest extends TestCase
                 private readonly float $outputPrice,
             ) {}
 
+            #[Override]
             public function pricePerMillionInputTokens(string $model): float
             {
                 return $this->inputPrice;
             }
 
+            #[Override]
             public function pricePerMillionOutputTokens(string $model): float
             {
                 return $this->outputPrice;
             }
 
+            #[Override]
             public function hasModel(string $model): bool
             {
                 return true;
@@ -1457,6 +1800,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         };
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_accumulates_tokens_across_iterations(): void
     {
         $tokenUsageRecorder = new TokenUsageRecorder();
@@ -1512,6 +1861,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 private array $tokenUsages,
             ) {}
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 $result = array_shift($this->results);
@@ -1532,6 +1882,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 return $deferredResult;
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -1539,6 +1890,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         };
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_retries_transient_failures_and_succeeds(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1558,6 +1916,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([10, 20], $fakeSleeper->durations);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_throws_transient_failure_after_exhausting_attempts(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1582,6 +1947,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         }
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_logs_warning_with_full_context_when_retrying_transient_failure(): void
     {
         /** @var list<array{string, array<string, mixed>}> $warnings */
@@ -1613,6 +1985,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('HTTP 503 first failure message', $context['error']);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_logs_one_warning_per_intermediate_attempt_no_warning_on_last(): void
     {
         /** @var list<array{string, array<string, mixed>}> $warnings */
@@ -1644,6 +2022,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         }
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_does_not_retry_non_transient_failures(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1666,6 +2051,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         }
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_returns_empty_response_when_platform_reports_empty_content(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1685,6 +2077,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([], $fakeSleeper->durations);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_logs_warning_when_platform_reports_empty_content(): void
     {
         /** @var list<array{string, array<string, mixed>}> $warnings */
@@ -1714,6 +2112,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         );
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_returns_empty_response_when_platform_reports_empty_content_on_first_iteration(): void
     {
         $tool = $this->makeTool('lookup', 'lookup');
@@ -1732,6 +2136,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(0, $llmResponse->outputTokens());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_logs_warning_when_platform_reports_empty_content(): void
     {
         $tool = $this->makeTool('lookup', 'lookup');
@@ -1765,6 +2175,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         );
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_demotes_empty_content_to_debug_after_at_least_one_tool_iteration(): void
     {
         $tool = $this->makeTool('lookup', 'lookup');
@@ -1806,6 +2222,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame(1, $emptyDebugs[0][1]['iterations']);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_does_not_retry_empty_content_failures(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1822,6 +2245,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([], $fakeSleeper->durations);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_uses_rate_limit_delay_for_429_errors(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1839,6 +2269,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([60_000], $fakeSleeper->durations);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_uses_regular_delay_for_non_rate_limit_transient_errors(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1856,6 +2293,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([500], $fakeSleeper->durations);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_non_rate_limit_transient_error_never_pauses_the_rate_limiter(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
@@ -1873,6 +2317,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([], $fakeRateLimiter->paused, 'A non-429 transient failure must not honor a Retry-After hint.');
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_eager_resolution_catches_transient_failure_thrown_from_deferred_result(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1891,6 +2342,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([10], $fakeSleeper->durations);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_acquire_runs_before_invoke_with_estimated_input_tokens(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
@@ -1906,6 +2363,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([246], $fakeRateLimiter->acquired, 'system + user prompts → 2 × 123 = 246');
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_record_runs_after_success_with_actual_tokens(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
@@ -1923,6 +2386,12 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([[250, 75]], $fakeRateLimiter->recorded);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_complete_with_tools_records_actual_tokens_after_each_iteration(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
@@ -1949,6 +2418,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame([[40, 10], [60, 5]], $fakeRateLimiter->recorded);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_429_with_retry_after_uses_server_hint_and_pauses_rate_limiter(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -1968,6 +2444,13 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertCount(1, $fakeRateLimiter->paused);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     */
     public function test_429_without_retry_after_falls_back_to_exponential_delay(): void
     {
         $fakeSleeper = new FakeSleeper();
@@ -2002,6 +2485,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 $this->remaining = $scriptedResultsOrErrors;
             }
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 $next = array_shift($this->remaining);
@@ -2020,6 +2504,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 );
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -2035,6 +2520,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 private readonly ?PlatformInvocationLog $platformInvocationLog,
             ) {}
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 if ($this->platformInvocationLog instanceof PlatformInvocationLog) {
@@ -2048,6 +2534,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 );
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -2070,6 +2557,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 $this->remaining = $scriptedResultsOrErrors;
             }
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 $next = array_shift($this->remaining);
@@ -2090,6 +2578,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 );
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -2116,6 +2605,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 $this->remaining = $scriptedResults;
             }
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 if ($this->platformInvocationLog instanceof PlatformInvocationLog) {
@@ -2137,6 +2627,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 );
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -2156,6 +2647,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 private readonly InvocationOptionsCapture $invocationOptionsCapture,
             ) {}
 
+            #[Override]
             public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
             {
                 if (++$this->invocations > 1) {
@@ -2171,6 +2663,7 @@ final class SymfonyAiLLMClientTest extends TestCase
                 );
             }
 
+            #[Override]
             public function getModelCatalog(): ModelCatalogInterface
             {
                 return new FallbackModelCatalog();
@@ -2200,11 +2693,13 @@ final class SymfonyAiLLMClientTest extends TestCase
                 private readonly array $parametersSchema,
             ) {}
 
+            #[Override]
             public function definition(): ToolDefinition
             {
                 return new ToolDefinition($this->name, $this->description, $this->parametersSchema);
             }
 
+            #[Override]
             public function execute(array $arguments): string
             {
                 return $this->executor instanceof Closure ? ($this->executor)($arguments) : 'ok';

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -719,6 +719,9 @@ final class SymfonyAiLLMClientTest extends TestCase
                             return true;
                         }
 
+                        /**
+                         * @throws RuntimeException
+                         */
                         #[Override]
                         public function convert(RawResultInterface $result, array $options = []): ResultInterface
                         {

--- a/tests/Phpunit/Integration/Pipeline/AuditPipelineIntegrationTest.php
+++ b/tests/Phpunit/Integration/Pipeline/AuditPipelineIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Pipeline;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Validator\Validation;
@@ -128,12 +129,14 @@ final class AuditPipelineIntegrationTest extends TestCase
         self::assertNotNull($auditContext->getMeta('audit.risk_score'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/pipeline_int_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->rmdirRecursive($this->tmpDir);

--- a/tests/Phpunit/Integration/Pipeline/AuditPipelineIntegrationTest.php
+++ b/tests/Phpunit/Integration/Pipeline/AuditPipelineIntegrationTest.php
@@ -204,7 +204,12 @@ final class AuditPipelineIntegrationTest extends TestCase
             return;
         }
 
-        foreach (scandir($dir) as $item) {
+        $items = scandir($dir);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
             if ('.' === $item) {
                 continue;
             }

--- a/tests/Phpunit/Integration/UseCase/RunAuditUseCaseIntegrationTest.php
+++ b/tests/Phpunit/Integration/UseCase/RunAuditUseCaseIntegrationTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\UseCase;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -49,6 +50,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
 {
     private string $tmpDir;
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_report_contains_correct_project_path(): void
     {
         mkdir($this->tmpDir.'/src', 0o777, true);
@@ -59,6 +63,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         self::assertSame($this->tmpDir, $auditReport->projectPath());
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_report_files_scanned_matches_real_file_count(): void
     {
         mkdir($this->tmpDir.'/src/Controller', 0o777, true);
@@ -72,6 +79,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         self::assertSame(2, $auditReport->filesScanned());
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_returns_safe_report_when_no_vulnerabilities_found(): void
     {
         mkdir($this->tmpDir.'/src', 0o777, true);
@@ -83,6 +93,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         self::assertSame(0, $auditReport->totalVulnerabilities());
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_report_contains_vulnerability_found_by_stub_llm(): void
     {
         mkdir($this->tmpDir.'/src/Controller', 0o777, true);
@@ -100,6 +113,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         self::assertSame('Missing access control on admin route', $auditReport->vulnerabilities()[0]->title());
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_attaches_token_and_cost_telemetry_to_report(): void
     {
         mkdir($this->tmpDir.'/src', 0o777, true);
@@ -116,6 +132,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         self::assertGreaterThan(0.0, $auditReport->cost()->estimatedCostUsd());
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_includes_cache_tokens_in_the_reported_cost(): void
     {
         mkdir($this->tmpDir.'/src', 0o777, true);
@@ -154,6 +173,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         }
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_attaches_zero_cost_when_recorder_set_but_calculator_omitted(): void
     {
         mkdir($this->tmpDir.'/src', 0o777, true);
@@ -209,6 +231,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         self::assertSame(0.0, $auditReport->cost()->estimatedCostUsd());
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_propagates_reviewer_budget_exception_as_audit_aborted(): void
     {
         mkdir($this->tmpDir.'/src/Controller', 0o777, true);
@@ -233,6 +258,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         $runAuditUseCase->execute($this->tmpDir);
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_propagates_reviewer_batch_budget_exception(): void
     {
         mkdir($this->tmpDir.'/src/Controller', 0o777, true);
@@ -326,6 +354,9 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         self::assertArrayHasKey('error', $abortLogs[0][1]);
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_execute_report_audit_id_is_non_empty(): void
     {
         mkdir($this->tmpDir.'/src', 0o777, true);
@@ -337,12 +368,14 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
         self::assertStringStartsWith('AUDIT-', $auditReport->auditId());
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/usecase_int_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->rmdirRecursive($this->tmpDir);

--- a/tests/Phpunit/Integration/UseCase/RunAuditUseCaseIntegrationTest.php
+++ b/tests/Phpunit/Integration/UseCase/RunAuditUseCaseIntegrationTest.php
@@ -480,7 +480,12 @@ final class RunAuditUseCaseIntegrationTest extends TestCase
             return;
         }
 
-        foreach (scandir($dir) as $item) {
+        $items = scandir($dir);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
             if ('.' === $item) {
                 continue;
             }

--- a/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AttackerAgentTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -34,6 +35,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\RecordVulnerabi
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityCollector;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\LLMProviderException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AccessControlMap;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
@@ -95,6 +98,10 @@ final class AttackerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     #[MaximumDuration(250)]
     public function test_lean_mode_skip_logs_counts_records_skipped_coverage_and_returns_empty(): void
     {
@@ -111,6 +118,7 @@ final class AttackerAgentTest extends TestCase
             /** @var list<string> */
             public array $statuses = [];
 
+            #[Override]
             public function recordCoverage(string $stage, string $filePath, string $status): void
             {
                 $this->statuses[] = $status;
@@ -135,6 +143,10 @@ final class AttackerAgentTest extends TestCase
         self::assertNotContains('Attacker agent starting analysis', $messages);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_risk_markers_are_prepended_before_the_user_message(): void
     {
         $markers = [RiskMarker::create('src/Controller/A.php', 10, 'request_get', 'Request input read')];
@@ -157,6 +169,12 @@ final class AttackerAgentTest extends TestCase
         self::assertStringContainsString('## Source Code', $captured);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_previous_findings_are_prepended_before_the_user_message(): void
     {
         $previousFindings = [$this->makeVulnerabilityFor('src/Controller/A.php')];
@@ -180,6 +198,12 @@ final class AttackerAgentTest extends TestCase
         self::assertStringContainsString('## Source Code', $captured);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_rejected_findings_are_prepended_before_the_user_message_with_a_blank_line(): void
     {
         $rejectedFindings = [$this->makeVulnerabilityFor('src/Controller/Rejected.php')];
@@ -205,6 +229,10 @@ final class AttackerAgentTest extends TestCase
         self::assertStringContainsString('## Source Code', $captured);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_sends_the_sliced_content_to_the_llm(): void
     {
         $codeSlicer = self::createStub(CodeSlicerInterface::class);
@@ -1290,17 +1318,23 @@ final class AttackerAgentTest extends TestCase
         );
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/attacker_agent_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_injects_previous_findings_section_into_prompt_when_provided(): void
     {
         $sentMessages = [];
@@ -1352,6 +1386,10 @@ final class AttackerAgentTest extends TestCase
         self::assertStringNotContainsString('Patterns Already Confirmed', $sentMessages[0]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_skips_cache_when_previous_findings_present(): void
     {
         $cache = self::createMock(AttackerCacheInterface::class);
@@ -1375,6 +1413,10 @@ final class AttackerAgentTest extends TestCase
         $this->callAnalyze($attackerAgent, $files, SymfonyMapping::of(ProjectFileInventory::fromGroups([]), new AccessControlMap()), new NullCoverageRecorder(), ['previousFindings' => $previousFindings]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_injects_rejected_findings_section_into_prompt_when_provided(): void
     {
         $sentMessages = [];
@@ -1418,6 +1460,10 @@ final class AttackerAgentTest extends TestCase
         self::assertStringNotContainsString('Findings Already Rejected by the Reviewer', $sentMessages[0]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_skips_cache_when_rejected_findings_present(): void
     {
         $cache = self::createMock(AttackerCacheInterface::class);
@@ -1448,6 +1494,10 @@ final class AttackerAgentTest extends TestCase
         $this->callAnalyze($attackerAgent, $files, SymfonyMapping::of(ProjectFileInventory::fromGroups([]), new AccessControlMap()), new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_previous_findings_section_groups_locations_by_vulnerability_type(): void
     {
         $sentMessages = [];
@@ -1496,6 +1546,7 @@ final class AttackerAgentTest extends TestCase
             });
 
         $scanner = new class implements StaticPreScannerInterface {
+            #[Override]
             public function scan(array $files): array
             {
                 return [
@@ -1565,6 +1616,7 @@ final class AttackerAgentTest extends TestCase
             });
 
         $scanner = new class implements StaticPreScannerInterface {
+            #[Override]
             public function scan(array $files): array
             {
                 return [
@@ -1596,6 +1648,7 @@ final class AttackerAgentTest extends TestCase
         $cache->expects(self::once())->method('store');
 
         $scanner = new class implements StaticPreScannerInterface {
+            #[Override]
             public function scan(array $files): array
             {
                 return [
@@ -1638,6 +1691,10 @@ final class AttackerAgentTest extends TestCase
         return ProjectFile::create($path, '/app/'.$path, '<?php class Foo {}');
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerabilityFor(string $filePath): Vulnerability
     {
         return Vulnerability::of(
@@ -1852,6 +1909,7 @@ final class AttackerAgentTest extends TestCase
             /** @var list<array{stage: string, file: string, status: string}> */
             public array $records = [];
 
+            #[Override]
             public function recordCoverage(string $stage, string $filePath, string $status): void
             {
                 $this->records[] = ['stage' => $stage, 'file' => $filePath, 'status' => $status];
@@ -2384,6 +2442,7 @@ final class AttackerAgentTest extends TestCase
     private function makeRecordToolFactory(): RecordVulnerabilityToolFactoryInterface
     {
         return new class implements RecordVulnerabilityToolFactoryInterface {
+            #[Override]
             public function create(VulnerabilityCollector $vulnerabilityCollector): ToolInterface
             {
                 return new RecordVulnerabilityTool($vulnerabilityCollector);
@@ -2391,6 +2450,10 @@ final class AttackerAgentTest extends TestCase
         };
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_context_aware_cache_serves_chunks_carrying_previous_findings(): void
     {
         $files = [$this->makeFile('src/Controller/A.php')];
@@ -2413,6 +2476,10 @@ final class AttackerAgentTest extends TestCase
         self::assertSame([], $result);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_context_aware_cache_stores_context_carrying_chunks_after_the_llm_call(): void
     {
         $files = [$this->makeFile('src/Controller/A.php')];
@@ -2449,6 +2516,10 @@ final class AttackerAgentTest extends TestCase
         $this->callAnalyze($attackerAgent, $files, SymfonyMapping::of(ProjectFileInventory::fromGroups([]), new AccessControlMap()), new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_context_unaware_cache_is_skipped_for_chunks_carrying_previous_findings(): void
     {
         $files = [$this->makeFile('src/Controller/A.php')];
@@ -2468,6 +2539,10 @@ final class AttackerAgentTest extends TestCase
         $this->callAnalyze($attackerAgent, $files, SymfonyMapping::of(ProjectFileInventory::fromGroups([]), new AccessControlMap()), new NullCoverageRecorder(), ['previousFindings' => $previousFindings]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_context_key_is_the_hash_of_the_rendered_context_preambles(): void
     {
         $files = [$this->makeFile('src/Controller/A.php')];
@@ -2499,6 +2574,10 @@ final class AttackerAgentTest extends TestCase
         self::assertSame([$expectedKey], $contextKeys);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_previous_and_rejected_findings_produce_distinct_context_keys(): void
     {
         $files = [$this->makeFile('src/Controller/A.php')];

--- a/tests/Phpunit/Unit/Application/Agent/AttackerAnalysisRequestTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AttackerAnalysisRequestTest.php
@@ -15,6 +15,8 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent;
 
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAnalysisRequest;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AccessControlMap;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
@@ -49,6 +51,10 @@ final class AttackerAnalysisRequestTest extends TestCase
         self::assertSame([], $attackerAnalysisRequest->rejectedFindings);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_exposes_rejected_findings_from_the_constructor(): void
     {
         $rejected = [$this->makeVulnerability()];
@@ -58,6 +64,10 @@ final class AttackerAnalysisRequestTest extends TestCase
         self::assertSame($rejected, $attackerAnalysisRequest->rejectedFindings);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_with_files_and_findings_preserves_rejected_findings(): void
     {
         $rejected = [$this->makeVulnerability()];
@@ -68,6 +78,10 @@ final class AttackerAnalysisRequestTest extends TestCase
         self::assertSame($rejected, $derived->rejectedFindings);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_exposes_the_constructor_arguments(): void
     {
         $files = [ProjectFile::create('src/A.php', '/app/src/A.php', '<?php')];
@@ -82,6 +96,10 @@ final class AttackerAnalysisRequestTest extends TestCase
         self::assertSame($findings, $attackerAnalysisRequest->previousFindings);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_with_files_and_findings_replaces_both_and_preserves_mapping_and_bypass(): void
     {
         $symfonyMapping = SymfonyMapping::of(ProjectFileInventory::fromGroups([]), new AccessControlMap());
@@ -102,6 +120,10 @@ final class AttackerAnalysisRequestTest extends TestCase
         self::assertTrue($derived->bypassCache);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Application/Agent/AttackerContextPromptRendererTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AttackerContextPromptRendererTest.php
@@ -15,6 +15,8 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent;
 
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerContextPromptRenderer;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskMarker;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
@@ -58,6 +60,10 @@ final class AttackerContextPromptRendererTest extends TestCase
         self::assertMatchesRegularExpression('/^  src\/X\.php:$/m', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_renders_previous_findings_grouped_by_type_with_locations(): void
     {
         $output = (new AttackerContextPromptRenderer())->renderPreviousFindings([
@@ -68,6 +74,10 @@ final class AttackerContextPromptRendererTest extends TestCase
         self::assertStringContainsString('- sql_injection: src/Repo.php:10-20, src/Other.php:5-5', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_indents_previous_finding_lines_with_leading_whitespace(): void
     {
         $output = (new AttackerContextPromptRenderer())->renderPreviousFindings([
@@ -77,6 +87,10 @@ final class AttackerContextPromptRendererTest extends TestCase
         self::assertMatchesRegularExpression('/^  - sql_injection: src\/Repo\.php:10-20$/m', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_renders_rejected_findings_grouped_by_type_with_locations(): void
     {
         $output = (new AttackerContextPromptRenderer())->renderRejectedFindings([
@@ -87,6 +101,10 @@ final class AttackerContextPromptRendererTest extends TestCase
         self::assertStringContainsString('- missing_csrf_protection: src/Form.php:12-12, src/Other.php:3-4', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_instructs_the_model_not_to_re_report_rejected_findings(): void
     {
         $output = (new AttackerContextPromptRenderer())->renderRejectedFindings([
@@ -97,6 +115,10 @@ final class AttackerContextPromptRendererTest extends TestCase
         self::assertStringContainsString('Do NOT re-report these', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_indents_rejected_finding_lines_with_leading_whitespace(): void
     {
         $output = (new AttackerContextPromptRenderer())->renderRejectedFindings([
@@ -106,6 +128,10 @@ final class AttackerContextPromptRendererTest extends TestCase
         self::assertMatchesRegularExpression('/^  - missing_csrf_protection: src\/Form\.php:12-12$/m', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(VulnerabilityType $vulnerabilityType, string $filePath, int $start, int $end): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -28,6 +29,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgentCollaborators;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerModeConfiguration;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityFactory;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AccessControlMap;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
@@ -617,6 +620,10 @@ final class AuditOrchestratorTest extends TestCase
         self::assertCount(1, $auditContext->vulnerabilities());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_passes_previously_validated_findings_to_next_iteration(): void
     {
         $vulnerability = Vulnerability::of(
@@ -645,6 +652,10 @@ final class AuditOrchestratorTest extends TestCase
         self::assertSame([0, 1], $recordingAttackerAgent->previousFindingsCountPerCall);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_passes_only_reviewer_rejected_findings_to_next_iteration(): void
     {
         $recordingAttackerAgent = new RecordingAttackerAgent([
@@ -715,12 +726,14 @@ final class AuditOrchestratorTest extends TestCase
         self::assertSame(['max_iterations' => 7], $startingLogs[0][1]);
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/orchestrator_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);

--- a/tests/Phpunit/Unit/Application/Agent/EscalatingAttackerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/EscalatingAttackerAgentTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\ErrorHandler\BufferingLogger;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgentInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAnalysisRequest;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\EscalatingAttackerAgent;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AccessControlMap;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
@@ -53,6 +55,10 @@ final class EscalatingAttackerAgentTest extends TestCase
         self::assertSame(0, $expensive->callCount);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_runs_expensive_pass_only_on_files_flagged_by_cheap(): void
     {
         $files = [
@@ -75,6 +81,10 @@ final class EscalatingAttackerAgentTest extends TestCase
         self::assertSame('src/Controller/A.php', $expensive->lastFiles[0]->relativePath());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_expensive_findings_supersede_cheap_findings_on_overlap(): void
     {
         $vulnerability = $this->makeVulnerability(
@@ -103,6 +113,10 @@ final class EscalatingAttackerAgentTest extends TestCase
         self::assertSame('expensive version', $result[0]->title());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_cheap_findings_on_files_expensive_did_not_re_flag_are_kept(): void
     {
         $cheapOnA = $this->makeVulnerability('src/Controller/A.php', title: 'cheap A');
@@ -125,6 +139,10 @@ final class EscalatingAttackerAgentTest extends TestCase
         self::assertContains('cheap B', $titles);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_expensive_pass_receives_cheap_findings_as_previous_context(): void
     {
         $vulnerability = $this->makeVulnerability('src/Controller/A.php');
@@ -143,6 +161,10 @@ final class EscalatingAttackerAgentTest extends TestCase
         self::assertSame([$vulnerability], $expensive->lastPreviousFindings);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_logs_file_counts_for_both_passes(): void
     {
         $files = [
@@ -175,6 +197,10 @@ final class EscalatingAttackerAgentTest extends TestCase
         self::assertSame([], $this->contextOf($bufferingLogger->cleanLogs(), 'Escalation: cheap pass found nothing, skipping expensive pass'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_expensive_pass_receives_original_previous_findings_plus_all_cheap_findings(): void
     {
         $previous = [$this->makeVulnerability('src/Controller/Z.php', title: 'prev')];
@@ -236,6 +262,10 @@ final class EscalatingAttackerAgentTest extends TestCase
         return ProjectFile::create($path, '/app/'.$path, '<?php');
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(
         string $filePath,
         VulnerabilitySeverity $vulnerabilitySeverity = VulnerabilitySeverity::HIGH,

--- a/tests/Phpunit/Unit/Application/Agent/Fixture/RecordingAttackerAgent.php
+++ b/tests/Phpunit/Unit/Application/Agent/Fixture/RecordingAttackerAgent.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent\Fixture;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgentInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAnalysisRequest;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
@@ -51,6 +52,7 @@ final class RecordingAttackerAgent implements AttackerAgentInterface
         private readonly array $returnFindings = [],
     ) {}
 
+    #[Override]
     public function analyze(AttackerAnalysisRequest $attackerAnalysisRequest, CoverageRecorderInterface $coverageRecorder): array
     {
         ++$this->callCount;

--- a/tests/Phpunit/Unit/Application/Agent/Fixture/RecordingLLMClient.php
+++ b/tests/Phpunit/Unit/Application/Agent/Fixture/RecordingLLMClient.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent\Fixture;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\TokenUsageSnapshot;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
@@ -32,6 +33,7 @@ final class RecordingLLMClient implements LLMClientInterface
         private readonly string $responseContent = '[]',
     ) {}
 
+    #[Override]
     public function complete(string $systemPrompt, string $userMessage): LLMResponse
     {
         $this->capturedUserMessages[] = $userMessage;
@@ -39,6 +41,7 @@ final class RecordingLLMClient implements LLMClientInterface
         return $this->response();
     }
 
+    #[Override]
     public function completeWithTools(
         string $systemPrompt,
         string $userMessage,
@@ -50,6 +53,7 @@ final class RecordingLLMClient implements LLMClientInterface
         return $this->response();
     }
 
+    #[Override]
     public function model(): string
     {
         return 'claude';

--- a/tests/Phpunit/Unit/Application/Agent/PoCSynthesizerTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/PoCSynthesizerTest.php
@@ -19,6 +19,8 @@ use RuntimeException;
 use Symfony\Component\ErrorHandler\BufferingLogger;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\PoCSynthesizer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\LLMProviderException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\TokenUsageSnapshot;
@@ -32,6 +34,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
 
 final class PoCSynthesizerTest extends TestCase
 {
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_returns_empty_when_input_is_empty(): void
     {
         $llmClient = self::createMock(LLMClientInterface::class);
@@ -42,6 +48,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertSame([], $poCSynthesizer->synthesize([]));
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_synthesizes_poc_for_validated_high_severity_finding(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH)->withReviewerValidation(true);
@@ -62,6 +74,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertStringContainsString('curl -X POST /admin/users', $enriched[0]->synthesizedPoC());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_skips_findings_below_severity_floor(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::LOW)->withReviewerValidation(true);
@@ -76,6 +94,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertNull($enriched[0]->synthesizedPoC());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_skips_findings_not_validated_by_reviewer(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH);
@@ -90,6 +114,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertNull($enriched[0]->synthesizedPoC());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_keeps_original_when_llm_returns_empty(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH)->withReviewerValidation(true);
@@ -104,6 +134,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertNull($enriched[0]->synthesizedPoC());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_keeps_original_when_llm_throws_generic_exception(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH)->withReviewerValidation(true);
@@ -118,6 +154,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertNull($enriched[0]->synthesizedPoC());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_severity_floor_medium_includes_medium_findings(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::MEDIUM)->withReviewerValidation(true);
@@ -137,6 +179,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertNotNull($enriched[0]->synthesizedPoC());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_returned_list_preserves_input_order_and_length(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH, filePath: 'src/A.php')->withReviewerValidation(true);
@@ -159,6 +207,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertNotNull($enriched[2]->synthesizedPoC());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_completion_summary_with_inputs_synthesized_and_skipped_counts(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH)->withReviewerValidation(true);
@@ -177,6 +231,10 @@ final class PoCSynthesizerTest extends TestCase
         self::assertSame(['inputs' => 2, 'synthesized' => 1, 'skipped' => 1], $completion[2]);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_does_not_log_completion_for_empty_input(): void
     {
         $bufferingLogger = new BufferingLogger();
@@ -186,6 +244,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertSame([], $bufferingLogger->cleanLogs());
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_vulnerability_id_and_error_when_synthesis_throws(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH)->withReviewerValidation(true);
@@ -206,6 +270,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertSame('network down', $entry[2]['error']);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_continues_to_the_next_finding_after_one_yields_no_poc(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH, filePath: 'src/First.php')->withReviewerValidation(true);
@@ -230,6 +300,12 @@ final class PoCSynthesizerTest extends TestCase
         self::assertSame(['inputs' => 2, 'synthesized' => 1, 'skipped' => 1], $completion[2]);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_rethrows_budget_exceeded_exception(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH)->withReviewerValidation(true);
@@ -241,6 +317,12 @@ final class PoCSynthesizerTest extends TestCase
         (new PoCSynthesizer($llmClient, new NullLogger()))->synthesize([$vulnerability]);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws LLMProviderException
+     */
     public function test_it_rethrows_llm_provider_exception(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH)->withReviewerValidation(true);
@@ -252,6 +334,10 @@ final class PoCSynthesizerTest extends TestCase
         (new PoCSynthesizer($llmClient, new NullLogger()))->synthesize([$vulnerability]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(
         VulnerabilitySeverity $vulnerabilitySeverity = VulnerabilitySeverity::HIGH,
         string $filePath = 'src/Controller/Foo.php',

--- a/tests/Phpunit/Unit/Application/Agent/Review/VerdictApplierTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/Review/VerdictApplierTest.php
@@ -16,6 +16,8 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent\Revi
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Review\VerdictApplier;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityClassification;
@@ -27,6 +29,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInter
 
 final class VerdictApplierTest extends TestCase
 {
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_reports_an_accepted_verdict_as_a_review_finding_event(): void
     {
         $progressReporter = $this->createMock(ProgressReporterInterface::class);
@@ -42,6 +48,10 @@ final class VerdictApplierTest extends TestCase
         self::assertTrue($vulnerability->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_reports_a_rejected_verdict_as_a_review_finding_event(): void
     {
         $progressReporter = $this->createMock(ProgressReporterInterface::class);
@@ -57,6 +67,10 @@ final class VerdictApplierTest extends TestCase
         self::assertFalse($vulnerability->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_elevates_severity_when_the_verdict_is_accepted(): void
     {
         $verdictApplier = new VerdictApplier(new NullLogger(), new NullProgressReporter());
@@ -66,6 +80,10 @@ final class VerdictApplierTest extends TestCase
         self::assertSame(VulnerabilitySeverity::CRITICAL, $vulnerability->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_does_not_adjust_severity_when_the_verdict_is_rejected(): void
     {
         $verdictApplier = new VerdictApplier(new NullLogger(), new NullProgressReporter());
@@ -75,6 +93,10 @@ final class VerdictApplierTest extends TestCase
         self::assertSame(VulnerabilitySeverity::HIGH, $vulnerability->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function vulnerability(): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Application/Agent/ReviewerAgentTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/ReviewerAgentTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -21,6 +22,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgent;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgentCollaborators;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerModeConfiguration;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\LLMProviderException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
@@ -49,6 +52,10 @@ final class ReviewerAgentTest extends TestCase
 
     private string $tmpDir;
 
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_returns_empty_array_when_no_vulnerabilities(): void
     {
         $llmClient = $this->createMock(LLMClientInterface::class);
@@ -60,6 +67,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertEmpty($result);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_marks_vulnerability_as_validated_when_accepted(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -86,6 +99,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_marks_vulnerability_as_not_validated_when_rejected(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -111,6 +130,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_adjusts_severity_when_reviewer_upgrades(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH);
@@ -136,6 +161,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(VulnerabilitySeverity::CRITICAL, $result[0]->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_handles_invalid_adjusted_severity_gracefully(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH);
@@ -162,6 +193,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(VulnerabilitySeverity::HIGH, $result[0]->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_handles_parse_error_by_rejecting(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -179,6 +216,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_handles_llm_exception_by_rejecting(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -196,6 +239,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_handles_empty_llm_response_by_rejecting(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -213,6 +262,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_returns_all_reviewed_vulnerabilities_including_rejected(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -235,6 +290,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_handles_nested_array_review_response_format(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH);
@@ -260,6 +321,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(VulnerabilitySeverity::CRITICAL, $result[0]->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_uses_empty_context_when_file_not_found_in_project_files(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -286,6 +353,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertStringNotContainsString('class OtherController', (string) $capturedUserMessage);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_finds_file_context_for_vulnerability(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -315,6 +388,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertStringContainsString('UserController', (string) $capturedUserMessage);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_info_when_starting_review(): void
     {
         $loggedMessages = [];
@@ -346,6 +425,10 @@ final class ReviewerAgentTest extends TestCase
         self::assertContains('Reviewer agent validating findings', $loggedMessages);
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_does_not_log_info_when_no_vulnerabilities(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -368,6 +451,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame([], $result);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_error_with_specific_message_on_json_parse_failure(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -401,6 +490,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_truncates_long_content_in_single_mode_parse_failure_log(): void
     {
         // Pin the truncation boundary so IncrementInteger / DecrementInteger
@@ -445,6 +540,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(str_repeat('y', self::PARSE_FAILURE_PREVIEW_BYTES), $preview);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_truncates_long_content_in_batch_mode_parse_failure_log(): void
     {
         // Same boundary pin for the batch path (separate constant on the
@@ -495,6 +596,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(str_repeat('z', self::PARSE_FAILURE_PREVIEW_BYTES), $preview);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_error_with_specific_message_on_llm_throwable(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -527,6 +634,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_info_start_and_complete_with_exact_context(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -560,6 +673,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['Reviewer agent complete', ['reviewed' => 1, 'accepted' => 1, 'rejected' => 0]], $infoLogs[1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_rejected_count_is_reviewed_minus_accepted(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -592,6 +711,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['Reviewer agent complete', ['reviewed' => 1, 'accepted' => 0, 'rejected' => 1]], $infoLogs[1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_debug_review_decision_with_exact_context(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -630,6 +755,12 @@ final class ReviewerAgentTest extends TestCase
         ], $debugLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_does_not_log_error_for_empty_llm_response(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -658,6 +789,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_debug_invalid_severity_with_exact_context(): void
     {
         $vulnerability = $this->makeVulnerability(VulnerabilitySeverity::HIGH);
@@ -693,6 +830,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['adjusted_severity' => 'SUPER_CRITICAL_9000'], $entry[1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_rejects_vulnerability_when_accepted_key_is_missing(): void
     {
         // Tests the `?? false` fallback: if 'accepted' key is absent, vulnerability must be rejected.
@@ -711,6 +854,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_debug_review_decision_when_finding_is_rejected(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -753,6 +902,12 @@ final class ReviewerAgentTest extends TestCase
         ], $reviewedLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_debug_review_decision_when_severity_is_elevated(): void
     {
         // Covers MethodCallRemoval on the logReviewDecision call after severity elevation
@@ -801,6 +956,12 @@ final class ReviewerAgentTest extends TestCase
         ], $reviewedLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_includes_actual_file_content_in_llm_message(): void
     {
         // Tests ReturnRemoval on getFileContext: if the return is removed, content is '' and
@@ -834,6 +995,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertStringContainsString('sensitiveAction', (string) $capturedUserMessage);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_sends_single_llm_call_for_multiple_vulnerabilities(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -871,6 +1038,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[2]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_chunks_when_vulnerabilities_exceed_batch_size(): void
     {
         $vulns = [];
@@ -905,6 +1078,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(3, $callIndex);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_rejects_vulnerabilities_missing_from_response(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -936,6 +1115,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_records_coverage_per_finding(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -975,6 +1160,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_marks_all_batch_vulnerabilities_errored_on_llm_exception(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1011,6 +1202,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_marks_all_batch_vulnerabilities_errored_on_json_parse_failure(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1045,6 +1242,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_rejects_all_when_response_is_empty(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1081,6 +1284,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_preserves_results_from_first_batch_when_second_batch_is_processed(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1119,6 +1328,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertCount(3, $result);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_records_coverage_rejected_for_vulnerabilities_missing_from_response(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1157,6 +1372,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_continues_processing_after_missing_response_entry(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1190,6 +1411,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_skips_non_array_entries_in_response(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1226,6 +1453,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_logs_error_with_batch_size_and_error_context_on_json_exception(): void
     {
         $errorLogs = [];
@@ -1272,6 +1505,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame('not json{{{', $batchParseLogs[0][1]['content_preview']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_logs_error_with_batch_size_and_error_context_on_llm_exception(): void
     {
         $errorLogs = [];
@@ -1317,6 +1556,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertNotSame('', $batchExLogs[0][1]['error']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_mode_applies_adjusted_severity_when_reviewer_elevates(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php', VulnerabilitySeverity::MEDIUM);
@@ -1346,6 +1591,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(VulnerabilitySeverity::CRITICAL, $result[0]->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_corrects_type_when_reviewer_reclassifies_accepted_finding(): void
     {
         // Attacker labelled it SQLi but reviewer determines it's actually an SSRF.
@@ -1374,6 +1625,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(VulnerabilityType::SSRF, $result[0]->type());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_keeps_original_type_when_corrected_type_is_invalid_string(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1397,6 +1654,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_ignores_corrected_type_when_finding_is_rejected(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1419,6 +1682,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame($vulnerability->type(), $result[0]->type());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_logs_debug_invalid_corrected_type_with_exact_context(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1456,6 +1725,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['corrected_type' => 'NOT_A_TYPE_999'], $invalidLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_ignores_corrected_type_when_value_is_not_a_string(): void
     {
         // Non-string corrected_type (e.g. integer) must be ignored — would TypeError on enum::from()
@@ -1474,6 +1749,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_records_coverage_validated_when_reviewer_accepts_finding(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1494,6 +1775,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_records_coverage_rejected_when_reviewer_rejects_finding(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1514,6 +1801,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_records_coverage_rejected_when_reviewer_returns_empty_response(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1534,6 +1827,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_records_coverage_errored_on_reviewer_json_parse_failure(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1554,6 +1853,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_records_coverage_errored_on_reviewer_llm_exception(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1574,6 +1879,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_single_review_propagates_llm_provider_exception_instead_of_swallowing_it(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1589,6 +1900,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$vulnerability], [], AuditContext::forProject($this->tmpDir));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_single_review_propagates_budget_exceeded_exception_instead_of_swallowing_it(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1603,6 +1920,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$vulnerability], [], AuditContext::forProject($this->tmpDir));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_review_propagates_llm_provider_exception_instead_of_swallowing_it(): void
     {
         $batch = [$this->makeVulnerabilityAt('src/A.php'), $this->makeVulnerabilityAt('src/B.php')];
@@ -1627,6 +1950,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review($batch, [], AuditContext::forProject($this->tmpDir));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_review_propagates_budget_exceeded_exception_instead_of_swallowing_it(): void
     {
         $batch = [$this->makeVulnerabilityAt('src/A.php'), $this->makeVulnerabilityAt('src/B.php')];
@@ -1650,17 +1979,25 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review($batch, [], AuditContext::forProject($this->tmpDir));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/reviewer_agent_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_reviews_singles_concurrently_when_batch_capable_and_concurrency_configured(): void
     {
         $vulnerabilities = [$this->makeVulnerabilityAt('src/A.php'), $this->makeVulnerabilityAt('src/B.php')];
@@ -1670,6 +2007,7 @@ final class ReviewerAgentTest extends TestCase
 
             public int $completeCalls = 0;
 
+            #[Override]
             public function complete(string $systemPrompt, string $userMessage): LLMResponse
             {
                 ++$this->completeCalls;
@@ -1677,16 +2015,19 @@ final class ReviewerAgentTest extends TestCase
                 return LLMResponse::of('{"accepted": true}', 'm', 'end_turn', TokenUsageSnapshot::of(0, 0));
             }
 
+            #[Override]
             public function completeWithTools(string $systemPrompt, string $userMessage, ToolRegistry $toolRegistry, int $maxToolIterations): LLMResponse
             {
                 return LLMResponse::of('{}', 'm', 'end_turn', TokenUsageSnapshot::of(0, 0));
             }
 
+            #[Override]
             public function model(): string
             {
                 return 'm';
             }
 
+            #[Override]
             public function completeBatch(array $requests, int $maxConcurrent): array
             {
                 ++$this->batchCalls;
@@ -1718,6 +2059,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($reviewed[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_concurrent_review_skips_the_batch_call_when_every_finding_is_a_cache_hit(): void
     {
         $vulnerabilities = [$this->makeVulnerabilityAt('src/A.php'), $this->makeVulnerabilityAt('src/B.php')];
@@ -1748,6 +2095,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($reviewed[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batch_json_mode_invokes_the_tool_aware_completion_when_tools_are_enabled(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1782,6 +2135,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($reviewed[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_stays_sequential_when_max_concurrent_is_one_even_if_batch_capable(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1791,6 +2150,7 @@ final class ReviewerAgentTest extends TestCase
 
             public int $completeCalls = 0;
 
+            #[Override]
             public function complete(string $systemPrompt, string $userMessage): LLMResponse
             {
                 ++$this->completeCalls;
@@ -1798,16 +2158,19 @@ final class ReviewerAgentTest extends TestCase
                 return LLMResponse::of('{"accepted": true}', 'm', 'end_turn', TokenUsageSnapshot::of(0, 0));
             }
 
+            #[Override]
             public function completeWithTools(string $systemPrompt, string $userMessage, ToolRegistry $toolRegistry, int $maxToolIterations): LLMResponse
             {
                 return LLMResponse::of('{}', 'm', 'end_turn', TokenUsageSnapshot::of(0, 0));
             }
 
+            #[Override]
             public function model(): string
             {
                 return 'm';
             }
 
+            #[Override]
             public function completeBatch(array $requests, int $maxConcurrent): array
             {
                 ++$this->batchCalls;
@@ -1833,6 +2196,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(1, $llmClient->completeCalls);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_uses_tool_registry_when_tools_enabled_and_factory_provided(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1862,6 +2231,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$vulnerability], [], new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_falls_back_to_complete_when_tools_disabled(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1891,6 +2266,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$vulnerability], [], new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_tools_enabled_logs_when_factory_provided(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -1939,6 +2320,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_validates_a_finding_via_a_record_review_tool_call(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -1979,6 +2366,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(VulnerabilitySeverity::CRITICAL, $result[0]->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_rejects_a_finding_when_no_verdict_is_recorded(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2004,6 +2397,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_rejects_a_finding_when_the_llm_call_fails(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2029,6 +2428,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_batch_rekeys_verdicts_by_id(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/Accepted.php');
@@ -2065,6 +2470,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_concurrency_falls_back_to_json_when_the_client_cannot_batch_tools(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2095,6 +2506,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_tools_opt_in_takes_precedence_over_structured_collection(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2132,6 +2549,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_is_the_default_when_a_record_review_factory_is_wired(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2164,6 +2587,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_flag_without_factory_falls_back_to_json_path(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2192,6 +2621,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_single_path_returns_a_verdict_for_every_finding(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/First.php');
@@ -2226,6 +2661,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame('src/Second.php', $result[1]->filePath());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_records_errored_coverage_and_returns_rejected_on_throwable(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2256,6 +2697,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_propagates_llm_provider_exception(): void
     {
         $llmClient = self::createStub(LLMClientInterface::class);
@@ -2278,6 +2725,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$this->makeVulnerabilityAt('src/A.php')], [], new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_propagates_budget_exceeded_exception(): void
     {
         $llmClient = self::createStub(LLMClientInterface::class);
@@ -2300,6 +2753,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$this->makeVulnerabilityAt('src/A.php')], [], new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_batch_marks_errored_on_throwable(): void
     {
         $llmClient = self::createStub(LLMClientInterface::class);
@@ -2333,6 +2792,12 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_batch_propagates_llm_provider_exception(): void
     {
         $llmClient = self::createStub(LLMClientInterface::class);
@@ -2356,6 +2821,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$this->makeVulnerabilityAt('src/A.php')], [], new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_batch_propagates_budget_exceeded_exception(): void
     {
         $llmClient = self::createStub(LLMClientInterface::class);
@@ -2379,6 +2850,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$this->makeVulnerabilityAt('src/A.php')], [], new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_cache_hit_short_circuits_the_llm_call_and_applies_the_stored_verdict(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php', VulnerabilitySeverity::MEDIUM);
@@ -2406,6 +2883,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(VulnerabilitySeverity::CRITICAL, $result[0]->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_cache_hit_logs_debug_message_with_the_vulnerability_id(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php', VulnerabilitySeverity::MEDIUM);
@@ -2443,6 +2926,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['vulnerability_id' => $vulnerability->id()], $cacheHitLogs[0][1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_cache_miss_calls_the_llm_and_stores_the_parsed_verdict(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2473,6 +2962,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_bypass_cache_skips_both_get_and_store(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2501,6 +2996,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_cache_miss_does_not_store_when_the_response_is_empty(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2527,6 +3028,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_cache_miss_does_not_log_a_cache_hit(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2562,6 +3069,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertNotContains('Reviewer verdict served from cache', $debugLogs);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_opt_out_uses_the_json_path(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2591,6 +3104,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_cache_hit_short_circuits_the_llm_call(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php', VulnerabilitySeverity::MEDIUM);
@@ -2621,6 +3140,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(VulnerabilitySeverity::CRITICAL, $result[0]->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_cache_miss_stores_the_recorded_verdict(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2658,6 +3183,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_bypass_cache_skips_both_get_and_store(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2693,6 +3224,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_collection_does_not_store_when_no_verdict_is_recorded(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2724,6 +3261,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_reviews_run_concurrently_when_the_client_can_batch_tools(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/First.php');
@@ -2766,6 +3309,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_concurrent_structured_path_logs_structured_collection_enabled(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2807,6 +3356,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['Reviewer agent validating findings', ['count' => 1, 'batch_size' => 1, 'tools_enabled' => false, 'structured_collection' => true]], $infoLogs[0]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_concurrent_reviews_serve_cached_verdicts_and_dispatch_only_misses(): void
     {
         $first = $this->makeVulnerabilityAt('src/First.php');
@@ -2861,6 +3416,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['src/First.php', 'src/Third.php'], $storedFor);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_concurrent_bypass_cache_skips_both_get_and_store(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2898,6 +3459,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_concurrent_reviews_mark_pending_findings_errored_on_throwable(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2928,6 +3495,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertFalse($result[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_concurrent_reviews_propagate_llm_provider_exceptions(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2953,6 +3526,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$vulnerability], [], new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_concurrent_reviews_propagate_budget_exceeded(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -2978,6 +3557,12 @@ final class ReviewerAgentTest extends TestCase
         $reviewerAgent->review([$vulnerability], [], new NullCoverageRecorder());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_concurrent_json_reviews_serve_cached_verdicts_and_dispatch_only_misses(): void
     {
         $first = $this->makeVulnerabilityAt('src/First.php');
@@ -3030,6 +3615,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['src/First.php', 'src/Third.php'], $storedFor);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_concurrent_json_reviews_bypass_cache_skips_both_get_and_store(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -3060,6 +3651,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batched_reviews_serve_cached_verdicts_and_batch_only_misses(): void
     {
         $first = $this->makeVulnerabilityAt('src/First.php');
@@ -3117,6 +3714,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['src/First.php', 'src/Third.php'], $storedFor);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batched_review_cache_miss_stores_the_matched_verdict(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -3149,6 +3752,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batched_review_bypass_cache_skips_both_get_and_store(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -3179,6 +3788,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_batched_review_cache_miss_does_not_store_an_unmatched_finding(): void
     {
         $matched = $this->makeVulnerabilityAt('src/Matched.php');
@@ -3217,6 +3832,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertSame(['src/Matched.php'], $storedFor);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_reviews_stay_sequential_when_concurrency_is_not_requested(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -3249,6 +3870,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[0]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_batches_ignore_the_concurrency_opt_in(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -3288,6 +3915,12 @@ final class ReviewerAgentTest extends TestCase
         self::assertTrue($result[1]->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_structured_opt_out_keeps_the_json_path_even_on_a_tool_batch_capable_client(): void
     {
         $vulnerability = $this->makeVulnerabilityAt('src/A.php');
@@ -3326,6 +3959,10 @@ final class ReviewerAgentTest extends TestCase
         return $toolRegistry;
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerabilityAt(
         string $filePath,
         VulnerabilitySeverity $vulnerabilitySeverity = VulnerabilitySeverity::HIGH,
@@ -3338,6 +3975,10 @@ final class ReviewerAgentTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(
         VulnerabilitySeverity $vulnerabilitySeverity = VulnerabilitySeverity::HIGH,
     ): Vulnerability {

--- a/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/VulnerabilityFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Agent;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -442,6 +443,7 @@ final class VulnerabilityFactoryTest extends TestCase
         self::assertSame(1.0, $vuln->confidence());
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->vulnerabilityFactory = new VulnerabilityFactory(new NullLogger(), Validation::createValidator());

--- a/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
+++ b/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Budget;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\BudgetTracker;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\CostCalculator;
@@ -24,6 +25,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
 
 final class BudgetTrackerTest extends TestCase
 {
+    /**
+     * @throws BudgetExceededException
+     */
     public function test_unlimited_budget_never_throws(): void
     {
         $budgetTracker = $this->budgetTracker(AuditBudget::unlimited());
@@ -34,6 +38,9 @@ final class BudgetTrackerTest extends TestCase
         self::expectNotToPerformAssertions();
     }
 
+    /**
+     * @throws BudgetExceededException
+     */
     public function test_token_budget_passes_at_cap(): void
     {
         $budgetTracker = $this->budgetTracker(AuditBudget::forTokens(150));
@@ -44,6 +51,9 @@ final class BudgetTrackerTest extends TestCase
         self::assertSame(150, $budgetTracker->tokensUsed());
     }
 
+    /**
+     * @throws BudgetExceededException
+     */
     public function test_token_budget_exceeded_throws(): void
     {
         $budgetTracker = $this->budgetTracker(AuditBudget::forTokens(100));
@@ -56,6 +66,9 @@ final class BudgetTrackerTest extends TestCase
         $budgetTracker->assertWithinBudget();
     }
 
+    /**
+     * @throws BudgetExceededException
+     */
     public function test_cost_budget_exceeded_throws(): void
     {
         $budgetTracker = $this->budgetTracker(AuditBudget::forCost(0.01), inputPrice: 100.0, outputPrice: 100.0);
@@ -68,6 +81,9 @@ final class BudgetTrackerTest extends TestCase
         $budgetTracker->assertWithinBudget();
     }
 
+    /**
+     * @throws BudgetExceededException
+     */
     public function test_for_both_enforces_whichever_cap_is_hit_first(): void
     {
         $budgetTracker = $this->budgetTracker(AuditBudget::forBoth(maxTokens: 1_000_000, maxCostUsd: 0.001), inputPrice: 100.0, outputPrice: 0.0);
@@ -80,6 +96,9 @@ final class BudgetTrackerTest extends TestCase
         $budgetTracker->assertWithinBudget();
     }
 
+    /**
+     * @throws BudgetExceededException
+     */
     public function test_multiple_record_calls_accumulate(): void
     {
         $budgetTracker = $this->budgetTracker(AuditBudget::forTokens(500));
@@ -113,6 +132,9 @@ final class BudgetTrackerTest extends TestCase
         self::assertSame(15.0, $budgetTracker->costUsdUsed());
     }
 
+    /**
+     * @throws BudgetExceededException
+     */
     public function test_cost_budget_passes_at_exact_cap_and_aborts_above(): void
     {
         $budgetTracker = $this->budgetTracker(AuditBudget::forCost(5.0), inputPrice: 10.0);
@@ -136,6 +158,9 @@ final class BudgetTrackerTest extends TestCase
         self::assertSame(0.000001, $budgetTracker->costUsdUsed());
     }
 
+    /**
+     * @throws BudgetExceededException
+     */
     public function test_at_cap_call_completes_next_call_aborts(): void
     {
         $budgetTracker = $this->budgetTracker(AuditBudget::forTokens(100));
@@ -183,26 +208,31 @@ final class BudgetTrackerTest extends TestCase
                 private readonly float $cacheCreationPrice,
             ) {}
 
+            #[Override]
             public function pricePerMillionInputTokens(string $model): float
             {
                 return $this->inputPrice;
             }
 
+            #[Override]
             public function pricePerMillionOutputTokens(string $model): float
             {
                 return $this->outputPrice;
             }
 
+            #[Override]
             public function cacheReadPricePerMillionTokens(string $model): float
             {
                 return $this->cacheReadPrice;
             }
 
+            #[Override]
             public function cacheCreationPricePerMillionTokens(string $model): float
             {
                 return $this->cacheCreationPrice;
             }
 
+            #[Override]
             public function hasModel(string $model): bool
             {
                 return true;

--- a/tests/Phpunit/Unit/Application/Budget/CostCalculatorTest.php
+++ b/tests/Phpunit/Unit/Application/Budget/CostCalculatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Budget;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\CostCalculator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CacheAwarePricingProviderInterface;
@@ -114,16 +115,19 @@ final class CostCalculatorTest extends TestCase
                 private readonly float $outputPrice,
             ) {}
 
+            #[Override]
             public function pricePerMillionInputTokens(string $model): float
             {
                 return $this->inputPrice;
             }
 
+            #[Override]
             public function pricePerMillionOutputTokens(string $model): float
             {
                 return $this->outputPrice;
             }
 
+            #[Override]
             public function hasModel(string $model): bool
             {
                 return true;
@@ -145,26 +149,31 @@ final class CostCalculatorTest extends TestCase
                 private readonly float $cacheCreationPrice,
             ) {}
 
+            #[Override]
             public function pricePerMillionInputTokens(string $model): float
             {
                 return $this->inputPrice;
             }
 
+            #[Override]
             public function pricePerMillionOutputTokens(string $model): float
             {
                 return $this->outputPrice;
             }
 
+            #[Override]
             public function cacheReadPricePerMillionTokens(string $model): float
             {
                 return $this->cacheReadPrice;
             }
 
+            #[Override]
             public function cacheCreationPricePerMillionTokens(string $model): float
             {
                 return $this->cacheCreationPrice;
             }
 
+            #[Override]
             public function hasModel(string $model): bool
             {
                 return true;

--- a/tests/Phpunit/Unit/Application/Pipeline/AuditPipelineTest.php
+++ b/tests/Phpunit/Unit/Application/Pipeline/AuditPipelineTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Pipeline;
 
 use ArrayIterator;
 use Closure;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -258,12 +259,14 @@ final class AuditPipelineTest extends TestCase
         self::assertSame(['a', 'b'], $callOrder);
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/pipeline_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
@@ -277,11 +280,13 @@ final class AuditPipelineTest extends TestCase
                 private readonly Closure $callback,
             ) {}
 
+            #[Override]
             public function process(AuditContext $auditContext): void
             {
                 ($this->callback)($auditContext);
             }
 
+            #[Override]
             public function name(): string
             {
                 return $this->stageName;

--- a/tests/Phpunit/Unit/Application/Pipeline/AuditPipelineTest.php
+++ b/tests/Phpunit/Unit/Application/Pipeline/AuditPipelineTest.php
@@ -272,9 +272,15 @@ final class AuditPipelineTest extends TestCase
         rmdir($this->tmpDir);
     }
 
+    /**
+     * @param Closure(AuditContext): void $callback
+     */
     private function createNamedStage(string $name, Closure $callback): StageInterface
     {
         return new class($name, $callback) implements StageInterface {
+            /**
+             * @param Closure(AuditContext): void $callback
+             */
             public function __construct(
                 private readonly string $stageName,
                 private readonly Closure $callback,

--- a/tests/Phpunit/Unit/Application/Pipeline/Fixture/RecordingProgressReporter.php
+++ b/tests/Phpunit/Unit/Application/Pipeline/Fixture/RecordingProgressReporter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Pipeline\Fixture;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ProgressReporterInterface;
 
 /**
@@ -25,6 +26,7 @@ final class RecordingProgressReporter implements ProgressReporterInterface
     /** @var list<array{0: string, 1: array<string, mixed>}> */
     public array $events = [];
 
+    #[Override]
     public function report(string $event, array $context = []): void
     {
         $this->events[] = [$event, $context];

--- a/tests/Phpunit/Unit/Application/Stage/PoCSynthesisStageTest.php
+++ b/tests/Phpunit/Unit/Application/Stage/PoCSynthesisStageTest.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Stage;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\ErrorHandler\BufferingLogger;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\PoCSynthesizerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\Stage\PoCSynthesisStage;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\BuiltInStageName;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
@@ -50,6 +53,10 @@ final class PoCSynthesisStageTest extends TestCase
         $poCSynthesisStage->process(AuditContext::forProject($this->tmpDir));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_does_not_call_synthesizer_when_no_validated_findings(): void
     {
         $synthesizer = self::createMock(PoCSynthesizerInterface::class);
@@ -62,6 +69,10 @@ final class PoCSynthesisStageTest extends TestCase
         $poCSynthesisStage->process($auditContext);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_replaces_validated_findings_with_enriched_copies(): void
     {
         $vulnerability = $this->makeVulnerability()->withReviewerValidation(true);
@@ -80,6 +91,10 @@ final class PoCSynthesisStageTest extends TestCase
         self::assertSame('curl /x', $stored->synthesizedPoC());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_records_count_metadata_in_context(): void
     {
         $vulnerability = $this->makeVulnerability()->withReviewerValidation(true);
@@ -97,6 +112,10 @@ final class PoCSynthesisStageTest extends TestCase
         self::assertSame(1, $auditContext->getMeta('audit.poc_synthesized'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_does_not_replace_findings_whose_poc_remained_null(): void
     {
         $vulnerability = $this->makeVulnerability()->withReviewerValidation(true);
@@ -114,6 +133,10 @@ final class PoCSynthesisStageTest extends TestCase
         self::assertNull($stored->synthesizedPoC());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_disabled_stage_does_not_synthesize_even_with_validated_findings(): void
     {
         $synthesizer = self::createMock(PoCSynthesizerInterface::class);
@@ -125,6 +148,10 @@ final class PoCSynthesisStageTest extends TestCase
         (new PoCSynthesisStage($synthesizer, new NullLogger(), false))->process($auditContext);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_stage_is_disabled_by_default_even_with_validated_findings(): void
     {
         $synthesizer = self::createMock(PoCSynthesizerInterface::class);
@@ -146,6 +173,10 @@ final class PoCSynthesisStageTest extends TestCase
         self::assertSame([], $this->contextOf($bufferingLogger->cleanLogs(), 'PoC synthesis stage disabled, skipping'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_logs_when_there_are_no_validated_findings(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -157,6 +188,10 @@ final class PoCSynthesisStageTest extends TestCase
         self::assertSame([], $this->contextOf($bufferingLogger->cleanLogs(), 'PoC synthesis: no validated findings to enrich'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_logs_completion_with_enriched_and_total_counts(): void
     {
         $vulnerability = $this->makeVulnerability()->withReviewerValidation(true);
@@ -176,12 +211,14 @@ final class PoCSynthesisStageTest extends TestCase
         );
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/poc_synthesis_stage_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
@@ -210,6 +247,7 @@ final class PoCSynthesisStageTest extends TestCase
     private function makeNoopSynthesizer(): PoCSynthesizerInterface
     {
         return new class implements PoCSynthesizerInterface {
+            #[Override]
             public function synthesize(array $vulnerabilities): array
             {
                 return $vulnerabilities;
@@ -217,6 +255,10 @@ final class PoCSynthesisStageTest extends TestCase
         };
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Application/Stage/StagesTest.php
+++ b/tests/Phpunit/Unit/Application/Stage/StagesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Stage;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -192,6 +193,7 @@ final class StagesTest extends TestCase
             /** @param list<RouteAccessControl> $entries */
             public function __construct(private array $entries) {}
 
+            #[Override]
             public function parse(ProjectFile $projectFile): array
             {
                 return $this->entries;
@@ -223,6 +225,7 @@ final class StagesTest extends TestCase
         $parser = new readonly class($entryA, $entryB) implements ControllerAccessControlParserInterface {
             public function __construct(private RouteAccessControl $entryA, private RouteAccessControl $entryB) {}
 
+            #[Override]
             public function parse(ProjectFile $projectFile): array
             {
                 return 'src/Controller/AController.php' === $projectFile->relativePath() ? [$this->entryA] : [$this->entryB];
@@ -249,6 +252,7 @@ final class StagesTest extends TestCase
         $parser = new readonly class($capabilityA, $capabilityB) implements VoterCapabilityParserInterface {
             public function __construct(private VoterCapability $capA, private VoterCapability $capB) {}
 
+            #[Override]
             public function parse(ProjectFile $projectFile): ?VoterCapability
             {
                 return match ($projectFile->relativePath()) {
@@ -275,6 +279,7 @@ final class StagesTest extends TestCase
     {
         $voterFile = ProjectFile::create('src/Security/SilentVoter.php', '/app/x', '<?php class SilentVoter {}');
         $parser = new readonly class implements VoterCapabilityParserInterface {
+            #[Override]
             public function parse(ProjectFile $projectFile): ?VoterCapability
             {
                 return null;
@@ -302,6 +307,7 @@ final class StagesTest extends TestCase
         $parser = new readonly class($bindingA, $bindingB) implements FormBindingParserInterface {
             public function __construct(private FormBinding $a, private FormBinding $b) {}
 
+            #[Override]
             public function parse(ProjectFile $projectFile): array
             {
                 return match ($projectFile->relativePath()) {
@@ -840,12 +846,14 @@ final class StagesTest extends TestCase
         self::fail(\sprintf('No log entry with message "%s"', $message));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/stages_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->rmdirRecursive($this->tmpDir);

--- a/tests/Phpunit/Unit/Application/Stage/StagesTest.php
+++ b/tests/Phpunit/Unit/Application/Stage/StagesTest.php
@@ -887,7 +887,12 @@ final class StagesTest extends TestCase
             return;
         }
 
-        foreach (scandir($dir) as $item) {
+        $items = scandir($dir);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
             if ('.' === $item) {
                 continue;
             }

--- a/tests/Phpunit/Unit/Application/Tool/ToolRegistryTest.php
+++ b/tests/Phpunit/Unit/Application/Tool/ToolRegistryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\Tool;
 
 use InvalidArgumentException;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -158,11 +159,13 @@ final class ToolRegistryTest extends TestCase
                 private readonly mixed $execute,
             ) {}
 
+            #[Override]
             public function definition(): ToolDefinition
             {
                 return new ToolDefinition($this->name, 'desc-'.$this->name, ['type' => 'object']);
             }
 
+            #[Override]
             public function execute(array $arguments): string
             {
                 if (null === $this->execute) {

--- a/tests/Phpunit/Unit/Application/UseCase/EstimateAuditCostUseCaseTest.php
+++ b/tests/Phpunit/Unit/Application/UseCase/EstimateAuditCostUseCaseTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\UseCase;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -437,6 +438,7 @@ final class EstimateAuditCostUseCaseTest extends TestCase
             /** @param list<ProjectFile> $files */
             public function __construct(private readonly array $files) {}
 
+            #[Override]
             public function scan(string $projectPath): array
             {
                 return $this->files;
@@ -449,6 +451,7 @@ final class EstimateAuditCostUseCaseTest extends TestCase
         return new class($perRoundTokens) implements TokenEstimatorInterface {
             public function __construct(private readonly int $perRoundTokens) {}
 
+            #[Override]
             public function estimateTokens(string $text, string $model): int
             {
                 return $this->perRoundTokens;
@@ -465,16 +468,19 @@ final class EstimateAuditCostUseCaseTest extends TestCase
     private function zeroPricing(): PricingProviderInterface
     {
         return new class implements PricingProviderInterface {
+            #[Override]
             public function pricePerMillionInputTokens(string $model): float
             {
                 return 0.0;
             }
 
+            #[Override]
             public function pricePerMillionOutputTokens(string $model): float
             {
                 return 0.0;
             }
 
+            #[Override]
             public function hasModel(string $model): bool
             {
                 return true;
@@ -495,16 +501,19 @@ final class EstimateAuditCostUseCaseTest extends TestCase
                 private readonly float $outputPricePerMillion,
             ) {}
 
+            #[Override]
             public function pricePerMillionInputTokens(string $model): float
             {
                 return $this->inputPricePerMillion;
             }
 
+            #[Override]
             public function pricePerMillionOutputTokens(string $model): float
             {
                 return $this->outputPricePerMillion;
             }
 
+            #[Override]
             public function hasModel(string $model): bool
             {
                 return true;
@@ -517,12 +526,14 @@ final class EstimateAuditCostUseCaseTest extends TestCase
         return ProjectFile::create($relative, $this->tmpDir.'/'.$relative, $content);
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/estimate_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         if (is_dir($this->tmpDir)) {

--- a/tests/Phpunit/Unit/Application/UseCase/Fixture/MeasuringTokenEstimator.php
+++ b/tests/Phpunit/Unit/Application/UseCase/Fixture/MeasuringTokenEstimator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\UseCase\Fixture;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\TokenEstimatorInterface;
 
 /**
@@ -24,6 +25,7 @@ final class MeasuringTokenEstimator implements TokenEstimatorInterface
 {
     public int $lastInputLength = -1;
 
+    #[Override]
     public function estimateTokens(string $text, string $model): int
     {
         $this->lastInputLength = mb_strlen($text);

--- a/tests/Phpunit/Unit/Application/UseCase/Fixture/RecordingStage.php
+++ b/tests/Phpunit/Unit/Application/UseCase/Fixture/RecordingStage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\UseCase\Fixture;
 
+use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\StageInterface;
 
@@ -33,11 +34,13 @@ final class RecordingStage implements StageInterface
     /** @var list<bool> */
     public array $observedCacheBypassed = [];
 
+    #[Override]
     public function name(): string
     {
         return 'recording';
     }
 
+    #[Override]
     public function process(AuditContext $auditContext): void
     {
         $this->processedAuditIds[] = $auditContext->auditId();

--- a/tests/Phpunit/Unit/Application/UseCase/ListScannedFilesUseCaseTest.php
+++ b/tests/Phpunit/Unit/Application/UseCase/ListScannedFilesUseCaseTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\UseCase;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\ListScannedFilesUseCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
@@ -59,6 +60,7 @@ final class ListScannedFilesUseCaseTest extends TestCase
             /** @param list<ProjectFile> $files */
             public function __construct(private readonly array $files) {}
 
+            #[Override]
             public function scan(string $projectPath): array
             {
                 return $this->files;

--- a/tests/Phpunit/Unit/Application/UseCase/RunAuditUseCaseTest.php
+++ b/tests/Phpunit/Unit/Application/UseCase/RunAuditUseCaseTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Application\UseCase;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByBudgetException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Pipeline\AuditPipeline;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\StageInterface;
@@ -25,17 +27,22 @@ final class RunAuditUseCaseTest extends TestCase
 {
     private string $tmpDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/usecase_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_it_runs_pipeline_against_the_audit_context(): void
     {
         $recordingStage = new RecordingStage();
@@ -47,6 +54,9 @@ final class RunAuditUseCaseTest extends TestCase
         self::assertSame($auditReport->auditId(), $recordingStage->processedAuditIds[0]);
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_it_logs_starting_audit_with_project_path(): void
     {
         $infoLogs = [];
@@ -66,6 +76,9 @@ final class RunAuditUseCaseTest extends TestCase
         );
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_it_marks_the_audit_context_as_cache_bypassed_when_requested(): void
     {
         $recordingStage = new RecordingStage();
@@ -76,6 +89,9 @@ final class RunAuditUseCaseTest extends TestCase
         self::assertSame([true], $recordingStage->observedCacheBypassed);
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_it_passes_scan_paths_to_the_pipeline_via_audit_context(): void
     {
         $recordingStage = new RecordingStage();
@@ -86,6 +102,9 @@ final class RunAuditUseCaseTest extends TestCase
         self::assertSame([['apps/api/src']], $recordingStage->observedScanPaths);
     }
 
+    /**
+     * @throws AuditAbortedByBudgetException
+     */
     public function test_it_logs_audit_complete_with_exact_context(): void
     {
         $infoLogs = [];

--- a/tests/Phpunit/Unit/Command/AuditCommandInputTest.php
+++ b/tests/Phpunit/Unit/Command/AuditCommandInputTest.php
@@ -82,6 +82,9 @@ final class AuditCommandInputTest extends TestCase
         self::assertNull($auditCommandInput->projectPath);
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_returns_cwd_when_property_is_null(): void
     {
         $auditCommandInput = new AuditCommandInput();
@@ -89,6 +92,9 @@ final class AuditCommandInputTest extends TestCase
         self::assertSame(getcwd(), $auditCommandInput->resolvedProjectPath());
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_returns_cwd_when_property_is_empty_string(): void
     {
         $auditCommandInput = new AuditCommandInput();
@@ -97,6 +103,9 @@ final class AuditCommandInputTest extends TestCase
         self::assertSame(getcwd(), $auditCommandInput->resolvedProjectPath());
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_returns_cwd_when_property_is_whitespace_only(): void
     {
         $auditCommandInput = new AuditCommandInput();
@@ -105,6 +114,9 @@ final class AuditCommandInputTest extends TestCase
         self::assertSame(getcwd(), $auditCommandInput->resolvedProjectPath());
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_returns_provided_path_when_set(): void
     {
         $auditCommandInput = new AuditCommandInput();
@@ -113,6 +125,9 @@ final class AuditCommandInputTest extends TestCase
         self::assertSame('/tmp/project', $auditCommandInput->resolvedProjectPath());
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_trims_surrounding_whitespace_and_returns_absolute(): void
     {
         $auditCommandInput = new AuditCommandInput();
@@ -121,6 +136,9 @@ final class AuditCommandInputTest extends TestCase
         self::assertSame('/tmp/project', $auditCommandInput->resolvedProjectPath());
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_resolves_dot_to_the_working_directory(): void
     {
         $auditCommandInput = new AuditCommandInput();
@@ -129,6 +147,9 @@ final class AuditCommandInputTest extends TestCase
         self::assertSame('/custom/cwd', $auditCommandInput->resolvedProjectPath(static fn (): string => '/custom/cwd'));
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_resolves_a_relative_path_against_the_working_directory(): void
     {
         $auditCommandInput = new AuditCommandInput();
@@ -137,6 +158,9 @@ final class AuditCommandInputTest extends TestCase
         self::assertSame('/custom/cwd/app', $auditCommandInput->resolvedProjectPath(static fn (): string => '/custom/cwd'));
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_throws_when_cwd_lookup_returns_false(): void
     {
         $auditCommandInput = new AuditCommandInput();
@@ -147,6 +171,9 @@ final class AuditCommandInputTest extends TestCase
         $auditCommandInput->resolvedProjectPath(static fn (): false => false);
     }
 
+    /**
+     * @throws WorkingDirectoryUnavailableException
+     */
     public function test_resolved_project_path_uses_injected_resolver_when_property_is_null(): void
     {
         $auditCommandInput = new AuditCommandInput();

--- a/tests/Phpunit/Unit/Command/AuditExitCodeResolverTest.php
+++ b/tests/Phpunit/Unit/Command/AuditExitCodeResolverTest.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
 
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
@@ -33,6 +36,7 @@ final class AuditExitCodeResolverTest extends TestCase
 
     private string $tmpDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->auditExitCodeResolver = new AuditExitCodeResolver();
@@ -40,11 +44,16 @@ final class AuditExitCodeResolverTest extends TestCase
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     #[DataProvider('thresholdCases')]
     public function test_it_fails_only_when_risk_level_meets_the_threshold(int $criticalFindings, RiskLevel $riskLevel, int $expectedExitCode): void
     {
@@ -78,6 +87,10 @@ final class AuditExitCodeResolverTest extends TestCase
         yield 'safe risk fails the safe gate' => [0, RiskLevel::Safe, Command::FAILURE];
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function reportWith(int $criticalFindings): AuditReport
     {
         $auditContext = AuditContext::forProject($this->tmpDir);

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
 
 use InvalidArgumentException;
+use Override;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditCost;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
@@ -39,6 +42,7 @@ final class AuditPresenterTest extends TestCase
 
     private string $tmpDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->auditPresenter = new AuditPresenter($this->pricingProviderKnowing('claude-opus-4-7', 'claude-haiku-4-5-20251001'));
@@ -46,6 +50,7 @@ final class AuditPresenterTest extends TestCase
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
@@ -99,6 +104,10 @@ final class AuditPresenterTest extends TestCase
         self::assertStringContainsString('Pipeline:', $display);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_result_for_failure_exit_omits_success_message(): void
     {
         $bufferedOutput = new BufferedOutput();
@@ -372,16 +381,19 @@ final class AuditPresenterTest extends TestCase
             /** @param array<string> $supportedModels */
             public function __construct(private array $supportedModels) {}
 
+            #[Override]
             public function pricePerMillionInputTokens(string $model): float
             {
                 return 0.0;
             }
 
+            #[Override]
             public function pricePerMillionOutputTokens(string $model): float
             {
                 return 0.0;
             }
 
+            #[Override]
             public function hasModel(string $model): bool
             {
                 return \in_array($model, $this->supportedModels, true);
@@ -389,6 +401,10 @@ final class AuditPresenterTest extends TestCase
         };
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeCriticalReport(): AuditReport
     {
         $auditContext = AuditContext::forProject($this->tmpDir);

--- a/tests/Phpunit/Unit/Command/BaselineProcessorTest.php
+++ b/tests/Phpunit/Unit/Command/BaselineProcessorTest.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
@@ -30,17 +33,23 @@ final class BaselineProcessorTest extends TestCase
 {
     private string $tmpDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/baseline_processor_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         (new Filesystem())->remove($this->tmpDir);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_generate_writes_the_report_fingerprints_and_returns_their_count(): void
     {
         $auditReport = $this->makeReport($this->makeVuln('src/A.php'), $this->makeVuln('src/B.php'));
@@ -55,6 +64,10 @@ final class BaselineProcessorTest extends TestCase
         self::assertSame(2, $count);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_apply_returns_the_report_unchanged_when_no_baseline_path_is_set(): void
     {
         $auditReport = $this->makeReport($this->makeVuln('src/A.php'));
@@ -68,6 +81,10 @@ final class BaselineProcessorTest extends TestCase
         self::assertSame(0, $baselineResult->suppressedCount);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_apply_suppresses_matching_findings_and_reports_the_suppressed_count(): void
     {
         $vulnerability = $this->makeVuln('src/Keep.php');
@@ -84,6 +101,10 @@ final class BaselineProcessorTest extends TestCase
         self::assertSame(1, $baselineResult->suppressedCount);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_apply_prefers_the_cli_baseline_over_the_configured_path(): void
     {
         $auditReport = $this->makeReport($this->makeVuln('src/A.php'));
@@ -99,6 +120,10 @@ final class BaselineProcessorTest extends TestCase
         self::assertSame(0, $baselineResult->suppressedCount);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_apply_falls_back_to_the_configured_path_when_no_cli_override(): void
     {
         $auditReport = $this->makeReport($this->makeVuln('src/A.php'));
@@ -124,6 +149,10 @@ final class BaselineProcessorTest extends TestCase
         return AuditReport::fromContext($auditContext);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVuln(string $filePath): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Command/BaselineTest.php
+++ b/tests/Phpunit/Unit/Command/BaselineTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Baseline;
@@ -24,6 +25,7 @@ final class BaselineTest extends TestCase
 
     private string $tmpDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->filesystem = new Filesystem();
@@ -31,16 +33,23 @@ final class BaselineTest extends TestCase
         $this->filesystem->mkdir($this->tmpDir);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->filesystem->remove($this->tmpDir);
     }
 
+    /**
+     * @throws MalformedBaselineFileException
+     */
     public function test_load_returns_empty_list_for_a_missing_file(): void
     {
         self::assertSame([], (new Baseline($this->filesystem))->load($this->tmpDir.'/absent.json'));
     }
 
+    /**
+     * @throws MalformedBaselineFileException
+     */
     public function test_save_then_load_round_trips_the_fingerprints(): void
     {
         $path = $this->tmpDir.'/baseline.json';
@@ -65,6 +74,9 @@ final class BaselineTest extends TestCase
         self::assertStringEndsWith(']'.\PHP_EOL, $contents);
     }
 
+    /**
+     * @throws MalformedBaselineFileException
+     */
     public function test_load_throws_when_the_file_is_not_valid_json(): void
     {
         $path = $this->tmpDir.'/broken.json';
@@ -75,6 +87,9 @@ final class BaselineTest extends TestCase
         (new Baseline($this->filesystem))->load($path);
     }
 
+    /**
+     * @throws MalformedBaselineFileException
+     */
     public function test_load_throws_when_the_json_is_a_bare_scalar(): void
     {
         $path = $this->tmpDir.'/scalar.json';
@@ -85,6 +100,9 @@ final class BaselineTest extends TestCase
         (new Baseline($this->filesystem))->load($path);
     }
 
+    /**
+     * @throws MalformedBaselineFileException
+     */
     public function test_load_throws_when_the_json_is_an_object_of_non_string_entries(): void
     {
         $path = $this->tmpDir.'/object.json';
@@ -95,6 +113,9 @@ final class BaselineTest extends TestCase
         (new Baseline($this->filesystem))->load($path);
     }
 
+    /**
+     * @throws MalformedBaselineFileException
+     */
     public function test_load_throws_when_an_entry_is_not_a_string(): void
     {
         $path = $this->tmpDir.'/mixed.json';

--- a/tests/Phpunit/Unit/Command/FindingTypeFilterTest.php
+++ b/tests/Phpunit/Unit/Command/FindingTypeFilterTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
 
+use Override;
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
@@ -28,17 +31,23 @@ final class FindingTypeFilterTest extends TestCase
 {
     private string $tmpDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/type_filter_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_apply_without_configured_types_keeps_all_findings(): void
     {
         $auditReport = $this->reportWithTypes(VulnerabilityType::SQL_INJECTION, VulnerabilityType::SSRF);
@@ -46,6 +55,10 @@ final class FindingTypeFilterTest extends TestCase
         self::assertSame(2, (new FindingTypeFilter())->apply($auditReport)->totalVulnerabilities());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_apply_excludes_configured_type_values(): void
     {
         $auditReport = $this->reportWithTypes(VulnerabilityType::SQL_INJECTION, VulnerabilityType::SSRF);
@@ -55,6 +68,10 @@ final class FindingTypeFilterTest extends TestCase
         self::assertSame([VulnerabilityType::SSRF], $this->typesOf($filtered));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_apply_restricts_to_included_type_values(): void
     {
         $auditReport = $this->reportWithTypes(VulnerabilityType::SQL_INJECTION, VulnerabilityType::SSRF, VulnerabilityType::MISSING_RATE_LIMITING);
@@ -64,6 +81,10 @@ final class FindingTypeFilterTest extends TestCase
         self::assertSame([VulnerabilityType::SSRF], $this->typesOf($filtered));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function reportWithTypes(VulnerabilityType ...$types): AuditReport
     {
         $auditContext = AuditContext::forProject($this->tmpDir);

--- a/tests/Phpunit/Unit/Command/ReportWriterTest.php
+++ b/tests/Phpunit/Unit/Command/ReportWriterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -32,6 +33,7 @@ final class ReportWriterTest extends TestCase
 
     private string $tmpDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->filesystem = new Filesystem();
@@ -40,6 +42,7 @@ final class ReportWriterTest extends TestCase
         $this->filesystem->mkdir($this->tmpDir);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         $this->filesystem->remove($this->tmpDir);

--- a/tests/Phpunit/Unit/Domain/Model/AuditContextDiffTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditContextDiffTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 
@@ -34,12 +35,14 @@ final class AuditContextDiffTest extends TestCase
         self::assertSame('origin/main', $auditContext->diffSinceRef());
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/audit_context_diff_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);

--- a/tests/Phpunit/Unit/Domain/Model/AuditContextTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditContextTest.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
 
 use InvalidArgumentException;
+use Override;
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AccessControlMap;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
@@ -88,6 +91,10 @@ final class AuditContextTest extends TestCase
         self::assertSame($symfonyMapping, $auditContext->mapping());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_stores_and_filters_vulnerabilities(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -104,6 +111,10 @@ final class AuditContextTest extends TestCase
         self::assertCount(1, $auditContext->criticalVulnerabilities());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_critical_vulnerabilities_requires_both_critical_severity_and_reviewer_validation(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -133,6 +144,10 @@ final class AuditContextTest extends TestCase
         self::assertSame(VulnerabilitySeverity::CRITICAL, $only->severity());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_replaces_vulnerability_by_id(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -148,6 +163,10 @@ final class AuditContextTest extends TestCase
         self::assertTrue($stored->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_calculates_risk_score_from_validated_vulnerabilities(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -178,6 +197,7 @@ final class AuditContextTest extends TestCase
         self::assertSame('default', $auditContext->getMeta('missing', 'default'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/audit_test_'.uniqid('', true);
@@ -259,11 +279,16 @@ final class AuditContextTest extends TestCase
         self::assertTrue($auditContext->isCacheBypassed());
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(string $discriminator, VulnerabilitySeverity $vulnerabilitySeverity): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Domain/Model/AuditReportTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditReportTest.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
 
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
@@ -40,6 +43,10 @@ final class AuditReportTest extends TestCase
         self::assertSame(0, $auditReport->filesScanned());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_includes_only_validated_vulnerabilities(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -58,6 +65,10 @@ final class AuditReportTest extends TestCase
         self::assertSame(10, $auditReport->riskScore());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_classifies_risk_levels_correctly(): void
     {
         // CRITICAL: score >= 50
@@ -72,6 +83,10 @@ final class AuditReportTest extends TestCase
         self::assertSame('SAFE', $this->reportWithScore(0)->riskLevel());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_filters_vulnerabilities_by_severity(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -94,6 +109,10 @@ final class AuditReportTest extends TestCase
         self::assertCount(0, $auditReport->vulnerabilitiesBySeverity(VulnerabilitySeverity::LOW));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_filters_vulnerabilities_by_type(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -113,6 +132,10 @@ final class AuditReportTest extends TestCase
         self::assertCount(0, $auditReport->vulnerabilitiesByType(VulnerabilityType::SSRF));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_vulnerabilities_are_ordered_most_severe_first(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -147,6 +170,10 @@ final class AuditReportTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_vulnerabilities_with_equal_severity_keep_discovery_order(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -198,6 +225,10 @@ final class AuditReportTest extends TestCase
         self::assertLessThan(1.0, $auditReport->durationSeconds());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_classifies_risk_level_at_exact_boundaries(): void
     {
         self::assertSame('CRITICAL', $this->reportWithExactScore(50)->riskLevel());
@@ -210,6 +241,10 @@ final class AuditReportTest extends TestCase
         self::assertSame('SAFE', $this->reportWithExactScore(4)->riskLevel());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     #[DataProvider('riskLevelEnumCases')]
     public function test_risk_level_enum_classifies_by_aggregate_score(int $score, RiskLevel $riskLevel): void
     {
@@ -232,12 +267,20 @@ final class AuditReportTest extends TestCase
         yield 'safe at 0' => [0, RiskLevel::Safe];
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_risk_level_string_is_the_uppercased_enum_value(): void
     {
         self::assertSame('CRITICAL', $this->reportWithExactScore(50)->riskLevel());
         self::assertSame('SAFE', $this->reportWithExactScore(0)->riskLevel());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_toarray_vulnerabilities_is_array_of_arrays(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -305,17 +348,23 @@ final class AuditReportTest extends TestCase
         );
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/report_test_'.uniqid('', true);
         mkdir($this->tmpDir, 0o777, true);
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function reportWithExactScore(int $score): AuditReport
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -338,6 +387,10 @@ final class AuditReportTest extends TestCase
         return AuditReport::fromContext($auditContext);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function reportWithScore(int $targetScore): AuditReport
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -353,6 +406,10 @@ final class AuditReportTest extends TestCase
         return AuditReport::fromContext($auditContext);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_fingerprints_lists_each_distinct_finding(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -366,6 +423,10 @@ final class AuditReportTest extends TestCase
         self::assertEqualsCanonicalizing([$vulnerability->fingerprint(), $second->fingerprint()], $auditReport->fingerprints());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_fingerprints_deduplicates_findings_that_share_a_fingerprint(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -377,6 +438,10 @@ final class AuditReportTest extends TestCase
         self::assertCount(1, $auditReport->fingerprints());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_without_fingerprints_removes_only_matching_findings(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -391,6 +456,10 @@ final class AuditReportTest extends TestCase
         self::assertSame($vulnerability->fingerprint(), $auditReport->vulnerabilities()[0]->fingerprint());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_without_fingerprints_keeps_findings_absent_from_the_list(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -402,6 +471,10 @@ final class AuditReportTest extends TestCase
         self::assertSame(2, $auditReport->totalVulnerabilities());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_without_fingerprints_preserves_report_metadata(): void
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -416,6 +489,10 @@ final class AuditReportTest extends TestCase
         self::assertSame($auditReport->projectPath(), $filtered->projectPath());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_filtered_by_types_with_no_filters_keeps_all_findings(): void
     {
         $auditReport = $this->reportWithTypes(VulnerabilityType::SQL_INJECTION, VulnerabilityType::SSRF);
@@ -423,6 +500,10 @@ final class AuditReportTest extends TestCase
         self::assertSame(2, $auditReport->filteredByTypes([], [])->totalVulnerabilities());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_filtered_by_types_drops_excluded_types(): void
     {
         $auditReport = $this->reportWithTypes(VulnerabilityType::SQL_INJECTION, VulnerabilityType::SSRF);
@@ -432,6 +513,10 @@ final class AuditReportTest extends TestCase
         self::assertSame([VulnerabilityType::SSRF], $this->typesOf($filtered));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_filtered_by_types_with_an_allowlist_keeps_only_included_types(): void
     {
         $auditReport = $this->reportWithTypes(VulnerabilityType::SQL_INJECTION, VulnerabilityType::SSRF, VulnerabilityType::MISSING_RATE_LIMITING);
@@ -441,6 +526,10 @@ final class AuditReportTest extends TestCase
         self::assertSame([VulnerabilityType::SSRF], $this->typesOf($filtered));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_filtered_by_types_lets_exclusions_win_over_the_allowlist(): void
     {
         $auditReport = $this->reportWithTypes(VulnerabilityType::SQL_INJECTION, VulnerabilityType::SSRF);
@@ -453,6 +542,10 @@ final class AuditReportTest extends TestCase
         self::assertSame([VulnerabilityType::SSRF], $this->typesOf($filtered));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_filtered_by_types_preserves_report_metadata(): void
     {
         $auditReport = $this->reportWithTypes(VulnerabilityType::SQL_INJECTION);
@@ -464,6 +557,10 @@ final class AuditReportTest extends TestCase
         self::assertSame($auditReport->projectPath(), $filtered->projectPath());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function reportWithTypes(VulnerabilityType ...$types): AuditReport
     {
         $auditContext = AuditContext::forProject($this->tmpDir);
@@ -487,6 +584,10 @@ final class AuditReportTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function sameFingerprintVuln(int $lineStart): Vulnerability
     {
         return Vulnerability::of(
@@ -497,6 +598,10 @@ final class AuditReportTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(
         string $discriminator,
         VulnerabilitySeverity $vulnerabilitySeverity,

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityHydrationResultTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityHydrationResultTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityClassification;
@@ -71,6 +73,10 @@ final class VulnerabilityHydrationResultTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_result_holds_vulnerabilities(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -81,6 +87,10 @@ final class VulnerabilityHydrationResultTest extends TestCase
         self::assertFalse($vulnerabilityHydrationResult->hasDrops());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTest.php
@@ -17,6 +17,8 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityClassification;
@@ -26,6 +28,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityType;
 
 final class VulnerabilityTest extends TestCase
 {
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_creates_with_valid_data(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -41,6 +47,9 @@ final class VulnerabilityTest extends TestCase
 
     /**
      * @deprecated covers the deprecated {@see Vulnerability::create()} delegator until it is removed in 2.0.
+     *
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
      */
     #[IgnoreDeprecations('vinceamstoutz/symfony-security-auditor')]
     public function test_deprecated_create_maps_every_field_to_of(): void
@@ -87,6 +96,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame($fromOf, $fromCreate);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_generates_unique_id(): void
     {
         $vulnerability = $this->makeVulnerability(['filePath' => 'src/A.php', 'lineStart' => 1]);
@@ -96,6 +109,10 @@ final class VulnerabilityTest extends TestCase
         self::assertNotSame($vulnerability->id(), $v2->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_id_is_deterministic_for_same_inputs(): void
     {
         $vulnerability = $this->makeVulnerability(['filePath' => 'src/A.php', 'lineStart' => 10]);
@@ -104,6 +121,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame($vulnerability->id(), $v2->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_id_differs_for_different_file_path(): void
     {
         $vulnerability = $this->makeVulnerability(['filePath' => 'src/A.php', 'lineStart' => 10]);
@@ -112,6 +133,10 @@ final class VulnerabilityTest extends TestCase
         self::assertNotSame($vulnerability->id(), $v2->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_id_differs_for_different_line_start(): void
     {
         $vulnerability = $this->makeVulnerability(['filePath' => 'src/A.php', 'lineStart' => 10, 'lineEnd' => 15]);
@@ -120,6 +145,10 @@ final class VulnerabilityTest extends TestCase
         self::assertNotSame($vulnerability->id(), $v2->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_id_matches_expected_format(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -127,6 +156,10 @@ final class VulnerabilityTest extends TestCase
         self::assertMatchesRegularExpression('/^VULN-[A-F0-9]{8}$/', $vulnerability->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_id_matches_exact_sha1_substring_of_concatenated_inputs(): void
     {
         // Locks in the exact id derivation to kill Concat reorderings of
@@ -142,6 +175,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame($expected, $vulnerability->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_id_differs_for_different_types_same_file_and_line(): void
     {
         // Different vulnerability type → different id (type is part of hash input)
@@ -159,42 +196,70 @@ final class VulnerabilityTest extends TestCase
         self::assertNotSame($vulnerability->id(), $bac->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_throws_on_invalid_confidence_above_one(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->makeVulnerability(['confidence' => 1.1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_throws_on_invalid_confidence_below_zero(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->makeVulnerability(['confidence' => -0.1]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_accepts_confidence_at_zero_boundary(): void
     {
         $vulnerability = $this->makeVulnerability(['confidence' => 0.0]);
         self::assertSame(0.0, $vulnerability->confidence());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_throws_on_line_start_less_than_one(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->makeVulnerability(['lineStart' => 0]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_throws_on_line_end_before_line_start(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->makeVulnerability(['lineStart' => 10, 'lineEnd' => 5]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_throws_on_empty_title(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->makeVulnerability(['title' => '   ']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_creates_reviewer_validated_copy(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -206,6 +271,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame($vulnerability->title(), $validated->title());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_creates_elevated_severity_copy(): void
     {
         $vulnerability = $this->makeVulnerability(['vulnerabilitySeverity' => VulnerabilitySeverity::HIGH]);
@@ -216,6 +285,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame($vulnerability->id(), $elevated->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_creates_corrected_type_copy_without_mutating_original(): void
     {
         $vulnerability = $this->makeVulnerability(['vulnerabilityType' => VulnerabilityType::SQL_INJECTION]);
@@ -225,6 +298,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame(VulnerabilityType::SSRF, $corrected->type());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_synthesized_poc_is_null_by_default(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -232,6 +309,10 @@ final class VulnerabilityTest extends TestCase
         self::assertNull($vulnerability->synthesizedPoC());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_attaches_synthesized_poc_via_with_method(): void
     {
         $vulnerability = $this->makeVulnerability();
@@ -241,6 +322,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame("curl -X POST /admin/users\n", $enriched->synthesizedPoC());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_synthesized_poc_appears_in_to_array_output(): void
     {
         $vulnerability = $this->makeVulnerability()->withSynthesizedPoC('curl /x');
@@ -248,6 +333,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame('curl /x', $vulnerability->toArray()['synthesized_poc']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_synthesized_poc_is_preserved_across_other_with_methods(): void
     {
         $vulnerability = $this->makeVulnerability()
@@ -258,6 +347,10 @@ final class VulnerabilityTest extends TestCase
         self::assertTrue($vulnerability->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_corrected_type_copy_preserves_original_id(): void
     {
         // The id embeds the ORIGINAL classification — correcting the type keeps the same id
@@ -268,6 +361,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame($vulnerability->id(), $corrected->id());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_corrected_type_copy_preserves_reviewer_validation_state(): void
     {
         $vulnerability = $this->makeVulnerability()->withReviewerValidation(true);
@@ -276,6 +373,10 @@ final class VulnerabilityTest extends TestCase
         self::assertTrue($corrected->isReviewerValidated());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_is_high_risk_requires_exploitable_severity_and_validation(): void
     {
         $vulnerability = $this->makeVulnerability(['vulnerabilitySeverity' => VulnerabilitySeverity::CRITICAL]);
@@ -290,6 +391,10 @@ final class VulnerabilityTest extends TestCase
         self::assertTrue($validatedCritical->isHighRisk());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_serializes_to_array(): void
     {
         $vulnerability = $this->makeVulnerability()->withReviewerValidation(true);
@@ -303,6 +408,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame('Injection', $array['category']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_vulnerable_code_returns_the_snippet_passed_at_creation(): void
     {
         $vulnerability = $this->makeVulnerability(['vulnerableCode' => 'SELECT * FROM users WHERE id = $id']);
@@ -310,6 +419,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame('SELECT * FROM users WHERE id = $id', $vulnerability->vulnerableCode());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_detected_at_returns_an_immutable_timestamp_at_or_before_now(): void
     {
         $before = new DateTimeImmutable();
@@ -320,6 +433,10 @@ final class VulnerabilityTest extends TestCase
         self::assertLessThanOrEqual($after->getTimestamp(), $vulnerability->detectedAt()->getTimestamp());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_fingerprint_has_the_expected_deterministic_value(): void
     {
         $vulnerability = $this->makeVulnerability([
@@ -331,6 +448,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame('SSA-52DE9FC9CB6C', $vulnerability->fingerprint());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_fingerprint_is_stable_across_line_severity_and_description_changes(): void
     {
         $vulnerability = $this->makeVulnerability(['vulnerabilitySeverity' => VulnerabilitySeverity::HIGH, 'description' => 'one', 'lineStart' => 10, 'lineEnd' => 12]);
@@ -339,6 +460,10 @@ final class VulnerabilityTest extends TestCase
         self::assertSame($vulnerability->fingerprint(), $second->fingerprint());
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_fingerprint_differs_when_the_title_differs(): void
     {
         self::assertNotSame(
@@ -347,6 +472,10 @@ final class VulnerabilityTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_fingerprint_differs_when_the_file_path_differs(): void
     {
         self::assertNotSame(
@@ -355,6 +484,10 @@ final class VulnerabilityTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_fingerprint_differs_when_the_type_differs(): void
     {
         self::assertNotSame(
@@ -378,6 +511,9 @@ final class VulnerabilityTest extends TestCase
      *     remediation?: string,
      *     confidence?: float,
      * } $overrides
+     *
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
      */
     private function makeVulnerability(array $overrides = []): Vulnerability
     {

--- a/tests/Phpunit/Unit/Infrastructure/Cache/NullReviewerCacheTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Cache/NullReviewerCacheTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Cache;
 
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityClassification;
@@ -24,11 +26,19 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\NullReviewer
 
 final class NullReviewerCacheTest extends TestCase
 {
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_always_misses(): void
     {
         self::assertNull((new NullReviewerCache())->get($this->makeVulnerability(), 'code'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_get_misses_even_after_store(): void
     {
         $nullReviewerCache = new NullReviewerCache();
@@ -39,6 +49,10 @@ final class NullReviewerCacheTest extends TestCase
         self::assertNull($nullReviewerCache->get($vulnerability, 'code'));
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Infrastructure/FileSystem/RegexSecretScrubberTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/FileSystem/RegexSecretScrubberTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\FileSystem;
 
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\Exception\SecretScrubberConfigurationException;
@@ -169,6 +170,9 @@ final class RegexSecretScrubberTest extends TestCase
         self::assertStringContainsString('***REDACTED:env_assignment***', $output);
     }
 
+    /**
+     * @throws SecretScrubberConfigurationException
+     */
     public function test_additional_patterns_are_applied(): void
     {
         $regexSecretScrubber = new RegexSecretScrubber(additionalPatterns: ['/INTERNAL-[A-Z0-9]{12}/']);
@@ -207,6 +211,9 @@ final class RegexSecretScrubberTest extends TestCase
         self::assertSame($url, $this->regexSecretScrubber->scrub($url));
     }
 
+    /**
+     * @throws SecretScrubberConfigurationException
+     */
     public function test_runtime_pcre_failure_continues_to_remaining_patterns(): void
     {
         $regexSecretScrubber = new RegexSecretScrubber(additionalPatterns: [
@@ -228,6 +235,9 @@ final class RegexSecretScrubberTest extends TestCase
         self::assertStringContainsString('***REDACTED:custom_1***', $output);
     }
 
+    /**
+     * @throws SecretScrubberConfigurationException
+     */
     public function test_invalid_additional_pattern_throws_configuration_exception(): void
     {
         $this->expectException(SecretScrubberConfigurationException::class);
@@ -236,6 +246,9 @@ final class RegexSecretScrubberTest extends TestCase
         new RegexSecretScrubber(additionalPatterns: ['/[unterminated/']);
     }
 
+    /**
+     * @throws SecretScrubberConfigurationException
+     */
     public function test_empty_additional_pattern_throws_configuration_exception(): void
     {
         $this->expectException(SecretScrubberConfigurationException::class);
@@ -256,6 +269,10 @@ final class RegexSecretScrubberTest extends TestCase
         }
     }
 
+    /**
+     * @throws SecretScrubberConfigurationException
+     */
+    #[Override]
     protected function setUp(): void
     {
         $this->regexSecretScrubber = new RegexSecretScrubber();

--- a/tests/Phpunit/Unit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiterTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\LLM\Rat
 
 use DateTimeImmutable;
 use InvalidArgumentException;
+use Override;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
 use RuntimeException;
@@ -26,6 +27,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RateLimit\Toke
 
 final class TokenBucketRateLimiterTest extends TestCase
 {
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_acquire_returns_immediately_when_capacity_available(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -46,6 +50,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_acquire_sleeps_until_next_window_when_rpm_exhausted(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -70,6 +77,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([30_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_acquire_sleeps_when_input_tokens_would_exceed_window(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -93,6 +103,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([50_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_window_resets_when_minute_elapses(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -116,6 +129,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([], $sleeper->sleepsMs, 'fresh window should not require sleeping');
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_record_reconciles_input_estimate_against_actual(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -139,6 +155,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_output_token_exhaustion_blocks_next_acquire(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -163,6 +182,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([50_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_output_under_quota_does_not_block(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -185,6 +207,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_pause_until_blocks_acquire_until_target(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -206,6 +231,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([45_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_pause_resumes_into_capacity_check_and_consumes_quota(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -229,6 +257,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([30_000, 30_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_pause_spanning_a_window_boundary_resets_the_window_before_reserving(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -253,6 +284,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([65_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_pause_until_in_the_past_does_not_block(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -293,6 +327,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         );
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_estimate_larger_than_window_throws(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -314,6 +351,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: 200);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_negative_estimate_is_rejected(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -335,6 +375,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         $tokenBucketRateLimiter->acquire(estimatedInputTokens: -1);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_record_accumulates_output_across_multiple_calls(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -361,6 +404,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([60_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_record_zero_output_does_not_increment_used(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -385,6 +431,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_post_reset_request_count_starts_at_zero(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -413,6 +462,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([59_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_post_reset_input_count_starts_at_zero(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -439,6 +491,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([59_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_post_reset_output_count_starts_at_zero(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -466,6 +521,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([59_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_acquire_accumulates_input_tokens_across_calls(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -488,6 +546,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([60_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_record_reconcile_adds_actual_input_to_bucket(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -510,6 +571,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([60_000], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_record_zero_input_uses_reconciled_value_not_pending_estimate(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -532,6 +596,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_consecutive_records_without_acquire_use_zeroed_pending_estimate(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00+00:00');
@@ -555,6 +622,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_ms_until_rounds_sub_millisecond_delta_up_to_one(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00.000500+00:00');
@@ -578,6 +648,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([1], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_ms_until_rounds_exact_one_millisecond_delta_to_one(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00.000000+00:00');
@@ -601,6 +674,9 @@ final class TokenBucketRateLimiterTest extends TestCase
         self::assertSame([1], $sleeper->sleepsMs);
     }
 
+    /**
+     * @throws RateLimitRequestTooLargeException
+     */
     public function test_ms_until_rounds_just_over_one_millisecond_delta_up_to_two(): void
     {
         $mockClock = new MockClock('2026-01-01T12:00:00.000000+00:00');
@@ -634,6 +710,7 @@ final class TokenBucketRateLimiterTest extends TestCase
                 private readonly int $maxCalls,
             ) {}
 
+            #[Override]
             public function now(): DateTimeImmutable
             {
                 if (++$this->calls > $this->maxCalls) {
@@ -656,6 +733,7 @@ final class TokenBucketRateLimiterTest extends TestCase
 
             public function __construct(private readonly MockClock $mockClock) {}
 
+            #[Override]
             public function sleep(int $milliseconds): void
             {
                 $this->sleepsMs[] = $milliseconds;

--- a/tests/Phpunit/Unit/Infrastructure/LLM/RetryPolicyTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/RetryPolicyTest.php
@@ -17,11 +17,15 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\BackoffSchedule;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\InvalidRetryConfigurationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RateLimitBackoff;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\RetryPolicy;
 
 final class RetryPolicyTest extends TestCase
 {
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_max_attempts_returns_configured_value(): void
     {
         $retryPolicy = new RetryPolicy(new BackoffSchedule(maxAttempts: 5));
@@ -29,6 +33,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(5, $retryPolicy->maxAttempts());
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     #[DataProvider('deterministicDelayCases')]
     public function test_delay_grows_geometrically_without_jitter(int $attempt, int $expectedMs): void
     {
@@ -49,6 +56,9 @@ final class RetryPolicyTest extends TestCase
         yield 'fourth retry octuples' => [4, 800];
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_jitter_scales_delay_within_configured_bounds(): void
     {
         $retryPolicyLow = new RetryPolicy(
@@ -64,6 +74,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(1200, $retryPolicyHigh->delayMs(1));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_delay_rounds_low_fraction_down_distinguishing_ceil(): void
     {
         // 100 × (1 + 0.5 × (2×0.744 − 1)) = 124.4 → round 124, ceil 125, floor 124.
@@ -75,6 +88,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(124, $retryPolicy->delayMs(1));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_delay_rounds_high_fraction_up_distinguishing_floor(): void
     {
         // 100 × (1 + 0.5 × (2×0.747 − 1)) = 124.7 → round 125, ceil 125, floor 124.
@@ -86,6 +102,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(125, $retryPolicy->delayMs(1));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_zero_initial_delay_always_returns_zero(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -117,6 +136,9 @@ final class RetryPolicyTest extends TestCase
         $retryPolicy->rateLimitDelayMs(0);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_invalid_max_attempts_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -125,6 +147,9 @@ final class RetryPolicyTest extends TestCase
         new BackoffSchedule(maxAttempts: 0);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_negative_initial_delay_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -133,6 +158,9 @@ final class RetryPolicyTest extends TestCase
         new BackoffSchedule(initialDelayMs: -1);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_backoff_multiplier_below_one_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -141,6 +169,9 @@ final class RetryPolicyTest extends TestCase
         new BackoffSchedule(backoffMultiplier: 0.5);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_jitter_ratio_outside_zero_one_range_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -149,6 +180,9 @@ final class RetryPolicyTest extends TestCase
         new BackoffSchedule(jitterRatio: 1.5);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_negative_jitter_ratio_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -157,6 +191,9 @@ final class RetryPolicyTest extends TestCase
         new BackoffSchedule(jitterRatio: -0.01);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_jitter_ratio_zero_is_accepted(): void
     {
         $retryPolicy = new RetryPolicy(new BackoffSchedule(jitterRatio: 0.0));
@@ -164,6 +201,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(3, $retryPolicy->maxAttempts());
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_jitter_ratio_one_is_accepted(): void
     {
         $retryPolicy = new RetryPolicy(new BackoffSchedule(jitterRatio: 1.0));
@@ -171,6 +211,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(3, $retryPolicy->maxAttempts());
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_max_attempts_one_is_accepted(): void
     {
         $retryPolicy = new RetryPolicy(new BackoffSchedule(maxAttempts: 1));
@@ -178,6 +221,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(1, $retryPolicy->maxAttempts());
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_initial_delay_zero_is_accepted(): void
     {
         $retryPolicy = new RetryPolicy(new BackoffSchedule(initialDelayMs: 0), jitterSource: static fn (): float => 0.5);
@@ -185,6 +231,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(0, $retryPolicy->delayMs(1));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_backoff_multiplier_one_is_accepted(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -207,6 +256,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(2000, $retryPolicy->delayMs(3));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_rate_limit_delay_uses_its_own_initial_delay(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -220,6 +272,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(240_000, $retryPolicy->rateLimitDelayMs(3));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_rate_limit_delay_is_independent_of_regular_delay(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -239,6 +294,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(60_000, $retryPolicy->rateLimitDelayMs(1));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_negative_rate_limit_initial_delay_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -247,6 +305,9 @@ final class RetryPolicyTest extends TestCase
         new RateLimitBackoff(initialDelayMs: -1);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_server_hint_overrides_exponential_backoff(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -257,6 +318,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(7_000, $retryPolicy->rateLimitDelayMs(1, serverHintSeconds: 7));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_server_hint_is_clamped_to_maximum(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -267,6 +331,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(300_000, $retryPolicy->rateLimitDelayMs(1, serverHintSeconds: 3_600));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_server_hint_zero_falls_back_to_exponential(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -278,6 +345,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(60_000, $retryPolicy->rateLimitDelayMs(1, serverHintSeconds: 0));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_negative_server_hint_falls_back_to_exponential(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -289,6 +359,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(60_000, $retryPolicy->rateLimitDelayMs(1, serverHintSeconds: -5));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_negative_rate_limit_max_delay_is_rejected(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -297,6 +370,9 @@ final class RetryPolicyTest extends TestCase
         new RateLimitBackoff(maxDelayMs: -1);
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_zero_rate_limit_delays_are_accepted_and_clamp_to_zero(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -307,6 +383,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(0, $retryPolicy->rateLimitDelayMs(1));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_exponential_delay_is_also_clamped_to_max(): void
     {
         $retryPolicy = new RetryPolicy(
@@ -318,6 +397,9 @@ final class RetryPolicyTest extends TestCase
         self::assertSame(120_000, $retryPolicy->rateLimitDelayMs(3));
     }
 
+    /**
+     * @throws InvalidRetryConfigurationException
+     */
     public function test_default_jitter_source_produces_value_in_range(): void
     {
         $retryPolicy = new RetryPolicy(new BackoffSchedule(initialDelayMs: 1_000, backoffMultiplier: 1.0, jitterRatio: 0.2));

--- a/tests/Phpunit/Unit/Infrastructure/LLM/TokenEstimator/ResolvingTokenEstimatorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/TokenEstimator/ResolvingTokenEstimatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\LLM\TokenEstimator;
 
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TokenEstimator\CharacterRatioCounter;
@@ -86,11 +87,13 @@ final class ResolvingTokenEstimatorTest extends TestCase
         return new class($supports, $tokens) implements ProviderTokenEstimatorInterface {
             public function __construct(private readonly bool $supports, private readonly int $tokens) {}
 
+            #[Override]
             public function supports(string $model): bool
             {
                 return $this->supports;
             }
 
+            #[Override]
             public function estimateTokens(string $text, string $model): int
             {
                 return $this->tokens;

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Progress;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\ConsoleProgressReporter;
@@ -386,6 +387,7 @@ final class ConsoleProgressReporterTest extends TestCase
         self::assertStringContainsString("\033[33m", $bufferedOutput->fetch());
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->bufferedOutput = new BufferedOutput();

--- a/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Progress;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Progress\PlainProgressReporter;
@@ -142,6 +143,7 @@ final class PlainProgressReporterTest extends TestCase
         self::assertStringNotContainsString("\r", $this->bufferedOutput->fetch());
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->bufferedOutput = new BufferedOutput();

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Prompt;
 
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AccessControlMap;
@@ -29,6 +30,7 @@ final class AttackerPromptBuilderTest extends TestCase
 {
     private AttackerPromptBuilder $attackerPromptBuilder;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->attackerPromptBuilder = new AttackerPromptBuilder();

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Prompt;
 
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityClassification;
@@ -27,6 +30,7 @@ final class ReviewerPromptBuilderTest extends TestCase
 {
     private ReviewerPromptBuilder $reviewerPromptBuilder;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->reviewerPromptBuilder = new ReviewerPromptBuilder();
@@ -40,6 +44,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString('one entry per input vulnerability', $prompt);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_batch_user_message_starts_with_reports_header(): void
     {
         $vulnerabilities = [$this->makeVulnerability('src/A.php')];
@@ -52,6 +60,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringStartsWith('## Vulnerability Reports to Review', $message);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_batch_user_message_numbers_findings_starting_from_one(): void
     {
         $vulnerabilities = [
@@ -67,6 +79,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringNotContainsString('### Finding 3', $message);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_batch_user_message_finding_numbers_match_input_position(): void
     {
         $vulnerabilities = [
@@ -91,6 +107,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertGreaterThan($finding2Pos, $bPos);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_batch_user_message_ends_with_id_based_array_instruction(): void
     {
         $vulnerabilities = [$this->makeVulnerability('src/A.php')];
@@ -103,6 +123,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_batch_user_message_includes_code_context_for_finding_id(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -116,6 +140,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString('sensitive-marker-token', $message);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_batch_user_message_uses_empty_string_when_code_context_missing_for_id(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -347,6 +375,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString('false-positive playbook', $batchPrompt);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_batch_user_message_line_numbers_full_file_context(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -361,6 +393,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString("  1 | <?php\n  2 | class Foo {}", $message);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_single_user_message_line_numbers_full_file_context(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -371,6 +407,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString("  1 | <?php\n  2 | class Foo {}", $message);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_empty_code_context_yields_empty_full_file_block(): void
     {
         $vulnerability = $this->makeVulnerability('src/A.php');
@@ -416,6 +456,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringNotContainsString('Your output MUST be a JSON array', $prompt);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_structured_single_user_message_asks_for_a_record_review_call(): void
     {
         $reviewerPromptBuilder = new ReviewerPromptBuilder(useStructuredCollection: true);
@@ -426,6 +470,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringNotContainsString('return your review JSON', $message);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_structured_batch_user_message_asks_for_record_review_calls(): void
     {
         $reviewerPromptBuilder = new ReviewerPromptBuilder(useStructuredCollection: true);
@@ -448,6 +496,10 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringNotContainsString('record_review', $prompt);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeVulnerability(string $filePath): Vulnerability
     {
         return Vulnerability::of(

--- a/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Report;
 
 use Composer\InstalledVersions;
+use Override;
 use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditCost;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
@@ -32,6 +35,7 @@ final class ReportRendererTest extends TestCase
 
     private string $tmpDir;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir().'/renderer_test_'.uniqid('', true);
@@ -39,6 +43,7 @@ final class ReportRendererTest extends TestCase
         $this->reportRenderer = new ReportRenderer();
     }
 
+    #[Override]
     protected function tearDown(): void
     {
         rmdir($this->tmpDir);
@@ -60,6 +65,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString(ReportRenderer::PACKAGE_NAME, $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_has_description_label_with_blank_line_above(): void
     {
         $output = $this->reportRenderer->renderConsole($this->makeReport($this->makeValidatedVuln()));
@@ -67,6 +76,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString("\n\n  Description:\n", $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_has_attack_vector_label_with_blank_line_above(): void
     {
         $output = $this->reportRenderer->renderConsole($this->makeReport($this->makeValidatedVuln()));
@@ -74,6 +87,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString("\n\n  Attack Vector:\n", $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_has_remediation_label_with_blank_line_above(): void
     {
         $output = $this->reportRenderer->renderConsole($this->makeReport($this->makeValidatedVuln()));
@@ -129,6 +146,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString("\n".str_repeat('─', 69)."\n", $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_with_vulns_has_four_single_bar_separators(): void
     {
         $output = $this->reportRenderer->renderConsole($this->makeReport($this->makeValidatedVuln()));
@@ -137,6 +158,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString(str_repeat('─', 71), $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_dot_separator_is_exactly_70_chars(): void
     {
         $output = $this->reportRenderer->renderConsole($this->makeReport($this->makeValidatedVuln()));
@@ -154,6 +179,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('VULNERABILITIES', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_lists_vulnerabilities_most_severe_first(): void
     {
         $vulnerability = $this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::LOW, filePath: 'src/Low.php');
@@ -168,6 +197,10 @@ final class ReportRendererTest extends TestCase
         self::assertLessThan($lowPosition, $criticalPosition);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_with_vulnerabilities_skips_no_findings_message(): void
     {
         $output = $this->reportRenderer->renderConsole($this->makeReport($this->makeValidatedVuln()));
@@ -176,6 +209,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('VULNERABILITIES', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_severity_summary_shows_severity_with_count_one(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
@@ -184,6 +221,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('HIGH', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_findings_output_ends_with_dot_separator_no_trailing_newline(): void
     {
         $output = $this->reportRenderer->renderConsole($this->makeReport($this->makeValidatedVuln()));
@@ -191,6 +232,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringEndsWith(str_repeat('·', 70), $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_severity_summary_has_header_line(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -199,6 +244,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('  SUMMARY BY SEVERITY', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_severity_summary_omits_zero_count_severities(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
@@ -269,6 +318,10 @@ final class ReportRendererTest extends TestCase
         self::assertArrayHasKey('results', $decoded['runs'][0]);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_rules_is_sequential_array_not_object(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
@@ -280,6 +333,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame(array_values($rules), $rules);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_two_different_types_produce_two_rules(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
@@ -290,6 +347,10 @@ final class ReportRendererTest extends TestCase
         self::assertCount(2, $rules);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_results_contains_one_entry_per_vulnerability(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
@@ -299,6 +360,10 @@ final class ReportRendererTest extends TestCase
         self::assertCount(2, $decoded['runs'][0]['results']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_level_is_error_for_critical(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::CRITICAL);
@@ -307,6 +372,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('error', $decoded['runs'][0]['results'][0]['level']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_level_is_error_for_high(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
@@ -315,6 +384,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('error', $decoded['runs'][0]['results'][0]['level']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_level_is_warning_for_medium(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::MEDIUM);
@@ -323,6 +396,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('warning', $decoded['runs'][0]['results'][0]['level']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_level_is_note_for_low(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::LOW);
@@ -331,6 +408,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('note', $decoded['runs'][0]['results'][0]['level']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_level_is_note_for_info(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::INFO);
@@ -339,6 +420,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('note', $decoded['runs'][0]['results'][0]['level']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_result_location_contains_file_and_lines(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -359,6 +444,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('\/', $schema);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_result_message_text_is_vulnerability_title(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -367,6 +456,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('Test Vuln', $decoded['runs'][0]['results'][0]['message']['text']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_result_ruleid_is_owasp_reference(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION);
@@ -375,6 +468,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame(VulnerabilityType::SQL_INJECTION->owaspReference(), $decoded['runs'][0]['results'][0]['ruleId']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_artifact_location_uri_is_vulnerability_file_path(): void
     {
         $vulnerability = $this->makeValidatedVuln(filePath: 'src/Foo.php');
@@ -383,6 +480,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('src/Foo.php', $decoded['runs'][0]['results'][0]['locations'][0]['physicalLocation']['artifactLocation']['uri']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_rule_short_description_text_is_type_category(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION);
@@ -396,6 +497,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame(VulnerabilityType::SQL_INJECTION->category(), $firstRule['shortDescription']['text']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_rule_has_all_required_keys(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION);
@@ -408,6 +513,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame(VulnerabilityType::SQL_INJECTION->owaspReferenceUrl(), $firstRule['helpUri']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_rule_help_uri_points_to_the_specific_owasp_category(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION);
@@ -417,6 +526,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('https://owasp.org/Top10/A03_2021-Injection/', $firstRule['helpUri']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_result_carries_the_vulnerability_partial_fingerprint(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -428,6 +541,10 @@ final class ReportRendererTest extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_sarif_rule_is_not_overwritten_when_same_type_appears_twice(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
@@ -443,6 +560,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame(VulnerabilityType::SQL_INJECTION->category(), $firstRule['shortDescription']['text']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_description_chunks_at_exactly_65_chars(): void
     {
         $longDescription = str_repeat('a', 70);
@@ -458,6 +579,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('    '.str_repeat('a', 65)."\n    ".str_repeat('a', 5), $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_attack_vector_chunks_at_exactly_65_chars(): void
     {
         $longVector = str_repeat('b', 70);
@@ -473,6 +598,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('    '.str_repeat('b', 65)."\n    ".str_repeat('b', 5), $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_remediation_chunks_at_exactly_65_chars(): void
     {
         $longRemediation = str_repeat('c', 70);
@@ -604,6 +733,10 @@ final class ReportRendererTest extends TestCase
         self::assertSame('gpt-4o', $decoded['primary_model']);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_id(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -613,6 +746,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{id}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_title(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -622,6 +759,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{title}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_severity_label(): void
     {
         $vulnerability = $this->makeValidatedVuln(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH);
@@ -631,6 +772,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{severity}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_owasp_reference(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -640,6 +785,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{owasp}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_file_location_with_line_range(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -651,6 +800,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{lineEnd}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_description(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -660,6 +813,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{description}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_attack_vector(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -669,6 +826,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{attackVector}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_proof(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -678,6 +839,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{proof}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_vulnerability_substitutes_remediation(): void
     {
         $vulnerability = $this->makeValidatedVuln();
@@ -687,6 +852,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{remediation}}', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_console_confidence_renders_as_exact_percent_value(): void
     {
         $vulnerability = Vulnerability::of(
@@ -810,6 +979,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('unknown model', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_html_lists_a_validated_vulnerability(): void
     {
         $output = $this->reportRenderer->renderHtml($this->makeReport($this->makeValidatedVuln(filePath: 'src/Admin/UserController.php')));
@@ -819,6 +992,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('class="finding severity-high"', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_html_summary_counts_only_present_severities(): void
     {
         $output = $this->reportRenderer->renderHtml($this->makeReport($this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::HIGH)));
@@ -828,6 +1005,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('<tr class="severity-critical">', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_html_escapes_finding_content_to_prevent_report_xss(): void
     {
         $vulnerability = Vulnerability::of(
@@ -843,6 +1024,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('<script>alert(1)</script>', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_html_renders_confidence_as_a_percentage(): void
     {
         $output = $this->reportRenderer->renderHtml($this->makeReport($this->makeValidatedVuln()));
@@ -850,6 +1035,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('90%', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_html_replaces_every_template_placeholder(): void
     {
         $output = $this->reportRenderer->renderHtml($this->makeReport($this->makeValidatedVuln()));
@@ -857,6 +1046,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString('{{', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_html_escapes_quote_characters_in_finding_fields(): void
     {
         // makeValidatedVuln's proof is "' OR 1=1"; the single quote must be
@@ -867,6 +1060,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString("<pre>' OR 1=1", $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_html_renders_the_location_with_file_and_line_range(): void
     {
         $output = $this->reportRenderer->renderHtml($this->makeReport(
@@ -876,6 +1073,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('<dd>src/Repo.php:10-14</dd>', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_html_summary_table_renders_exactly_one_row_per_present_severity(): void
     {
         $output = $this->reportRenderer->renderHtml($this->makeReport(
@@ -921,6 +1122,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('SAFE', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_markdown_lists_a_validated_finding_with_its_location(): void
     {
         $output = $this->reportRenderer->renderMarkdown($this->makeReport(
@@ -932,6 +1137,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString('`src/Admin/UserController.php:10-14`', $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_markdown_finding_shows_confidence_percent_and_indented_proof(): void
     {
         $output = $this->reportRenderer->renderMarkdown($this->makeReport($this->makeValidatedVuln()));
@@ -940,6 +1149,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringContainsString("\n    ' OR 1=1", $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_markdown_renders_a_severity_summary_table(): void
     {
         $output = $this->reportRenderer->renderMarkdown($this->makeReport(
@@ -951,6 +1164,10 @@ final class ReportRendererTest extends TestCase
         self::assertStringNotContainsString(VulnerabilitySeverity::CRITICAL->label(), $output);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_render_markdown_orders_findings_most_severe_first(): void
     {
         $vulnerability = $this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::LOW, filePath: 'src/Low.php');
@@ -985,6 +1202,10 @@ final class ReportRendererTest extends TestCase
         return AuditReport::fromContext($auditContext, $auditCost);
     }
 
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     private function makeValidatedVuln(
         VulnerabilityType $vulnerabilityType = VulnerabilityType::SQL_INJECTION,
         VulnerabilitySeverity $vulnerabilitySeverity = VulnerabilitySeverity::HIGH,

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserControllerAccessControlParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserControllerAccessControlParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserControllerAccessControlParser;
@@ -21,6 +22,7 @@ final class PhpParserControllerAccessControlParserTest extends TestCase
 {
     private PhpParserControllerAccessControlParser $phpParserControllerAccessControlParser;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->phpParserControllerAccessControlParser = new PhpParserControllerAccessControlParser();

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserFormBindingParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserFormBindingParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserFormBindingParser;
@@ -21,6 +22,7 @@ final class PhpParserFormBindingParserTest extends TestCase
 {
     private PhpParserFormBindingParser $phpParserFormBindingParser;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->phpParserFormBindingParser = new PhpParserFormBindingParser();

--- a/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/PhpParserVoterCapabilityParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserVoterCapabilityParser;
@@ -21,6 +22,7 @@ final class PhpParserVoterCapabilityParserTest extends TestCase
 {
     private PhpParserVoterCapabilityParser $phpParserVoterCapabilityParser;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->phpParserVoterCapabilityParser = new PhpParserVoterCapabilityParser();

--- a/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Scan;
 
+use Override;
 use PHPUnit\Framework\TestCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskMarker;
@@ -22,6 +23,7 @@ final class RegexStaticPreScannerTest extends TestCase
 {
     private RegexStaticPreScanner $regexStaticPreScanner;
 
+    #[Override]
     protected function setUp(): void
     {
         $this->regexStaticPreScanner = new RegexStaticPreScanner();

--- a/tools/PHPStan/FinalRule.php
+++ b/tools/PHPStan/FinalRule.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\PHPStan;
 
+use Override;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
@@ -35,6 +36,7 @@ final readonly class FinalRule implements Rule
      */
     private const array ALLOWED_NON_FINAL = [LLMProviderException::class];
 
+    #[Override]
     public function getNodeType(): string
     {
         return Class_::class;
@@ -45,6 +47,7 @@ final readonly class FinalRule implements Rule
      *
      * @throws ShouldNotHappenException
      */
+    #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
         if ($node->isFinal() || $node->isAbstract() || $node->isAnonymous()) {

--- a/tools/PHPStan/ForbiddenTestAttributeRule.php
+++ b/tools/PHPStan/ForbiddenTestAttributeRule.php
@@ -74,13 +74,12 @@ final readonly class ForbiddenTestAttributeRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         $errors = [];
-        foreach ($this->forbiddenAttributes($node) as $attribute) {
+        foreach ($this->forbiddenAttributes($node) as [$attribute, $name, $reason]) {
             if ($this->isAllowed($attribute, $node)) {
                 continue;
             }
 
-            $name = $attribute->name->getLast();
-            $errors[] = RuleErrorBuilder::message(\sprintf('Attribute #[%s] is forbidden — %s.', $name, self::FORBIDDEN[$name]))
+            $errors[] = RuleErrorBuilder::message(\sprintf('Attribute #[%s] is forbidden — %s.', $name, $reason))
                 ->identifier('ssa.forbiddenTestAttribute')
                 ->build();
         }
@@ -89,14 +88,15 @@ final readonly class ForbiddenTestAttributeRule implements Rule
     }
 
     /**
-     * @return iterable<Attribute>
+     * @return iterable<array{Attribute, string, string}>
      */
     private function forbiddenAttributes(ClassMethod $classMethod): iterable
     {
         foreach ($classMethod->attrGroups as $group) {
             foreach ($group->attrs as $attribute) {
-                if (\array_key_exists($attribute->name->getLast(), self::FORBIDDEN)) {
-                    yield $attribute;
+                $name = $attribute->name->getLast();
+                if (\array_key_exists($name, self::FORBIDDEN)) {
+                    yield [$attribute, $name, self::FORBIDDEN[$name]];
                 }
             }
         }

--- a/tools/PHPStan/ForbiddenTestAttributeRule.php
+++ b/tools/PHPStan/ForbiddenTestAttributeRule.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\PHPStan;
 
+use Override;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr\MethodCall;
@@ -58,6 +59,7 @@ final readonly class ForbiddenTestAttributeRule implements Rule
         'WithoutErrorHandler' => 'keep the error handler so failOnWarning/failOnNotice still apply',
     ];
 
+    #[Override]
     public function getNodeType(): string
     {
         return ClassMethod::class;
@@ -68,6 +70,7 @@ final readonly class ForbiddenTestAttributeRule implements Rule
      *
      * @throws ShouldNotHappenException
      */
+    #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
         $errors = [];

--- a/tools/PHPStan/MaxParameterCountRule.php
+++ b/tools/PHPStan/MaxParameterCountRule.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\PHPStan;
 
+use Override;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -29,6 +30,7 @@ final readonly class MaxParameterCountRule implements Rule
 {
     private const int MAX_PARAMETERS = 5;
 
+    #[Override]
     public function getNodeType(): string
     {
         return ClassMethod::class;
@@ -39,6 +41,7 @@ final readonly class MaxParameterCountRule implements Rule
      *
      * @throws ShouldNotHappenException
      */
+    #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
         $parameterCount = \count($node->params);

--- a/tools/PHPStan/NoEmptyCatchRule.php
+++ b/tools/PHPStan/NoEmptyCatchRule.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\PHPStan;
 
+use Override;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\Nop;
@@ -27,6 +28,7 @@ use PHPStan\ShouldNotHappenException;
  */
 final readonly class NoEmptyCatchRule implements Rule
 {
+    #[Override]
     public function getNodeType(): string
     {
         return Catch_::class;
@@ -37,6 +39,7 @@ final readonly class NoEmptyCatchRule implements Rule
      *
      * @throws ShouldNotHappenException
      */
+    #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
         $meaningfulStatements = array_filter($node->stmts, static fn (Node $statement): bool => !$statement instanceof Nop);

--- a/tools/PHPStan/NoSilencingErrorHandlerRule.php
+++ b/tools/PHPStan/NoSilencingErrorHandlerRule.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\PHPStan;
 
+use Override;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrowFunction;
@@ -35,6 +36,7 @@ use PHPStan\ShouldNotHappenException;
  */
 final readonly class NoSilencingErrorHandlerRule implements Rule
 {
+    #[Override]
     public function getNodeType(): string
     {
         return FuncCall::class;
@@ -45,6 +47,7 @@ final readonly class NoSilencingErrorHandlerRule implements Rule
      *
      * @throws ShouldNotHappenException
      */
+    #[Override]
     public function processNode(Node $node, Scope $scope): array
     {
         if (!$node->name instanceof Name) {

--- a/tools/PHPUnit/MinimumLineCoverageExtension.php
+++ b/tools/PHPUnit/MinimumLineCoverageExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\PHPUnit;
 
+use Override;
 use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
@@ -27,6 +28,7 @@ final readonly class MinimumLineCoverageExtension implements Extension
 {
     private const float DEFAULT_MINIMUM = 100.0;
 
+    #[Override]
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
         $minimumCoverage = $parameters->has('min-coverage')

--- a/tools/PHPUnit/MinimumLineCoverageSubscriber.php
+++ b/tools/PHPUnit/MinimumLineCoverageSubscriber.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\PHPUnit;
 
+use Override;
 use PHPUnit\Event\Application\Finished;
 use PHPUnit\Event\Application\FinishedSubscriber;
 
@@ -23,6 +24,7 @@ final readonly class MinimumLineCoverageSubscriber implements FinishedSubscriber
         private float $minimumCoverage,
     ) {}
 
+    #[Override]
     public function notify(Finished $finished): void
     {
         if (null === $this->cloverPath || !is_file($this->cloverPath)) {


### PR DESCRIPTION
## Summary

Completes the PHPStan tightening from #90 and then audits the full PHPStan 2.2.2 parameter reference for any remaining worthwhile checks. On top of `level: max` + `phpstan-strict-rules`, this enables every strict parameter that is free or cheap-with-real-fixes on this codebase, fixing the underlying code rather than suppressing anything (per `CLAUDE.md` §5).

Closes #90

## Type of change

- [x] Refactor / internal improvement

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/))