### PR TITLE
feat(config): support when env blocks in the config schema

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -262,5 +262,14 @@
         }
       }
     }
+  },
+  "patternProperties": {
+    "^when@[a-z0-9_-]+$": {
+      "type": "object",
+      "description": "Symfony environment-scoped configuration block (when@dev, when@test, …). Mirrors the root schema so editors give completion and validation for symfony_security_auditor nested under when@<env>.",
+      "properties": {
+        "symfony_security_auditor": { "$ref": "#/properties/symfony_security_auditor" }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Problem

The Flex recipe ships the bundle config wrapped in `when@dev` / `when@test`:

```yaml
when@dev: &symfony_security_auditor
    symfony_security_auditor:
        model: 'claude-opus-4-8'
when@test: *symfony_security_auditor
```

But `resources/schema.json` only modelled a document whose **root** key is
`symfony_security_auditor`. Once nested under `when@<env>`, the document root
keys become `when@dev`/`when@test`, which the schema didn't model — so PhpStorm
and the Red Hat yaml-language-server gave **no completion and no validation**
inside the env blocks. Typos, bad enum values and wrong types passed silently.

Root-level config (no `when@`) can't be used instead, because the bundle is
registered `['dev','test']` only — a root-level key in a shared file makes
`prod` fail with *"no extension able to load the configuration for
symfony_security_auditor"*. So `when@` is the only single-file layout, and it
was exactly the one the schema didn't support.

## Fix

Add a `patternProperties` entry for `^when@…` that `$ref`s the existing
`symfony_security_auditor` definition, so the full config shape is enforced
under any environment block. **9-line, backward-compatible** change — root-level
configs validate exactly as before.

## Validation

Validated with `jsonschema` (draft-07) — same engine IDEs use:

| sample | before | after |
|---|---|---|
| root-level config | PASS | PASS |
| `when@dev`/`when@test` valid config | PASS | PASS |
| unknown key under `when@dev.symfony_security_auditor` | ⚠️ PASS (blind) | ✅ rejected |
| bad `profile` enum under `when@` | ⚠️ PASS (blind) | ✅ rejected |
| wrong type (`max_output_tokens`) under `when@` | ⚠️ PASS (blind) | ✅ rejected |

`Draft7Validator.check_schema()` passes on the edited file.