### PR TITLE
fix(tests): drop redundant always-false coverage guard

### DIFF
--- a/tools/PHPUnit/MinimumLineCoverageSubscriber.php
+++ b/tools/PHPUnit/MinimumLineCoverageSubscriber.php
@@ -36,7 +36,7 @@ final readonly class MinimumLineCoverageSubscriber implements FinishedSubscriber
         $report = (string) file_get_contents($this->cloverPath);
 
         $metricsCount = preg_match_all('/<metrics\b[^>]*>/', $report, $matches);
-        if (false === $metricsCount || 0 === $metricsCount || [] === $matches[0]) {
+        if (false === $metricsCount || 0 === $metricsCount) {
             return;
         }
 


### PR DESCRIPTION
## Problem

`tools/PHPUnit/MinimumLineCoverageSubscriber.php:39` fails PHPStan after the
stricter opt-in checks from #92:

```
Strict comparison using === between array{} and non-empty-list<string>
will always evaluate to false.  (identical.alwaysFalse)
```

`preg_match_all()` returns the number of full-pattern matches. The guard already
returns when that count is `false` or `0`, so on the following line `$matches[0]`
is necessarily a **non-empty** list — the extra `[] === $matches[0]` clause can
never be true. It is dead code.

## Fix

Drop the redundant clause (one line). Per the repo's no-suppression policy, this
is fixed at the source rather than by relaxing `treatPhpDocTypesAsCertain`.

```diff
-        if (false === $metricsCount || 0 === $metricsCount || [] === $matches[0]) {
+        if (false === $metricsCount || 0 === $metricsCount) {
```

## Verification

`vendor/bin/phpstan analyse --memory-limit=500M` → **[OK] No errors**.
Behaviour is unchanged: the two live conditions still short-circuit when there
are no `<metrics>` tags.