### PR TITLE
docs(config): use schema for editor completion

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -37,11 +37,12 @@ following the established entry style:
 2. Add a short intro paragraph summarizing the release theme.
 3. Add the link reference at the bottom block:
    `[X.Y.Z]: https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/X.Y.Z`.
-4. Bump the version pins to `X.Y.Z`: the config-schema URL
-   (`resources/schema.json` `$id`, the `# yaml-language-server` modelines in
-   `examples/configs/*.yaml`, and `docs/configuration.md`) and the GitHub Action
-   `uses:` examples in `docs/ci.md` and `README.md`. These point at the release
-   tag, so they must move every release.
+4. Bump the version pins to `X.Y.Z`: the config-schema `$id` in
+   `resources/schema.json` and the GitHub Action `uses:` examples in
+   `docs/ci.md` and `README.md`. These point at the release tag, so they must
+   move every release. (The `# $schema:` modelines in `examples/configs/*.yaml`,
+   `examples/vulnerable-app/…`, and `docs/configuration.md` track `main` and
+   need no per-release bump.)
 5. Prepare GitHub release notes in this exact format:
 
    ```markdown

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,21 +57,22 @@ Create `config/packages/symfony_security_auditor.yaml`. The bundle exposes the
 following keys:
 
 > **Editor autocompletion.** A JSON Schema for this configuration ships at
-> [`resources/schema.json`](../resources/schema.json). Editors backed by the
+> [`resources/schema.json`](../resources/schema.json). Editors pick it up from a
+> `# $schema:` modeline on the first line of your config file — both the
 > [YAML Language Server](https://github.com/redhat-developer/yaml-language-server)
-> (VS Code, Neovim, …) pick it up from a modeline on the first line of your
-> config file:
+> (VS Code, Neovim, …) and PhpStorm/IntelliJ understand this form:
 >
 > ```yaml
-> # yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.12.0/resources/schema.json
+> # $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
+>
 > symfony_security_auditor:
 >     model: "claude-opus-4-8"
 > ```
 >
 > This gives key completion, type checking, and inline docs as you edit. The
 > example files under [`examples/configs/`](../examples/configs/) include the
-> modeline. The URL is pinned to the release tag (`…/1.12.0/…`) so the schema
-> matches the version you have installed — bump it when you upgrade the bundle.
+> modeline. The URL tracks the `main` branch so it always resolves to the
+> current schema — no per-release bump needed.
 
 ### Top-level
 

--- a/examples/configs/ci-optimized.yaml
+++ b/examples/configs/ci-optimized.yaml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.12.0/resources/schema.json
+# $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
+
 # Scheduled CI run — split-model, cache + prompt caching enabled.
 #
 # Target: accuracy on a medium-to-large Symfony codebase, run nightly.

--- a/examples/configs/cost-aware.yaml
+++ b/examples/configs/cost-aware.yaml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.12.0/resources/schema.json
+# $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
+
 # Triage scan — single small model, single iteration, tools disabled.
 #
 # Target: smallest possible bill for an initial pass on a large monorepo.

--- a/examples/configs/dev-fast.yaml
+++ b/examples/configs/dev-fast.yaml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.12.0/resources/schema.json
+# $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
+
 # Local development scan — Ollama backend, no spend, exploratory recall.
 #
 # Pair with the following in config/packages/ai.yaml:

--- a/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
+++ b/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
@@ -1,4 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.12.0/resources/schema.json
+# $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
+
 symfony_security_auditor:
     attacker_model: 'claude-opus-4-8'
     reviewer_model: 'claude-haiku-4-5-20251001'


### PR DESCRIPTION
## Problem

The example configs and `docs/configuration.md` advertised the schema via the
`# yaml-language-server: $schema=…` modeline, **pinned to a release tag**. Two issues:

1. Only the Red Hat YAML Language Server (VS Code, Neovim) reads that form —
   **PhpStorm/IntelliJ ignore it**, so many Symfony users got no completion.
2. The pinned URL had to be bumped on every release.

## Change

- Switch every occurrence to the `# $schema:` form, understood by **both**
  PhpStorm (native inline-schema support) and the yaml-language-server.
- Point the URL at **`main/resources/schema.json`** (floating), matching the
  Flex recipe — always resolves to the current schema, no per-release bump.
- Add a blank line after the modeline so the directive reads apart from the
  comment block.

Files:
- `examples/configs/{ci-optimized,cost-aware,dev-fast}.yaml`
- `examples/vulnerable-app/config/packages/symfony_security_auditor.yaml`
- `docs/configuration.md` (example + prose: names PhpStorm, floating URL)
- `.claude/rules/changelog.md` (release checklist: modelines no longer bumped per release)

Comment-only — generated configuration unchanged. YAML re-validated.