### PR TITLE
docs(examples): drop prompt_caching from examples

### DIFF
--- a/examples/configs/ci-optimized.yaml
+++ b/examples/configs/ci-optimized.yaml
@@ -1,6 +1,6 @@
 # $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
 
-# Scheduled CI run — split-model, cache + prompt caching enabled.
+# Scheduled CI run — split-model, chunk/verdict cache enabled.
 #
 # Target: accuracy on a medium-to-large Symfony codebase, run nightly.
 # Cost:   ~$0.50–$2.00 per run on a 150-file project (varies by provider).
@@ -21,6 +21,7 @@ symfony_security_auditor:
         tools_enabled: true     # cross-file investigation + advisory lookups
         max_tool_iterations: 8
 
+    # Provider prompt caching is configured in config/packages/ai.yaml
+    # (e.g. Anthropic `cache_retention`) — see docs/configuration.md#prompt-caching.
     cache:
         enabled: true           # skip identical chunks on rerun
-        prompt_caching: true    # ~90% discount on Anthropic

--- a/examples/configs/cost-aware.yaml
+++ b/examples/configs/cost-aware.yaml
@@ -19,6 +19,7 @@ symfony_security_auditor:
         tools_enabled: false    # disables read_file / grep / list_files / lookup_advisory
         max_tool_iterations: 1
 
+    # Provider prompt caching is configured in config/packages/ai.yaml
+    # (e.g. Anthropic `cache_retention`) — see docs/configuration.md#prompt-caching.
     cache:
         enabled: true
-        prompt_caching: true

--- a/examples/configs/dev-fast.yaml
+++ b/examples/configs/dev-fast.yaml
@@ -26,4 +26,3 @@ symfony_security_auditor:
 
     cache:
         enabled: true
-        prompt_caching: false   # Ollama ignores prompt caching anyway

--- a/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
+++ b/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
@@ -8,4 +8,3 @@ symfony_security_auditor:
         tools_enabled: true
     cache:
         enabled: true
-        prompt_caching: true


### PR DESCRIPTION
## Summary

All four shipped example configs still set `cache.prompt_caching` — deprecated since 1.7 and ignored — and `ci-optimized.yaml` advertised a "~90% discount on Anthropic" the key no longer delivers. The copy-paste starting points now point at the real knob instead: provider prompt caching in `config/packages/ai.yaml` (`cache_retention`), per `docs/configuration.md#prompt-caching`.

## Type of change

- [x] Documentation

## Checklist

- [x] All checks pass: `bin/castor lint` (Prettier/markdownlint pass; no PHP touched)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)