### PR TITLE
feat(domain): map vulnerabilities to OWASP Top 10:2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,22 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Changed
 
+- **OWASP references now point at the Top 10:2025 edition instead of 2021.**
+  `VulnerabilityType::owaspReference()` and `owaspReferenceUrl()`
+  (`src/Audit/Domain/Model/VulnerabilityType.php`) emitted 2021 category ids
+  (e.g. `OWASP A03:2021 - Injection`) in the report `owasp` field and SARIF
+  `helpUri`, which read as stale against the released OWASP Top 10:2025. Every
+  type is remapped to its 2025 category: injection types move to
+  `A05:2025 - Injection`, misconfiguration types to
+  `A02:2025 - Security Misconfiguration`, cryptographic types to
+  `A04:2025 - Cryptographic Failures`, design flaws to
+  `A06:2025 - Insecure Design`, integrity types to
+  `A08:2025 - Software or Data Integrity Failures` (renamed from "and"),
+  `authenticator_bypass` to `A07:2025 - Authentication Failures`, and `ssrf`
+  folds into `A01:2025 - Broken Access Control` per the 2025 consolidation. URLs
+  now use the `https://owasp.org/Top10/2025/…` category pages. The report schema
+  is unchanged — only the `owasp`/`helpUri` values move.
+
 - **Prompt-cache traffic is now priced from each provider's real per-model cache
   rates instead of Anthropic-only multipliers.** `CostCalculator`
   (`src/Audit/Application/Budget/CostCalculator.php`) previously derived cache

--- a/src/Audit/Domain/Model/VulnerabilityType.php
+++ b/src/Audit/Domain/Model/VulnerabilityType.php
@@ -130,18 +130,20 @@ enum VulnerabilityType: string
             self::TWIG_INJECTION,
             self::HEADER_INJECTION,
             self::LOG_INJECTION,
-            self::MAILER_HEADER_INJECTION => 'OWASP A03:2021 - Injection',
+            self::MAILER_HEADER_INJECTION => 'OWASP A05:2025 - Injection',
 
             self::BROKEN_ACCESS_CONTROL,
             self::MISSING_VOTER,
             self::VOTER_BYPASS,
             self::ROLE_ESCALATION,
             self::INSECURE_DIRECT_OBJECT_REFERENCE,
-            self::PATH_TRAVERSAL => 'OWASP A01:2021 - Broken Access Control',
+            self::PATH_TRAVERSAL => 'OWASP A01:2025 - Broken Access Control',
 
-            self::MISSING_CSRF_PROTECTION => 'OWASP A01:2021 - Broken Access Control (CSRF)',
+            self::MISSING_CSRF_PROTECTION => 'OWASP A01:2025 - Broken Access Control (CSRF)',
 
-            self::AUTHENTICATOR_BYPASS => 'OWASP A07:2021 - Identification and Authentication Failures',
+            self::SSRF => 'OWASP A01:2025 - Broken Access Control (SSRF)',
+
+            self::AUTHENTICATOR_BYPASS => 'OWASP A07:2025 - Authentication Failures',
 
             self::BUSINESS_LOGIC_FLAW,
             self::RACE_CONDITION,
@@ -149,7 +151,7 @@ enum VulnerabilityType: string
             self::PRICE_MANIPULATION,
             self::STATE_MACHINE_BYPASS,
             self::MISSING_RATE_LIMITING,
-            self::WEBHOOK_REPLAY => 'OWASP A04:2021 - Insecure Design',
+            self::WEBHOOK_REPLAY => 'OWASP A06:2025 - Insecure Design',
 
             self::MASS_ASSIGNMENT,
             self::UNSAFE_PARAMETER_BINDING,
@@ -159,18 +161,16 @@ enum VulnerabilityType: string
             self::OPEN_REDIRECT,
             self::XXE,
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
-            self::CACHE_POISONING => 'OWASP A05:2021 - Security Misconfiguration',
+            self::CACHE_POISONING => 'OWASP A02:2025 - Security Misconfiguration',
 
             self::INSECURE_DESERIALIZATION,
             self::MESSENGER_HANDLER_UNSAFE,
-            self::MISSING_SIGNATURE_VERIFICATION => 'OWASP A08:2021 - Software and Data Integrity Failures',
+            self::MISSING_SIGNATURE_VERIFICATION => 'OWASP A08:2025 - Software or Data Integrity Failures',
 
             self::SENSITIVE_DATA_EXPOSURE,
             self::WEAK_CRYPTOGRAPHY,
             self::INSECURE_RANDOM,
-            self::HARDCODED_SECRET => 'OWASP A02:2021 - Cryptographic Failures',
-
-            self::SSRF => 'OWASP A10:2021 - Server-Side Request Forgery',
+            self::HARDCODED_SECRET => 'OWASP A04:2025 - Cryptographic Failures',
         };
     }
 
@@ -184,7 +184,7 @@ enum VulnerabilityType: string
             self::TWIG_INJECTION,
             self::HEADER_INJECTION,
             self::LOG_INJECTION,
-            self::MAILER_HEADER_INJECTION => 'https://owasp.org/Top10/A03_2021-Injection/',
+            self::MAILER_HEADER_INJECTION => 'https://owasp.org/Top10/2025/A05_2025-Injection/',
 
             self::BROKEN_ACCESS_CONTROL,
             self::MISSING_VOTER,
@@ -192,9 +192,10 @@ enum VulnerabilityType: string
             self::ROLE_ESCALATION,
             self::INSECURE_DIRECT_OBJECT_REFERENCE,
             self::PATH_TRAVERSAL,
-            self::MISSING_CSRF_PROTECTION => 'https://owasp.org/Top10/A01_2021-Broken_Access_Control/',
+            self::MISSING_CSRF_PROTECTION,
+            self::SSRF => 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/',
 
-            self::AUTHENTICATOR_BYPASS => 'https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/',
+            self::AUTHENTICATOR_BYPASS => 'https://owasp.org/Top10/2025/A07_2025-Authentication_Failures/',
 
             self::BUSINESS_LOGIC_FLAW,
             self::RACE_CONDITION,
@@ -202,7 +203,7 @@ enum VulnerabilityType: string
             self::PRICE_MANIPULATION,
             self::STATE_MACHINE_BYPASS,
             self::MISSING_RATE_LIMITING,
-            self::WEBHOOK_REPLAY => 'https://owasp.org/Top10/A04_2021-Insecure_Design/',
+            self::WEBHOOK_REPLAY => 'https://owasp.org/Top10/2025/A06_2025-Insecure_Design/',
 
             self::MASS_ASSIGNMENT,
             self::UNSAFE_PARAMETER_BINDING,
@@ -212,18 +213,16 @@ enum VulnerabilityType: string
             self::OPEN_REDIRECT,
             self::XXE,
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
-            self::CACHE_POISONING => 'https://owasp.org/Top10/A05_2021-Security_Misconfiguration/',
+            self::CACHE_POISONING => 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/',
 
             self::INSECURE_DESERIALIZATION,
             self::MESSENGER_HANDLER_UNSAFE,
-            self::MISSING_SIGNATURE_VERIFICATION => 'https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/',
+            self::MISSING_SIGNATURE_VERIFICATION => 'https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/',
 
             self::SENSITIVE_DATA_EXPOSURE,
             self::WEAK_CRYPTOGRAPHY,
             self::INSECURE_RANDOM,
-            self::HARDCODED_SECRET => 'https://owasp.org/Top10/A02_2021-Cryptographic_Failures/',
-
-            self::SSRF => 'https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/',
+            self::HARDCODED_SECRET => 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/',
         };
     }
 }

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTest.php
@@ -402,7 +402,7 @@ final class VulnerabilityTest extends TestCase
 
         self::assertSame($vulnerability->id(), $array['id']);
         self::assertSame('high', $array['severity']);
-        self::assertSame('OWASP A03:2021 - Injection', $array['owasp']);
+        self::assertSame('OWASP A05:2025 - Injection', $array['owasp']);
         self::assertTrue($array['reviewer_validated']);
         self::assertSame('sql_injection', $array['type']);
         self::assertSame('Injection', $array['category']);

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
@@ -67,33 +67,33 @@ final class VulnerabilityTypeTest extends TestCase
 
     public static function owaspProvider(): Iterator
     {
-        yield [VulnerabilityType::SQL_INJECTION, 'A03:2021'];
-        yield [VulnerabilityType::COMMAND_INJECTION, 'A03:2021'];
-        yield [VulnerabilityType::LDAP_INJECTION, 'A03:2021'];
-        yield [VulnerabilityType::XPATH_INJECTION, 'A03:2021'];
-        yield [VulnerabilityType::TWIG_INJECTION, 'A03:2021'];
-        yield [VulnerabilityType::HEADER_INJECTION, 'A03:2021'];
-        yield [VulnerabilityType::BROKEN_ACCESS_CONTROL, 'A01:2021'];
-        yield [VulnerabilityType::MISSING_VOTER, 'A01:2021'];
-        yield [VulnerabilityType::VOTER_BYPASS, 'A01:2021'];
-        yield [VulnerabilityType::ROLE_ESCALATION, 'A01:2021'];
-        yield [VulnerabilityType::INSECURE_DIRECT_OBJECT_REFERENCE, 'A01:2021'];
-        yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'A01:2021'];
-        yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'A08:2021'];
-        yield [VulnerabilityType::SENSITIVE_DATA_EXPOSURE, 'A02:2021'];
-        yield [VulnerabilityType::WEAK_CRYPTOGRAPHY, 'A02:2021'];
-        yield [VulnerabilityType::INSECURE_RANDOM, 'A02:2021'];
-        yield [VulnerabilityType::HARDCODED_SECRET, 'A02:2021'];
-        yield [VulnerabilityType::SSRF, 'A10:2021'];
-        yield [VulnerabilityType::XXE, 'A05:2021'];
-        yield [VulnerabilityType::MISSING_SIGNATURE_VERIFICATION, 'A08:2021'];
-        yield [VulnerabilityType::MAILER_HEADER_INJECTION, 'A03:2021'];
-        yield [VulnerabilityType::MESSENGER_HANDLER_UNSAFE, 'A08:2021'];
-        yield [VulnerabilityType::MISSING_RATE_LIMITING, 'A04:2021'];
-        yield [VulnerabilityType::CACHE_POISONING, 'A05:2021'];
-        yield [VulnerabilityType::WEBHOOK_REPLAY, 'A04:2021'];
-        yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'A07:2021'];
-        yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'A05:2021'];
+        yield [VulnerabilityType::SQL_INJECTION, 'A05:2025'];
+        yield [VulnerabilityType::COMMAND_INJECTION, 'A05:2025'];
+        yield [VulnerabilityType::LDAP_INJECTION, 'A05:2025'];
+        yield [VulnerabilityType::XPATH_INJECTION, 'A05:2025'];
+        yield [VulnerabilityType::TWIG_INJECTION, 'A05:2025'];
+        yield [VulnerabilityType::HEADER_INJECTION, 'A05:2025'];
+        yield [VulnerabilityType::BROKEN_ACCESS_CONTROL, 'A01:2025'];
+        yield [VulnerabilityType::MISSING_VOTER, 'A01:2025'];
+        yield [VulnerabilityType::VOTER_BYPASS, 'A01:2025'];
+        yield [VulnerabilityType::ROLE_ESCALATION, 'A01:2025'];
+        yield [VulnerabilityType::INSECURE_DIRECT_OBJECT_REFERENCE, 'A01:2025'];
+        yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'A01:2025'];
+        yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'A08:2025'];
+        yield [VulnerabilityType::SENSITIVE_DATA_EXPOSURE, 'A04:2025'];
+        yield [VulnerabilityType::WEAK_CRYPTOGRAPHY, 'A04:2025'];
+        yield [VulnerabilityType::INSECURE_RANDOM, 'A04:2025'];
+        yield [VulnerabilityType::HARDCODED_SECRET, 'A04:2025'];
+        yield [VulnerabilityType::SSRF, 'A01:2025'];
+        yield [VulnerabilityType::XXE, 'A02:2025'];
+        yield [VulnerabilityType::MISSING_SIGNATURE_VERIFICATION, 'A08:2025'];
+        yield [VulnerabilityType::MAILER_HEADER_INJECTION, 'A05:2025'];
+        yield [VulnerabilityType::MESSENGER_HANDLER_UNSAFE, 'A08:2025'];
+        yield [VulnerabilityType::MISSING_RATE_LIMITING, 'A06:2025'];
+        yield [VulnerabilityType::CACHE_POISONING, 'A02:2025'];
+        yield [VulnerabilityType::WEBHOOK_REPLAY, 'A06:2025'];
+        yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'A07:2025'];
+        yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'A02:2025'];
     }
 
     #[DataProvider('categoryProvider')]
@@ -139,16 +139,16 @@ final class VulnerabilityTypeTest extends TestCase
      */
     public static function owaspUrlProvider(): iterable
     {
-        yield [VulnerabilityType::SQL_INJECTION, 'https://owasp.org/Top10/A03_2021-Injection/'];
-        yield [VulnerabilityType::BROKEN_ACCESS_CONTROL, 'https://owasp.org/Top10/A01_2021-Broken_Access_Control/'];
-        yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'https://owasp.org/Top10/A01_2021-Broken_Access_Control/'];
-        yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/'];
-        yield [VulnerabilityType::MISSING_SIGNATURE_VERIFICATION, 'https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/'];
-        yield [VulnerabilityType::BUSINESS_LOGIC_FLAW, 'https://owasp.org/Top10/A04_2021-Insecure_Design/'];
-        yield [VulnerabilityType::MASS_ASSIGNMENT, 'https://owasp.org/Top10/A05_2021-Security_Misconfiguration/'];
-        yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/'];
-        yield [VulnerabilityType::SENSITIVE_DATA_EXPOSURE, 'https://owasp.org/Top10/A02_2021-Cryptographic_Failures/'];
-        yield [VulnerabilityType::SSRF, 'https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/'];
+        yield [VulnerabilityType::SQL_INJECTION, 'https://owasp.org/Top10/2025/A05_2025-Injection/'];
+        yield [VulnerabilityType::BROKEN_ACCESS_CONTROL, 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/'];
+        yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/'];
+        yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'https://owasp.org/Top10/2025/A07_2025-Authentication_Failures/'];
+        yield [VulnerabilityType::MISSING_SIGNATURE_VERIFICATION, 'https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/'];
+        yield [VulnerabilityType::BUSINESS_LOGIC_FLAW, 'https://owasp.org/Top10/2025/A06_2025-Insecure_Design/'];
+        yield [VulnerabilityType::MASS_ASSIGNMENT, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
+        yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/'];
+        yield [VulnerabilityType::SENSITIVE_DATA_EXPOSURE, 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/'];
+        yield [VulnerabilityType::SSRF, 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/'];
     }
 
     public function test_all_types_have_a_non_empty_owasp_reference_url(): void

--- a/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ReportRendererTest.php
@@ -523,7 +523,7 @@ final class ReportRendererTest extends TestCase
         $decoded = $this->decodeSarif($this->makeReport($vulnerability));
 
         $firstRule = array_values($decoded['runs'][0]['tool']['driver']['rules'])[0];
-        self::assertSame('https://owasp.org/Top10/A03_2021-Injection/', $firstRule['helpUri']);
+        self::assertSame('https://owasp.org/Top10/2025/A05_2025-Injection/', $firstRule['helpUri']);
     }
 
     /**


### PR DESCRIPTION
## Summary

`VulnerabilityType::owaspReference()` / `owaspReferenceUrl()` emitted OWASP Top 10 **2021** ids and URLs in the report `owasp` field and SARIF `helpUri`, stale against the released 2025 edition. Every type is remapped per the official 2025 list (verified against the OWASP/Top10 repository): injections → A05:2025, misconfiguration → A02:2025, crypto → A04:2025, insecure design → A06:2025, integrity → A08:2025 (*Software **or** Data Integrity Failures*), `authenticator_bypass` → A07:2025 (*Authentication Failures*), and `ssrf` folds into A01:2025 per the 2025 SSRF consolidation. URLs move to the `owasp.org/Top10/2025/…` category pages. The report **schema** is unchanged — only the `owasp` / `helpUri` values move (called out in the CHANGELOG under *Changed*).

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — both data providers, `Vulnerability::toArray()`, and the SARIF `helpUri` assertions updated to 2025
- [x] All checks pass locally: PHPUnit (2203 tests), PHPStan max, Rector, PHP CS Fixer, Deptrac — coverage + Infection could not run in this sandbox (no coverage driver); CI verifies both
- [x] No `createMock` without a matching `expects()` (no mocks touched)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)