### PR TITLE
chore(ci): release:bump task and tag-push pin guard

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -37,10 +37,13 @@ following the established entry style:
 2. Add a short intro paragraph summarizing the release theme.
 3. Add the link reference at the bottom block:
    `[X.Y.Z]: https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/X.Y.Z`.
-4. Bump the version pins to `X.Y.Z`: the config-schema `$id` in
+4. Bump the version pins to `X.Y.Z`: run `bin/castor release:bump X.Y.Z`. It
+   rewrites every pinned location — the config-schema `$id` in
    `resources/schema.json` and the GitHub Action `uses:` examples in
-   `docs/ci.md` and `README.md`. These point at the release tag, so they must
-   move every release. (The `# $schema:` modelines in `examples/configs/*.yaml`,
+   `README.md`, `docs/ci.md`, and `docs/versioning.md` — and fails loudly if a
+   pin goes missing. The `Release Guard` workflow
+   (`.github/workflows/release-guard.yaml`) re-checks the pins against the tag
+   on every tag push. (The `# $schema:` modelines in `examples/configs/*.yaml`,
    `examples/vulnerable-app/…`, and `docs/configuration.md` track `main` and
    need no per-release bump.)
 5. Prepare GitHub release notes in this exact format:

--- a/.github/workflows/release-guard.yaml
+++ b/.github/workflows/release-guard.yaml
@@ -1,0 +1,34 @@
+name: Release Guard
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  verify-version-pins:
+    name: Version pins match the tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify every pin points at ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          FAIL=0
+
+          check() {
+            local file="$1" pattern="$2"
+            if ! grep -qE "$pattern" "$file"; then
+              echo "::error file=$file::expected a version pin matching '$pattern' — run 'bin/castor release:bump $TAG' before tagging"
+              FAIL=1
+            fi
+          }
+
+          check resources/schema.json "symfony-security-auditor/${TAG}/resources/schema\.json"
+          check README.md "uses: vinceamstoutz/symfony-security-auditor@${TAG}"
+          check docs/ci.md "uses: vinceamstoutz/symfony-security-auditor@${TAG}"
+          check docs/versioning.md "uses: vinceamstoutz/symfony-security-auditor@${TAG}"
+
+          exit "$FAIL"

--- a/castor.php
+++ b/castor.php
@@ -28,6 +28,44 @@ function down(): void
     run('docker compose down --remove-orphans');
 }
 
+#[AsTask(name: 'release:bump', description: 'Rewrite every release version pin (schema $id, GitHub Action uses: examples) to the given X.Y.Z tag')]
+function releaseBump(string $version): void
+{
+    if (1 !== preg_match('/^\\d+\\.\\d+\\.\\d+$/', $version)) {
+        io()->error(sprintf('"%s" is not a X.Y.Z version.', $version));
+
+        exit(1);
+    }
+
+    $pinnedFiles = [
+        'resources/schema.json' => '#(symfony-security-auditor/)\\d+\\.\\d+\\.\\d+(/resources/schema\\.json)#',
+        'README.md' => '#(uses: vinceamstoutz/symfony-security-auditor@)\\d+\\.\\d+\\.\\d+#',
+        'docs/ci.md' => '#(uses: vinceamstoutz/symfony-security-auditor@)\\d+\\.\\d+\\.\\d+#',
+        'docs/versioning.md' => '#(uses: vinceamstoutz/symfony-security-auditor@)\\d+\\.\\d+\\.\\d+#',
+    ];
+
+    foreach ($pinnedFiles as $file => $pattern) {
+        $content = file_get_contents($file);
+        if (false === $content) {
+            io()->error(sprintf('Could not read %s.', $file));
+
+            exit(1);
+        }
+
+        $rewritten = preg_replace($pattern, '${1}'.$version.'${2}', $content, -1, $count);
+        if (null === $rewritten || 0 === $count) {
+            io()->error(sprintf('No version pin matched in %s — the pin list in castor.php is stale.', $file));
+
+            exit(1);
+        }
+
+        file_put_contents($file, $rewritten);
+        io()->writeln(sprintf('  <info>OK</info> %s (%d pin%s)', $file, $count, 1 === $count ? '' : 's'));
+    }
+
+    io()->success(sprintf('All version pins now point at %s.', $version));
+}
+
 #[AsTask(name: 'lint', description: 'Check code style and analyze code')]
 function lint(): void
 {

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -102,6 +102,9 @@ is a `MAJOR` change.
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.
+  At release time, `bin/castor release:bump X.Y.Z` rewrites every pinned
+  location in one shot, and the `Release Guard` workflow fails the tag push if
+  any pin does not match the tag.
 
 ### Output schemas
 


### PR DESCRIPTION
## Summary

Releasing required hand-editing the version pin in four files (the `resources/schema.json` `$id` and the GitHub Action `uses:` examples in `README.md`, `docs/ci.md`, `docs/versioning.md`) with nothing catching a missed spot. `bin/castor release:bump X.Y.Z` now rewrites every pinned location in one shot — validating the version shape and failing loudly when a pin pattern stops matching — and the new `Release Guard` workflow re-checks all pins against the tag name on every tag push, so a stale pin can no longer ship. The release checklist in `.claude/rules/changelog.md` and `docs/versioning.md` now references the task.

Exercised end-to-end locally: `bin/castor release:bump 9.9.9` rewrote all four pins (then reverted); `not-a-version` is rejected.

## Type of change

- [x] Refactor / internal improvement

## Checklist

- [x] Tests added or updated — n/a: `castor.php` is release tooling outside the PHPUnit/PHPStan scope; behavior exercised manually end-to-end (see above) and re-checked by the new workflow on every tag
- [x] All checks pass: Prettier, markdownlint, PHP CS Fixer on `castor.php`, `php -l`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
