### PR TITLE
docs: note planned provider batch-endpoint support in cost docs

### DIFF
--- a/docs/cost-and-performance.md
+++ b/docs/cost-and-performance.md
@@ -39,6 +39,14 @@ Each key a profile sets is documented in
   with an async transport; `4`–`8` (within your rate limits) cuts each phase's
   wall-clock roughly proportionally. Cache hits short-circuit, so only the
   misses are dispatched.
+- **Provider batch endpoints (planned)** — Anthropic Message Batches, the OpenAI
+  Batch API, and Mistral Batch price tokens ~50% below the live rate for
+  asynchronous workloads, which matches the attacker/reviewer fan-out exactly.
+  Support is intentionally deferred until the `symfony/ai` Platform component
+  ships its in-progress batch-processing support, so it can land once behind
+  `BatchCapableLLMClientInterface` for every provider instead of as per-provider
+  HTTP adapters. Until then, the concurrency levers above are the way to trade
+  rate-limit headroom for wall-clock.
 - **Caching** — content-hash caching skips identical chunks across runs, and
   Anthropic prompt caching (`cache_retention` in `ai.yaml`) gives a ~90%
   input-token discount on cache hits. Both are on by default; see


### PR DESCRIPTION
## Summary

Anthropic/OpenAI/Mistral batch endpoints price tokens ~50% below the live rate for exactly the async fan-out shape the attacker/reviewer sweep has, and readers of the cost docs may wonder why the bundle doesn't use them. This records the decision in `docs/cost-and-performance.md`: support is deferred until the `symfony/ai` Platform component ships its in-progress batch-processing support (verified: not in 0.10/0.11, upstream work visible on `symfony/ai` main), so it can land once behind `BatchCapableLLMClientInterface` for every provider instead of as per-provider HTTP adapters.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal improvement
- [x] Documentation
- [ ] Tests only

## Checklist

- [ ] Tests added or updated — n/a, docs only
- [x] All checks pass: Prettier + markdownlint
- [ ] 100% MSI maintained — n/a, docs only
- [ ] No `createMock` without a matching `expects()` — n/a
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwdyPCVfMKZwsGJPbSVQp2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwdyPCVfMKZwsGJPbSVQp2)_