### PR TITLE
fix(scan): stop --since from dropping changed dotfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   default `claude-opus-4-8` and every current model are catalog-present and
   unchanged.
 
+### Fixed
+
+- **`--since` silently dropped changed dotfiles (`.env`, `.github/...`) from
+  incremental audits.** `ProcessGitChangedFilesResolver::mergeAndNormalize()`
+  (`src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php`) used
+  `trimStart('./')`, which strips a leading **character mask** (every leading
+  `.` and `/`), not the literal prefix `./` — `.env` was mangled to `env` and
+  `.github/workflows/ci.yml` to `github/workflows/ci.yml`. The mangled path
+  then failed the exact-match lookup against real project files, so a changed
+  `.env` (or any dotfile/dot-directory) was excluded from `audit:run --since`
+  scope even though it changed. Now uses `trimPrefix('./')`, which strips only
+  the literal `./` prefix.
+
 ### Security
 
 - **The install scripts now fail closed on checksum verification.** Previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,11 +359,11 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   (`src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php`) used
   `trimStart('./')`, which strips a leading **character mask** (every leading
   `.` and `/`), not the literal prefix `./` — `.env` was mangled to `env` and
-  `.github/workflows/ci.yml` to `github/workflows/ci.yml`. The mangled path
-  then failed the exact-match lookup against real project files, so a changed
-  `.env` (or any dotfile/dot-directory) was excluded from `audit:run --since`
-  scope even though it changed. Now uses `trimPrefix('./')`, which strips only
-  the literal `./` prefix.
+  `.github/workflows/ci.yml` to `github/workflows/ci.yml`. The mangled path then
+  failed the exact-match lookup against real project files, so a changed `.env`
+  (or any dotfile/dot-directory) was excluded from `audit:run --since` scope
+  even though it changed. Now uses `trimPrefix('./')`, which strips only the
+  literal `./` prefix.
 
 ### Security
 

--- a/src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php
+++ b/src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php
@@ -117,7 +117,7 @@ final readonly class ProcessGitChangedFilesResolver implements GitChangedFilesRe
     {
         $normalized = [];
         foreach ($paths as $path) {
-            $trimmed = u($path)->trim()->trimStart('./')->toString();
+            $trimmed = u($path)->trim()->trimPrefix('./')->toString();
             if ('' !== $trimmed) {
                 $normalized[] = $trimmed;
             }

--- a/tests/Phpunit/Integration/Diff/ProcessGitChangedFilesResolverTest.php
+++ b/tests/Phpunit/Integration/Diff/ProcessGitChangedFilesResolverTest.php
@@ -105,6 +105,21 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
     /**
      * @throws GitChangedFilesUnavailableException
      */
+    public function test_it_includes_a_changed_dotfile(): void
+    {
+        $this->initRepo();
+        $this->commit('src/Foo.php', '<?php // initial', 'init');
+        $this->createBranch('feature');
+        $this->commit('.env', 'APP_SECRET=changed', 'add env');
+
+        $changed = (new ProcessGitChangedFilesResolver())->changedSince($this->tmpDir, 'main');
+
+        self::assertContains('.env', $changed);
+    }
+
+    /**
+     * @throws GitChangedFilesUnavailableException
+     */
     public function test_it_includes_uncommitted_changes_against_head(): void
     {
         $this->initRepo();


### PR DESCRIPTION
## Summary

`ProcessGitChangedFilesResolver::mergeAndNormalize()` normalized diff paths with `trimStart('./')`, which strips a leading **character mask** (any run of `.` and `/`), not the literal prefix `./`. A changed `.env` became `env`, and `.github/workflows/ci.yml` became `github/workflows/ci.yml`. The mangled path then failed the exact-match lookup against real project files in `IngestionStage::filterByGitDiff`, so a changed dotfile silently fell out of `audit:run --since` scope even though it changed — including `.env`, the exact file the `env_credential_assignment` pre-scan marker exists to catch.

Fix: use `trimPrefix('./')`, which strips only the literal prefix.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — new regression test committing a changed `.env` on a feature branch and asserting it's included in `changedSince()`'s result
- [x] All checks pass locally: PHPUnit (2392 tests, full suite green) — PHPStan/Rector/CS Fixer/Deptrac/Infection could not run in this sandbox (GitHub access is scoped to this repo only, and `phpstan/phpstan` publishes as a dist-only package with no git source, so it cannot be fetched here); CI verifies these
- [x] No `createMock` without a matching `expects()` (no mocks added)
- [x] `CHANGELOG.md` updated (Fixed, Unreleased)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)