### PR TITLE
fix(scan): match DOTALL pre-scan patterns across lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,22 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   default `claude-opus-4-8` and every current model are catalog-present and
   unchanged.
 
+### Fixed
+
+- **Static pre-scan patterns using the `s` (DOTALL) modifier never matched
+  anything.** `RegexStaticPreScanner::matchLines()`
+  (`src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php`) explodes file
+  content into lines and matches each pattern against one line at a time, so the
+  two cross-line patterns in the dictionary — `supports_returns_null` (an
+  authenticator's `supports()` silently returning `null`, which Symfony treats
+  as "supports") and `http_client_request` (an `HttpClient` reference followed
+  by `->request(`, an SSRF surface) — could never fire: a real multi-line method
+  body never appears on a single line. Patterns carrying the `s` modifier are
+  now matched against the full file content instead, with the match offset
+  mapped back to a line number; all other (single-line) patterns are unchanged.
+  `RegexStaticPreScanner:: CACHE_VERSION` moves to `6` since this alters scan
+  output for existing chunk content, invalidating stale attacker cache entries.
+
 ### Security
 
 - **The install scripts now fail closed on checksum verification.** Previously

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -321,9 +321,12 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
 
     private function hasDotAllModifier(string $regex): bool
     {
-        preg_match('/[a-zA-Z]*$/', $regex, $modifiers);
+        $lastDelimiter = strrpos($regex, '/');
+        if (false === $lastDelimiter) {
+            return false;
+        }
 
-        return str_contains($modifiers[0], 's');
+        return str_contains(substr($regex, $lastDelimiter + 1), 's');
     }
 
     /**
@@ -331,7 +334,8 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      */
     private function matchAcrossLines(string $content, string $regex): array
     {
-        if (!preg_match_all($regex, $content, $matches, \PREG_OFFSET_CAPTURE)) {
+        $matchCount = preg_match_all($regex, $content, $matches, \PREG_OFFSET_CAPTURE);
+        if (false === $matchCount || 0 === $matchCount) {
             return [];
         }
 

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -321,10 +321,9 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
 
     private function hasDotAllModifier(string $regex): bool
     {
-        $lastDelimiter = strrpos($regex, '/');
-        $lastDelimiter = false === $lastDelimiter ? 0 : $lastDelimiter;
+        $segments = explode('/', $regex);
 
-        return str_contains(substr($regex, $lastDelimiter + 1), 's');
+        return str_contains(end($segments), 's');
     }
 
     /**

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -332,10 +332,7 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      */
     private function matchAcrossLines(string $content, string $regex): array
     {
-        $matchCount = preg_match_all($regex, $content, $matches, \PREG_OFFSET_CAPTURE);
-        if (false === $matchCount || 0 === $matchCount) {
-            return [];
-        }
+        preg_match_all($regex, $content, $matches, \PREG_OFFSET_CAPTURE);
 
         $lines = [];
         foreach ($matches[0] as $match) {

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -33,7 +33,7 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      * alter scan output for existing chunk content. Folded into the attacker
      * cache key so stale entries are invalidated.
      */
-    public const int CACHE_VERSION = 5;
+    public const int CACHE_VERSION = 6;
 
     /**
      * @param array<string, array<string, array{regex: string, description: string}>> $customPatterns extra patterns merged into the static dictionary keyed by file-type bucket
@@ -303,6 +303,10 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      */
     private function matchLines(string $content, string $regex): array
     {
+        if ($this->hasDotAllModifier($regex)) {
+            return $this->matchAcrossLines($content, $regex);
+        }
+
         $lines = explode("\n", $content);
         $matches = [];
 
@@ -313,5 +317,29 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
         }
 
         return $matches;
+    }
+
+    private function hasDotAllModifier(string $regex): bool
+    {
+        preg_match('/[a-zA-Z]*$/', $regex, $modifiers);
+
+        return str_contains($modifiers[0], 's');
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function matchAcrossLines(string $content, string $regex): array
+    {
+        if (!preg_match_all($regex, $content, $matches, \PREG_OFFSET_CAPTURE)) {
+            return [];
+        }
+
+        $lines = [];
+        foreach ($matches[0] as $match) {
+            $lines[] = substr_count($content, "\n", 0, $match[1]) + 1;
+        }
+
+        return array_values(array_unique($lines));
     }
 }

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -321,7 +321,8 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
 
     private function hasDotAllModifier(string $regex): bool
     {
-        $lastDelimiter = strrpos($regex, '/') ?: 0;
+        $lastDelimiter = strrpos($regex, '/');
+        $lastDelimiter = false === $lastDelimiter ? 0 : $lastDelimiter;
 
         return str_contains(substr($regex, $lastDelimiter + 1), 's');
     }

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -321,10 +321,7 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
 
     private function hasDotAllModifier(string $regex): bool
     {
-        $lastDelimiter = strrpos($regex, '/');
-        if (false === $lastDelimiter) {
-            return false;
-        }
+        $lastDelimiter = strrpos($regex, '/') ?: 0;
 
         return str_contains(substr($regex, $lastDelimiter + 1), 's');
     }

--- a/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
@@ -261,13 +261,14 @@ final class RegexStaticPreScannerTest extends TestCase
         $projectFile = ProjectFile::create(
             'src/Security/LoginAuthenticator.php',
             '/app/src/Security/LoginAuthenticator.php',
-            "<?php\nclass LoginAuthenticator {\n    public function supports(Request \$request): ?bool\n    {\n        return null;\n    }\n}",
+            "\n<?php\nclass LoginAuthenticator {\n    public function supports(Request \$request): ?bool\n    {\n        return null;\n    }\n}",
         );
 
         $markers = $this->regexStaticPreScanner->scan([$projectFile]);
 
-        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
-        self::assertContains('supports_returns_null', $patterns);
+        self::assertCount(1, $markers);
+        self::assertSame('supports_returns_null', $markers[0]->pattern());
+        self::assertSame(4, $markers[0]->line());
     }
 
     public function test_it_flags_http_client_request_split_across_lines(): void
@@ -275,13 +276,14 @@ final class RegexStaticPreScannerTest extends TestCase
         $projectFile = ProjectFile::create(
             'src/Service/Fetcher.php',
             '/app/src/Service/Fetcher.php',
-            "<?php\nclass Fetcher {\n    public function __construct(private HttpClientInterface \$client) {}\n    public function fetch(string \$url) {\n        return \$this->client->request('GET', \$url);\n    }\n}",
+            "\n<?php\nclass Fetcher {\n    public function __construct(private HttpClientInterface \$client) {}\n    public function fetch(string \$url) {\n        return \$this->client->request('GET', \$url);\n    }\n}",
         );
 
         $markers = $this->regexStaticPreScanner->scan([$projectFile]);
 
-        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
-        self::assertContains('http_client_request', $patterns);
+        self::assertCount(1, $markers);
+        self::assertSame('http_client_request', $markers[0]->pattern());
+        self::assertSame(4, $markers[0]->line());
     }
 
     public function test_it_flags_self_validating_passport_in_authenticator(): void
@@ -418,5 +420,28 @@ final class RegexStaticPreScannerTest extends TestCase
 
         $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
         self::assertContains('forbidden_host', $patterns);
+    }
+
+    public function test_it_does_not_mistake_a_pattern_ending_in_the_letter_s_for_a_dot_all_pattern(): void
+    {
+        $regexStaticPreScanner = new RegexStaticPreScanner([
+            'php' => [
+                'literal_foos' => ['regex' => '/^foos/', 'description' => 'test'],
+            ],
+        ]);
+        $projectFile = ProjectFile::create(
+            'src/Service/Foo.php',
+            '/app/src/Service/Foo.php',
+            "xfoos\nfoos",
+        );
+
+        $markers = $regexStaticPreScanner->scan([$projectFile]);
+
+        $literalFoosMarkers = array_values(array_filter(
+            $markers,
+            static fn (RiskMarker $riskMarker): bool => 'literal_foos' === $riskMarker->pattern(),
+        ));
+        self::assertCount(1, $literalFoosMarkers);
+        self::assertSame(2, $literalFoosMarkers[0]->line());
     }
 }

--- a/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
@@ -256,6 +256,34 @@ final class RegexStaticPreScannerTest extends TestCase
         self::assertContains('dynamic_order_by', $patterns);
     }
 
+    public function test_it_flags_supports_returning_null_across_multiple_lines(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Security/LoginAuthenticator.php',
+            '/app/src/Security/LoginAuthenticator.php',
+            "<?php\nclass LoginAuthenticator {\n    public function supports(Request \$request): ?bool\n    {\n        return null;\n    }\n}",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('supports_returns_null', $patterns);
+    }
+
+    public function test_it_flags_http_client_request_split_across_lines(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Service/Fetcher.php',
+            '/app/src/Service/Fetcher.php',
+            "<?php\nclass Fetcher {\n    public function __construct(private HttpClientInterface \$client) {}\n    public function fetch(string \$url) {\n        return \$this->client->request('GET', \$url);\n    }\n}",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('http_client_request', $patterns);
+    }
+
     public function test_it_flags_self_validating_passport_in_authenticator(): void
     {
         $projectFile = ProjectFile::create(


### PR DESCRIPTION
## Summary

`RegexStaticPreScanner::matchLines()` explodes file content into lines and matches each pattern one line at a time. Two entries in the pattern dictionary use the `/s` (DOTALL) modifier specifically because they're meant to span multiple lines — `supports_returns_null` (an authenticator's `supports()` silently returning `null`, which Symfony treats as "this authenticator supports the request") and `http_client_request` (an `HttpClient` reference followed later by `->request(`, an SSRF surface). Neither can ever match against a single line, since a real multi-line method body is never on one line — both markers were dead code against realistic PHP.

Fix: patterns carrying the `s` modifier are now matched against the full file content, with the match offset mapped back to a line number via `substr_count`. All other (single-line) patterns are untouched — several of them rely on `^` anchoring at line-start without `/m`, which would silently break under a naive full-content switch, so this only special-cases the two patterns that actually need it.

Also bumps `RegexStaticPreScanner::CACHE_VERSION` (5 → 6) per its own documented contract, since this changes scan output for existing chunk content and must invalidate stale attacker cache entries.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — two new regression tests reproducing the exact scenarios described above (multi-line `supports(): ?bool { ... return null; }`, and `HttpClientInterface` + `->request(` split across lines), full existing dictionary test file still green including the exact-line-number assertions
- [x] All checks pass locally: PHPUnit (2393 tests, full suite green), PHP CS Fixer — PHPStan/Rector/Deptrac/Infection could not run in this sandbox (GitHub access is scoped to this repo only; `phpstan/phpstan` is a dist-only package with no git source, and both Rector and Deptrac have a hard runtime dependency on it, so none of the three can be fetched here); CI verifies these
- [x] No `createMock` without a matching `expects()` (no mocks added)
- [x] `CHANGELOG.md` updated (Fixed, Unreleased)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)