### PR TITLE
fix(report): strip xml-illegal from junit output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   default `claude-opus-4-8` and every current model are catalog-present and
   unchanged.
 
+### Fixed
+
+- **`--format junit` could emit XML that no consumer could re-parse.**
+  `JunitReportRenderer`
+  (`src/Audit/Infrastructure/Report/JunitReportRenderer.php`) inserted a
+  finding's LLM-produced title, description, and remediation text directly into
+  DOM attributes and text nodes. `DOMDocument::saveXML()` escapes XML
+  metacharacters (`<`, `&`, `"`) but writes XML-1.0-illegal control bytes
+  (`\x00`-`\x08`, `\x0B`, `\x0C`, `\x0E`-`\x1F`) out verbatim, so a finding
+  whose narrative happened to reproduce one of those bytes (a plausible outcome
+  when the model echoes a raw exploit payload) produced a `.xml` report that
+  GitLab, Jenkins, and any standard XML parser rejected outright. Those bytes
+  are now stripped before insertion.
+
 ### Security
 
 - **The install scripts now fail closed on checksum verification.** Previously

--- a/src/Audit/Infrastructure/Report/JunitReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/JunitReportRenderer.php
@@ -27,6 +27,17 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
  */
 final readonly class JunitReportRenderer implements ReportRendererInterface
 {
+    /**
+     * XML 1.0 forbids every control character other than tab, CR and LF.
+     *
+     * @var list<string>
+     */
+    private const array ILLEGAL_XML_CHARACTERS = [
+        "\x00", "\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08",
+        "\x0B", "\x0C",
+        "\x0E", "\x0F", "\x10", "\x11", "\x12", "\x13", "\x14", "\x15", "\x16", "\x17", "\x18", "\x19", "\x1A", "\x1B", "\x1C", "\x1D", "\x1E", "\x1F",
+    ];
+
     #[Override]
     public function format(): string
     {
@@ -60,30 +71,42 @@ final readonly class JunitReportRenderer implements ReportRendererInterface
 
     private function testCase(DOMDocument $domDocument, Vulnerability $vulnerability): DOMElement
     {
+        $title = $this->stripIllegalXmlCharacters($vulnerability->title());
+
         $domElement = $domDocument->createElement('testcase');
         $domElement->setAttribute('classname', $vulnerability->type()->value);
         $domElement->setAttribute('name', \sprintf(
             '%s (%s:%d)',
-            $vulnerability->title(),
+            $title,
             $vulnerability->filePath(),
             $vulnerability->lineStart(),
         ));
 
         $failure = $domDocument->createElement('failure');
         $failure->setAttribute('type', $vulnerability->severity()->value);
-        $failure->setAttribute('message', $vulnerability->title());
+        $failure->setAttribute('message', $title);
         $failure->appendChild($domDocument->createTextNode(\sprintf(
             "%s\n\nSeverity: %s\nLocation: %s:%d-%d\nOWASP: %s\nRemediation: %s",
-            $vulnerability->description(),
+            $this->stripIllegalXmlCharacters($vulnerability->description()),
             $vulnerability->severity()->value,
             $vulnerability->filePath(),
             $vulnerability->lineStart(),
             $vulnerability->lineEnd(),
             $vulnerability->type()->owaspReference(),
-            $vulnerability->remediation(),
+            $this->stripIllegalXmlCharacters($vulnerability->remediation()),
         )));
         $domElement->appendChild($failure);
 
         return $domElement;
+    }
+
+    /**
+     * DOMDocument::saveXML() writes illegal control characters out verbatim
+     * without escaping them — a finding whose LLM-produced text carries one
+     * silently corrupts the document for any consumer that re-parses it.
+     */
+    private function stripIllegalXmlCharacters(string $value): string
+    {
+        return str_replace(self::ILLEGAL_XML_CHARACTERS, '', $value);
     }
 }

--- a/tests/Phpunit/Unit/Infrastructure/Report/JunitReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/JunitReportRendererTest.php
@@ -106,9 +106,9 @@ final class JunitReportRendererTest extends AbstractReportRendererTestCase
     {
         $illegalCharacters = implode('', array_map('chr', [...range(0x00, 0x08), 0x0B, 0x0C, ...range(0x0E, 0x1F)]));
         $vulnerability = Vulnerability::of(
-            new VulnerabilityClassification(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH, "Bad{$illegalCharacters}Title", 0.9),
+            new VulnerabilityClassification(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH, \sprintf('Bad%sTitle', $illegalCharacters), 0.9),
             new CodeLocation('src/Foo.php', 1, 5),
-            new VulnerabilityNarrative("Desc{$illegalCharacters}End", 'vector', 'proof', "Rem{$illegalCharacters}End"),
+            new VulnerabilityNarrative(\sprintf('Desc%sEnd', $illegalCharacters), 'vector', 'proof', \sprintf('Rem%sEnd', $illegalCharacters)),
             '$q',
         )->withReviewerValidation(true);
 

--- a/tests/Phpunit/Unit/Infrastructure/Report/JunitReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/JunitReportRendererTest.php
@@ -102,6 +102,32 @@ final class JunitReportRendererTest extends AbstractReportRendererTestCase
      * @throws InvalidCodeLocationException
      * @throws InvalidVulnerabilityClassificationException
      */
+    public function test_it_strips_xml_illegal_control_characters(): void
+    {
+        $illegalCharacters = implode('', array_map('chr', [...range(0x00, 0x08), 0x0B, 0x0C, ...range(0x0E, 0x1F)]));
+        $vulnerability = Vulnerability::of(
+            new VulnerabilityClassification(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::HIGH, "Bad{$illegalCharacters}Title", 0.9),
+            new CodeLocation('src/Foo.php', 1, 5),
+            new VulnerabilityNarrative("Desc{$illegalCharacters}End", 'vector', 'proof', "Rem{$illegalCharacters}End"),
+            '$q',
+        )->withReviewerValidation(true);
+
+        $domDocument = $this->decodeJunit($this->makeReport($vulnerability));
+
+        $testcase = $domDocument->getElementsByTagName('testcase')->item(0);
+        self::assertNotNull($testcase);
+        self::assertSame('BadTitle (src/Foo.php:1)', $testcase->getAttribute('name'));
+
+        $failure = $domDocument->getElementsByTagName('failure')->item(0);
+        self::assertNotNull($failure);
+        self::assertStringContainsString('DescEnd', $failure->textContent);
+        self::assertStringContainsString('RemEnd', $failure->textContent);
+    }
+
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     */
     public function test_it_pretty_prints_the_document(): void
     {
         $output = $this->renderer->render($this->makeReport($this->makeValidatedVuln()));


### PR DESCRIPTION
## Summary

`JunitReportRenderer` inserts a finding's LLM-produced title, description, and remediation text directly into DOM attributes and text nodes. `DOMDocument::saveXML()` escapes XML metacharacters (`&lt;`, `&amp;`, `&#34;`) but writes XML-1.0-illegal control bytes (`\x00`-`\x08`, `\x0B`, `\x0C`, `\x0E`-`\x1F`) out verbatim — confirmed empirically: `saveXML()` embeds the raw byte silently, and re-parsing the result with `loadXML()` then fails with "invalid character in attribute value" and returns `false`. A finding whose narrative happens to reproduce one of those bytes (plausible when the model echoes a raw exploit payload) produced a `.xml` report that GitLab, Jenkins, or any standard XML parser rejected outright.

Fix: strip the illegal byte range from title/description/remediation before insertion, via an explicit character list (`str_replace`, not a regex) so the removal doesn't depend on preg's `string|null` return type.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — one test builds a string containing every XML-1.0-illegal control byte (0x00-0x08, 0x0B, 0x0C, 0x0E-0x1F) and asserts each is stripped from the rendered attribute and text-node content, plus that the surrounding legal text survives intact
- [x] All checks pass locally: PHPUnit (2392 tests, full suite green), PHP CS Fixer — PHPStan/Rector/Deptrac/Infection could not run in this sandbox (GitHub access is scoped to this repo only, and `phpstan/phpstan`/`rector`/`deptrac` are blocked by a hard dependency on it being dist-only); CI verifies these
- [x] No `createMock` without a matching `expects()` (no mocks added)
- [x] `CHANGELOG.md` updated (Fixed, Unreleased)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)