### PR TITLE
feat(scan): detect file-upload vulnerabilities as a dedicated attacker skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
+- **File uploads are now a dedicated attacker skill.** `FormType`s carrying a
+  `FileType`/`VichUploaderBundle` field, and the manual `UploadedFile` handling
+  built on top of them, were only covered by `FormAttackerSkill`'s general
+  mass-assignment/CSRF hunting — extension/MIME spoofing, path traversal via the
+  original filename, and web-root RCE via an uploaded `.php` were invisible to
+  the attacker. A new `FileUploadAttackerSkill`
+  (`src/Audit/Infrastructure/Prompt/Skill/FileUploadAttackerSkill.php`, tagged
+  `symfony_security_auditor.attacker_skill`, `priority()` 115 — right after
+  `FormAttackerSkill`) targets the existing `ProjectFileType::FORM` case and
+  hunts client-trusted `Content-Type`/extension checks, missing size limits,
+  `getClientOriginalName()`-derived paths, public-web-root storage without
+  execution disabled, predictable stored filenames, missing authorization on the
+  upload endpoint, and download routes that don't re-check ownership — with a
+  "do NOT flag" section for allow-listed extensions stored outside the web root
+  and randomized filenames. `AttackerPromptBuilder::PROMPT_VERSION` bumps to 12,
+  invalidating cached attacker responses for chunks containing a form.
 - **New `--format junit` output renders findings as JUnit XML for CI test-report
   panels.** SARIF gets findings into GitHub Code Scanning and GitLab's security
   dashboard, but GitLab's dashboard requires the Ultimate tier — free-tier users

--- a/config/services.php
+++ b/config/services.php
@@ -115,6 +115,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\Confi
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\ControllerAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\EntityAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\EventSubscriberAttackerSkill;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\FileUploadAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\FormAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\LiveComponentAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\MessengerHandlerAttackerSkill;
@@ -257,6 +258,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $defaultsConfigurator->set(ControllerAttackerSkill::class);
     $defaultsConfigurator->set(EntityAttackerSkill::class);
     $defaultsConfigurator->set(EventSubscriberAttackerSkill::class);
+    $defaultsConfigurator->set(FileUploadAttackerSkill::class);
     $defaultsConfigurator->set(FormAttackerSkill::class);
     $defaultsConfigurator->set(LiveComponentAttackerSkill::class);
     $defaultsConfigurator->set(MessengerHandlerAttackerSkill::class);

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -29,7 +29,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
      * previously-cached LLM responses. Bump whenever the prompt structure or
      * skill blocks change in a way the LLM is expected to react to.
      */
-    public const int PROMPT_VERSION = 11;
+    public const int PROMPT_VERSION = 12;
 
     public const bool DEFAULT_STRUCTURED_COLLECTION = true;
 

--- a/src/Audit/Infrastructure/Prompt/Skill/AttackerSkillRegistry.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/AttackerSkillRegistry.php
@@ -74,6 +74,7 @@ final readonly class AttackerSkillRegistry
             new NormalizerAttackerSkill(),
             new SchedulerAttackerSkill(),
             new FormAttackerSkill(),
+            new FileUploadAttackerSkill(),
             new RepositoryAttackerSkill(),
             new EntityAttackerSkill(),
             new TemplateAttackerSkill(),

--- a/src/Audit/Infrastructure/Prompt/Skill/FileUploadAttackerSkill.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/FileUploadAttackerSkill.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class FileUploadAttackerSkill implements AttackerSkillInterface
+{
+    #[Override]
+    public function fileType(): ProjectFileType
+    {
+        return ProjectFileType::FORM;
+    }
+
+    #[Override]
+    public function priority(): int
+    {
+        return 115;
+    }
+
+    #[Override]
+    public function block(): string
+    {
+        return <<<'SKILL'
+            <skills role="file_upload">
+            Hunt (`FileType` fields, `VichUploaderBundle` mappings, and manual `UploadedFile` handling):
+            - Extension/MIME validation missing or based on the client-supplied `Content-Type` header / `getClientMimeType()` instead of `guessExtension()` or a server-side allow-list.
+            - No `maxSize` constraint (or a `MimeType`/`File` constraint with an empty `mimeTypes` allow-list), letting an attacker exhaust disk space.
+            - Stored filename built from `getClientOriginalName()` without sanitization — user-controlled `../../etc/passwd`-style path traversal into `move()`'s target directory.
+            - Upload target directory inside the public web root (`public/uploads`, `public/media`) without a `.htaccess` / web-server rule disabling script execution — an uploaded `.php`/`.phtml`/`.phar` becomes remote code execution.
+            - Stored filename derived from the original name or a predictable counter/timestamp instead of a random token (`uniqid()` without the `more_entropy` argument, sequential IDs) — enables overwrite of another user's file or enumeration of private uploads.
+            - Upload controller/form action reachable without `denyAccessUnlessGranted()` / `#[IsGranted]` where the surrounding feature requires authentication.
+            - A download/serve route for uploaded files that streams by filename or ID without re-checking the requester's access to the owning entity.
+            Do NOT flag:
+            - Handlers validating the extension against an explicit allow-list (`mimeTypes: ['image/png', 'image/jpeg']` or an equivalent `in_array()` check) AND storing outside the public web root, or with execution disabled for that path.
+            - Filenames generated via `uniqid('', true)`, `Uuid::v4()`, `md5(uniqid())`, or `VichUploaderBundle`'s default namer — these are unpredictable enough to resist enumeration.
+            - Download actions that resolve the owning entity first and call `denyAccessUnlessGranted()` against it before streaming the file.
+            </skills>
+            SKILL;
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -494,7 +494,7 @@ final class AttackerPromptBuilderTest extends TestCase
 
         $prompt = $attackerPromptBuilder->buildSystemPrompt([$projectFile]);
 
-        self::assertSame(16, substr_count($prompt, '<skills role="'));
+        self::assertSame(17, substr_count($prompt, '<skills role="'));
     }
 
     public function test_stable_mode_system_prompt_is_byte_identical_across_chunk_types(): void
@@ -586,6 +586,20 @@ final class AttackerPromptBuilderTest extends TestCase
         $prompt = $this->attackerPromptBuilder->buildSystemPrompt([$projectFile]);
 
         self::assertStringContainsString('<skills role="form">', $prompt);
+    }
+
+    public function test_it_injects_file_upload_skills_when_form_in_chunk(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Form/AvatarUploadType.php',
+            '/app/src/Form/AvatarUploadType.php',
+            '<?php class AvatarUploadType {}',
+        );
+
+        $prompt = $this->attackerPromptBuilder->buildSystemPrompt([$projectFile]);
+
+        self::assertStringContainsString('<skills role="file_upload">', $prompt);
+        self::assertStringContainsString('path traversal', $prompt);
     }
 
     public function test_it_injects_template_skills_when_twig_in_chunk(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/Skill/AttackerSkillRegistryTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/Skill/AttackerSkillRegistryTest.php
@@ -25,6 +25,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\Confi
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\ControllerAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\EntityAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\EventSubscriberAttackerSkill;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\FileUploadAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\FormAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\LiveComponentAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\MessengerHandlerAttackerSkill;
@@ -69,6 +70,7 @@ final class AttackerSkillRegistryTest extends TestCase
         yield 'normalizer' => [new NormalizerAttackerSkill(), ProjectFileType::NORMALIZER, 90, 'normalizer'];
         yield 'scheduler' => [new SchedulerAttackerSkill(), ProjectFileType::SCHEDULER, 100, 'scheduler'];
         yield 'form' => [new FormAttackerSkill(), ProjectFileType::FORM, 110, 'form'];
+        yield 'file_upload' => [new FileUploadAttackerSkill(), ProjectFileType::FORM, 115, 'file_upload'];
         yield 'repository' => [new RepositoryAttackerSkill(), ProjectFileType::REPOSITORY, 120, 'repository'];
         yield 'entity' => [new EntityAttackerSkill(), ProjectFileType::ENTITY, 130, 'entity'];
         yield 'template' => [new TemplateAttackerSkill(), ProjectFileType::TEMPLATE, 140, 'template'];
@@ -93,7 +95,7 @@ final class AttackerSkillRegistryTest extends TestCase
 
         $output = $attackerSkillRegistry->render([], emitAll: true);
 
-        self::assertSame(16, substr_count($output, '<skills role="'));
+        self::assertSame(17, substr_count($output, '<skills role="'));
     }
 
     public function test_it_emits_blocks_in_attack_surface_priority_order(): void
@@ -116,6 +118,7 @@ final class AttackerSkillRegistryTest extends TestCase
             'normalizer',
             'scheduler',
             'form',
+            'file_upload',
             'repository',
             'entity',
             'template',
@@ -125,40 +128,42 @@ final class AttackerSkillRegistryTest extends TestCase
     }
 
     /**
-     * @param non-empty-string $role
+     * @param list<non-empty-string> $roles
      */
     #[DataProvider('everyFileTypeWithASkill')]
-    public function test_each_file_type_emits_its_own_skill_block(ProjectFileType $projectFileType, string $role): void
+    public function test_each_file_type_emits_its_own_skill_blocks(ProjectFileType $projectFileType, array $roles): void
     {
         $attackerSkillRegistry = new AttackerSkillRegistry();
 
         $output = $attackerSkillRegistry->render([$projectFileType], emitAll: false);
 
-        self::assertSame(1, substr_count($output, '<skills role="'));
-        self::assertStringContainsString(\sprintf('<skills role="%s">', $role), $output);
+        self::assertSame(\count($roles), substr_count($output, '<skills role="'));
+        foreach ($roles as $role) {
+            self::assertStringContainsString(\sprintf('<skills role="%s">', $role), $output);
+        }
     }
 
     /**
-     * @return iterable<string, array{ProjectFileType, non-empty-string}>
+     * @return iterable<string, array{ProjectFileType, list<non-empty-string>}>
      */
     public static function everyFileTypeWithASkill(): iterable
     {
-        yield 'controller' => [ProjectFileType::CONTROLLER, 'controller'];
-        yield 'api_resource' => [ProjectFileType::API_RESOURCE, 'api_resource'];
-        yield 'live_component' => [ProjectFileType::LIVE_COMPONENT, 'live_component'];
-        yield 'authenticator' => [ProjectFileType::AUTHENTICATOR, 'authenticator'];
-        yield 'voter' => [ProjectFileType::VOTER, 'voter'];
-        yield 'webhook_consumer' => [ProjectFileType::WEBHOOK_CONSUMER, 'webhook_consumer'];
-        yield 'messenger_handler' => [ProjectFileType::MESSENGER_HANDLER, 'messenger_handler'];
-        yield 'event_subscriber' => [ProjectFileType::EVENT_SUBSCRIBER, 'event_subscriber'];
-        yield 'normalizer' => [ProjectFileType::NORMALIZER, 'normalizer'];
-        yield 'scheduler' => [ProjectFileType::SCHEDULER, 'scheduler'];
-        yield 'form' => [ProjectFileType::FORM, 'form'];
-        yield 'repository' => [ProjectFileType::REPOSITORY, 'repository'];
-        yield 'entity' => [ProjectFileType::ENTITY, 'entity'];
-        yield 'template' => [ProjectFileType::TEMPLATE, 'template'];
-        yield 'config' => [ProjectFileType::CONFIG, 'config'];
-        yield 'php' => [ProjectFileType::PHP, 'php'];
+        yield 'controller' => [ProjectFileType::CONTROLLER, ['controller']];
+        yield 'api_resource' => [ProjectFileType::API_RESOURCE, ['api_resource']];
+        yield 'live_component' => [ProjectFileType::LIVE_COMPONENT, ['live_component']];
+        yield 'authenticator' => [ProjectFileType::AUTHENTICATOR, ['authenticator']];
+        yield 'voter' => [ProjectFileType::VOTER, ['voter']];
+        yield 'webhook_consumer' => [ProjectFileType::WEBHOOK_CONSUMER, ['webhook_consumer']];
+        yield 'messenger_handler' => [ProjectFileType::MESSENGER_HANDLER, ['messenger_handler']];
+        yield 'event_subscriber' => [ProjectFileType::EVENT_SUBSCRIBER, ['event_subscriber']];
+        yield 'normalizer' => [ProjectFileType::NORMALIZER, ['normalizer']];
+        yield 'scheduler' => [ProjectFileType::SCHEDULER, ['scheduler']];
+        yield 'form' => [ProjectFileType::FORM, ['form', 'file_upload']];
+        yield 'repository' => [ProjectFileType::REPOSITORY, ['repository']];
+        yield 'entity' => [ProjectFileType::ENTITY, ['entity']];
+        yield 'template' => [ProjectFileType::TEMPLATE, ['template']];
+        yield 'config' => [ProjectFileType::CONFIG, ['config']];
+        yield 'php' => [ProjectFileType::PHP, ['php']];
     }
 
     public function test_it_accepts_a_traversable_of_skills(): void


### PR DESCRIPTION
## Summary

`FormType`s carrying a `FileType`/`VichUploaderBundle` field — and the manual `UploadedFile` handling built on top of them — were only covered by `FormAttackerSkill`'s general mass-assignment/CSRF hunting. Extension/MIME spoofing, path traversal via the original filename, and web-root RCE via an uploaded `.php` were invisible to the attacker.

A new `FileUploadAttackerSkill` targets the existing `ProjectFileType::FORM` case (no new enum case needed — file uploads in Symfony overwhelmingly go through a `FormType`, not raw controller code) and hunts:

- Extension/MIME validation missing or trusting the client-supplied `Content-Type`/`getClientMimeType()` instead of a server-side allow-list
- Missing size limits
- Stored filenames built from `getClientOriginalName()` without sanitization (path traversal)
- Upload targets inside the public web root without execution disabled (RCE via uploaded `.php`)
- Predictable stored filenames (overwrite/enumeration)
- Missing authorization on the upload endpoint
- Download routes that don't re-check ownership before streaming

With a "do NOT flag" section for allow-listed extensions stored outside the web root and randomized filenames, mirroring every other skill's noise-reduction guidance.

`AttackerPromptBuilder::PROMPT_VERSION` bumps 11 → 12, invalidating cached attacker responses for chunks containing a form (same pattern as prior per-surface skill additions).

This is also the first case where a `ProjectFileType` maps to two skills (`FormAttackerSkill` + `FileUploadAttackerSkill` both target `FORM`) — `AttackerSkillRegistry::render()` already supported this without changes; one existing test assumed a 1:1 file-type-to-skill mapping and was generalized to assert a list of expected roles per type instead of special-casing `FORM`.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated — new `FileUploadAttackerSkill` data-provider entry (fileType/priority/role), stable-mode skill count 16→17, priority-order assertion, a dedicated `test_it_injects_file_upload_skills_when_form_in_chunk`, and the per-file-type "own skill block(s)" test generalized to support a file type with more than one skill
- [x] All checks pass locally: PHP lint, Prettier, markdownlint — PHPUnit/PHPStan/Rector/Deptrac/Infection could not run in this sandbox (no network access to fetch dev dependencies); CI verifies these
- [x] No `createMock` without a matching `expects()` (no mocks added)
- [x] `CHANGELOG.md` updated (Added, Unreleased)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)