### PR TITLE
test: raise slow-test threshold for bundle boot test to match observed duration

### DIFF
--- a/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
+++ b/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
@@ -75,7 +75,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     private ?Kernel $bootedKernel = null;
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(1250)]
+    #[MaximumDuration(1500)]
     public function test_bundle_boots_with_minimal_config_and_registers_audit_command(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);


### PR DESCRIPTION
## Summary

CI flagged `test_bundle_boots_with_minimal_config_and_registers_audit_command` via `Ergebnis\PHPUnit\SlowTestDetector`:

```
# Duration          Test
  Actual   Maximum
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1    1.361    1.250 VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Bundle\SymfonySecurityAuditorBundleTest::test_bundle_boots_with_minimal_config_and_registers_audit_command
```

Booting the full Symfony kernel in a separate process (`#[RunInSeparateProcess]`) runs slower on CI runners than the previously configured `#[MaximumDuration(1250)]` allowed. Bumped to `1500`ms — the next 250ms tier used by every other `#[MaximumDuration]` value in this file — close enough to the observed 1.361s to catch a genuine regression, with enough headroom over normal runner variance to avoid flaking again.

## Type of change

- [x] Bug fix (CI flake)

## Checklist

- [x] Tests added or updated — N/A, this only adjusts an existing test's `#[MaximumDuration]` attribute value
- [x] All checks pass locally: PHP lint (`php -l`) on the changed file — PHPUnit/PHPStan/Rector/Deptrac/Infection could not run in this sandbox (GitHub access is scoped to this repo only, and those tools have a hard dependency on dist-only packages blocked by that scoping); CI verifies these
- [x] No `createMock` without a matching `expects()` (no mocks added)
- [x] `CHANGELOG.md` not updated — pure test-tooling threshold change, exempt per the changelog rules
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)