### PR TITLE
refactor(command): remove dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -546,6 +546,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `ministral-{3b,8b,14b}-2512`) now resolve to `$0.00` with a warning. The
   default `claude-opus-4-8` and every current model are catalog-present and
   unchanged.
+- **`AuditPresenterInterface::baselineApplied()` and its `AuditCommand` call
+  site.** Since `AuditOrchestrator` already strips baseline-accepted findings
+  from the pipeline before they reach the report (see the "skip baselined
+  findings before review" change), `AuditCommand::finalizeAuditRun()`'s own
+  `BaselineProcessor::apply()` pass never had anything left to suppress —
+  `suppressedCount` was always `0`, and the message this method printed could
+  never actually fire. Both were `@internal`, so this is not a public-API break;
+  the CLI's console output is unaffected because the message never appeared in
+  any real run.
 
 ### Fixed
 

--- a/src/Command/AuditCommand.php
+++ b/src/Command/AuditCommand.php
@@ -220,10 +220,6 @@ final readonly class AuditCommand
     ): int {
         $baselineResult = $this->baselineProcessor->apply($auditReport, $auditCommandInput->baseline);
 
-        if (!$auditCommandInput->isMachineReadableToStdout()) {
-            $this->auditPresenter->baselineApplied($symfonyStyle, $baselineResult->suppressedCount);
-        }
-
         $reportToRender = OutputFormat::Sarif === $auditCommandInput->format ? $auditReport : $baselineResult->report;
         $this->reportWriter->write($reportToRender, $auditCommandInput->format, $auditCommandInput->output, $symfonyStyle, $baselineResult->acceptedFingerprints);
 

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -222,17 +222,4 @@ final readonly class AuditPresenter implements AuditPresenterInterface
             $fingerprintCount,
         ));
     }
-
-    #[Override]
-    public function baselineApplied(SymfonyStyle $symfonyStyle, int $suppressedCount): void
-    {
-        if ($suppressedCount < 1) {
-            return;
-        }
-
-        $symfonyStyle->note(\sprintf(
-            '%d finding(s) suppressed by the baseline.',
-            $suppressedCount,
-        ));
-    }
 }

--- a/src/Command/AuditPresenterInterface.php
+++ b/src/Command/AuditPresenterInterface.php
@@ -50,6 +50,4 @@ interface AuditPresenterInterface
     public function result(SymfonyStyle $symfonyStyle, AuditReport $auditReport, int $exitCode): void;
 
     public function baselineGenerated(SymfonyStyle $symfonyStyle, string $path, int $fingerprintCount): void;
-
-    public function baselineApplied(SymfonyStyle $symfonyStyle, int $suppressedCount): void;
 }

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -184,36 +184,6 @@ final class AuditPresenterTest extends TestCase
         self::assertStringContainsString('3 finding fingerprint(s)', $flattened);
     }
 
-    public function test_baseline_applied_reports_the_suppressed_count(): void
-    {
-        $bufferedOutput = new BufferedOutput();
-        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
-
-        $this->auditPresenter->baselineApplied($symfonyStyle, 2);
-
-        self::assertStringContainsString('2 finding(s) suppressed by the baseline.', $bufferedOutput->fetch());
-    }
-
-    public function test_baseline_applied_reports_a_single_suppression(): void
-    {
-        $bufferedOutput = new BufferedOutput();
-        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
-
-        $this->auditPresenter->baselineApplied($symfonyStyle, 1);
-
-        self::assertStringContainsString('1 finding(s) suppressed by the baseline.', $bufferedOutput->fetch());
-    }
-
-    public function test_baseline_applied_is_silent_when_nothing_suppressed(): void
-    {
-        $bufferedOutput = new BufferedOutput();
-        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
-
-        $this->auditPresenter->baselineApplied($symfonyStyle, 0);
-
-        self::assertSame('', $bufferedOutput->fetch());
-    }
-
     public function test_running_section_emits_section_header(): void
     {
         $bufferedOutput = new BufferedOutput();


### PR DESCRIPTION
## Summary

`main`'s Infection job has been stuck at 99.96% MSI (100% required) since PR #128 closed the third of three originally-escaped mutants. The remaining two live in `AuditCommand::finalizeAuditRun()`:

```php
if (!$auditCommandInput->isMachineReadableToStdout()) {
    $this->auditPresenter->baselineApplied($symfonyStyle, $baselineResult->suppressedCount);
}
```

`AuditOrchestrator` already strips baseline-accepted findings from the pipeline before they reach the report (`withoutBaselineAccepted()`, added by PR #103, well before this session). By the time `finalizeAuditRun()` runs its own `BaselineProcessor::apply()` pass, matching findings are already gone from `$auditReport`, so `suppressedCount` is always `0` in every real invocation, and `baselineApplied()` no-ops whenever the count is below 1. Neither the `!` guard nor the method call is observable from the outside — which is exactly why Infection can't kill either mutant: removing them changes nothing.

Removes:

- The unreachable `if` block in `AuditCommand::finalizeAuditRun()`.
- `AuditPresenterInterface::baselineApplied()` and its `AuditPresenter` implementation (the method's only caller).
- The 3 now-orphaned unit tests in `AuditPresenterTest.php`.

Both the interface and the class are `@internal` (not part of the BC promise), so this is not a public-API break, and the CLI's console output is unaffected — the message never printed in any real run to begin with.

## Type of change

- [x] Bug fix (CI-blocking mutation-coverage gap)

## Checklist

- [x] Tests added or updated — removed 3 tests that only exercised the now-deleted method directly, not through `AuditCommand`
- [x] All checks pass locally: PHP lint (`php -l`) on every changed file, manual trace confirming `AuditOrchestrator::withoutBaselineAccepted()` removes matching findings before `AuditReport` is built, so `finalizeAuditRun()`'s second suppression pass is provably dead — PHPUnit/PHPStan/Rector/Deptrac/Infection could not run in this sandbox (GitHub access is scoped to this repo only, and those tools have a hard dependency on dist-only packages blocked by that scoping); CI verifies these
- [x] No `createMock` without a matching `expects()` (no mocks added)
- [x] `CHANGELOG.md` updated (Removed, Unreleased)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)