### PR TITLE
chore: release 1.13.0 and fix ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
-A large batch of bug fixes and `@internal` hardening accumulated across many
-review rounds, plus several new user-facing features. No public API is removed
-or altered incompatibly — every change is additive, a bug fix, or an internal
-improvement. The per-change detail that previously lived here is preserved in
-the git history of this branch.
+## [1.13.0] — 2026-07-12 — Groundtruth
+
+A precision release: the auditor's picture of the audited codebase now matches
+reality. Route, security, voter, and form parsing report the truth to the
+attacker LLM; the pre-scanner and code slicer recognize the multi-line and
+idiomatic forms of every construct they target; and four new attack surfaces —
+file uploads, Twig extensions, API Platform resources, and Symfony UX Live
+Components — are first-class. On top of that: findings carry CWE references,
+`audit:diff` compares two reports by fingerprint, JUnit and GitHub-annotation
+output formats land, the auditor ships as a standalone native binary, and LLM
+pricing comes from the daily `symfony/models-dev` catalog. No public API is
+removed or altered incompatibly — every change is additive, a bug fix, or an
+internal improvement.
 
 ### Added
 
@@ -27,6 +35,9 @@ the git history of this branch.
   (`external/cwe/cwe-*`).
 - **New `audit:diff` command** compares two JSON reports and reports new, fixed,
   and persisting findings by fingerprint.
+- **Each finding in JSON output now carries its stable `fingerprint`** — the
+  same `SSA-`-prefixed hash that backs baselines and SARIF `partialFingerprints`
+  — so reports can be diffed and findings tracked across runs.
 - **New output formats**: `--format junit` (JUnit XML for CI test panels) and
   `--format github` (GitHub Actions annotations shown inline on a PR's Files
   Changed view).
@@ -1945,6 +1956,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.13.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.13.0
 [1.12.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.12.0
 [1.11.0]:

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ bin/console audit:run --dry-run
   report and exit code so only new findings fail CI.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.12.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.13.0`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **DDD architecture** — strict layering and a sole `LLMClientInterface` seam

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -264,7 +264,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.12.0
+        uses: vinceamstoutz/symfony-security-auditor@1.13.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -139,7 +139,7 @@ deprecated by the other.
   `MINOR`; renaming or removing one is a `MAJOR`. The Marketplace `name`
   (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.12.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.13.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.12.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.13.0/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",

--- a/src/Audit/Application/Agent/Review/ConcurrentReviewAnalyzer.php
+++ b/src/Audit/Application/Agent/Review/ConcurrentReviewAnalyzer.php
@@ -124,10 +124,6 @@ final readonly class ConcurrentReviewAnalyzer
      */
     private function dispatchPending(array $requests, array $pending, CoverageRecorderInterface $coverageRecorder): array
     {
-        if ([] === $requests) {
-            return [];
-        }
-
         $windowSize = max(1, $this->maxConcurrent);
         $requestWindows = array_chunk($requests, $windowSize);
         $pendingWindows = array_chunk($pending, $windowSize);

--- a/src/Audit/Application/Pipeline/Stage/PoCSynthesisStage.php
+++ b/src/Audit/Application/Pipeline/Stage/PoCSynthesisStage.php
@@ -44,7 +44,7 @@ final readonly class PoCSynthesisStage implements StageInterface
             return;
         }
 
-        $validated = array_values($auditContext->validatedVulnerabilities());
+        $validated = $auditContext->validatedVulnerabilities();
 
         if ([] === $validated) {
             $this->logger->info('PoC synthesis: no validated findings to enrich');

--- a/src/Audit/Infrastructure/LLM/PlatformToolsMapper.php
+++ b/src/Audit/Infrastructure/LLM/PlatformToolsMapper.php
@@ -50,7 +50,7 @@ final readonly class PlatformToolsMapper
     /**
      * @param array<string, mixed> $schema
      *
-     * @return JsonSchema
+     * @phpstan-return JsonSchema
      */
     private static function normalizeSchema(array $schema): array
     {

--- a/tests/Phpunit/Unit/Application/Agent/Chunking/FileChunkerTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/Chunking/FileChunkerTest.php
@@ -438,6 +438,25 @@ final class FileChunkerTest extends TestCase
     /**
      * @throws InvalidProjectFileException
      */
+    public function test_feature_strategy_still_chunks_every_later_feature_after_a_feature_emptied_by_a_directory_claim(): void
+    {
+        $files = [
+            $this->makeFile('src/Controller/Order/UserController.php'),
+            $this->makeFile('src/Controller/OrderController.php'),
+            $this->makeFile('src/Controller/ProductController.php'),
+        ];
+
+        $chunks = (new FileChunker(ChunkingStrategy::Feature, 10))->chunk($files);
+
+        self::assertCount(2, $chunks);
+        $productChunk = $this->findChunkContaining($chunks, 'src/Controller/ProductController.php');
+        self::assertNotNull($productChunk);
+        self::assertCount(1, $productChunk);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     */
     public function test_feature_strategy_chunks_later_features_correctly_alongside_prefix_colliding_ones(): void
     {
         $files = [

--- a/tests/Phpunit/Unit/Application/Stage/PoCSynthesisStageTest.php
+++ b/tests/Phpunit/Unit/Application/Stage/PoCSynthesisStageTest.php
@@ -218,6 +218,22 @@ final class PoCSynthesisStageTest extends TestCase
      * @throws InvalidAuditContextException
      * @throws InvalidVulnerabilityNarrativeException
      */
+    public function test_it_does_not_record_count_metadata_when_no_validated_findings(): void
+    {
+        $auditContext = AuditContext::forProject($this->tmpDir);
+        $auditContext->addVulnerability($this->makeVulnerability());
+
+        (new PoCSynthesisStage($this->makeNoopSynthesizer(), new NullLogger(), true))->process($auditContext);
+
+        self::assertNull($auditContext->getMeta('audit.poc_synthesized'));
+    }
+
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
     public function test_it_logs_completion_with_enriched_and_total_counts(): void
     {
         $vulnerability = $this->makeVulnerability()->withReviewerValidation(true);


### PR DESCRIPTION
## Summary

Prepares the **1.13.0 — Groundtruth** release (changelog block, release-theme
intro, new `fingerprint` JSON-key entry, `release:bump` version pins) and
restores the full-suite CI that failed on `main` after #134: the four escaped
Infection mutants are killed by new tests or removed as provably dead code, and
the `@return JsonSchema` docblock stripped by Rector 2.5.6 moves to
`@phpstan-return`.

## Type of change

- [x] Chore

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)