### PR TITLE
chore(tests): detection-quality eval harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,16 +40,17 @@ to detect vulnerabilities and produce structured reports.
 bin/castor up
 ```
 
-| Task                 | Command                                           |
-| -------------------- | ------------------------------------------------- |
-| Install dependencies | `bin/castor up` (runs `docker compose up --wait`) |
-| Stop containers      | `bin/castor down`                                 |
-| Lint (check only)    | `bin/castor lint`                                 |
-| Lint + auto-fix      | `bin/castor lint:fix`                             |
-| Markdown check only  | `bin/castor lint:docs` (fast pre-push check)      |
-| Run PHP tests        | `docker compose exec php vendor/bin/phpunit`      |
-| Run mutation tests   | `docker compose exec php bin/infection`           |
-| Symfony console      | `docker compose exec php bin/console <command>`   |
+| Task                    | Command                                                                     |
+| ----------------------- | --------------------------------------------------------------------------- |
+| Install dependencies    | `bin/castor up` (runs `docker compose up --wait`)                           |
+| Stop containers         | `bin/castor down`                                                           |
+| Lint (check only)       | `bin/castor lint`                                                           |
+| Lint + auto-fix         | `bin/castor lint:fix`                                                       |
+| Markdown check only     | `bin/castor lint:docs` (fast pre-push check)                                |
+| Run PHP tests           | `docker compose exec php vendor/bin/phpunit`                                |
+| Run mutation tests      | `docker compose exec php bin/infection`                                     |
+| Score detection quality | `bin/castor eval` (audits a ground-truth fixture, reports precision/recall) |
+| Symfony console         | `docker compose exec php bin/console <command>`                             |
 
 `bin/castor lint` runs sequentially: Prettier (check) → Markdown lint
 (markdownlint-cli2) → Composer Normalize → PHP CS Fixer → Rector → PHPStan (max,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ the dual-agent loop before you touch code.
 - [Daily Dev Loop](#daily-dev-loop)
 - [Running Tests](#running-tests)
 - [Mutation Testing](#mutation-testing)
+- [Evaluating Detection Quality](#evaluating-detection-quality)
 - [Code Quality](#code-quality)
 - [Writing Tests](#writing-tests)
 - [Common Tasks](#common-tasks)
@@ -118,6 +119,38 @@ killed. Suppression directives (`@infection-ignore-all`,
 `ignoreSourceCodeByRegex`, …) are not allowed — fix the underlying test gap
 instead. See
 [CLAUDE.md → Never Silence Quality Gates](CLAUDE.md#5-never-silence-quality-gates).
+
+## Evaluating Detection Quality
+
+Unit and mutation tests prove the code behaves as written; they say nothing
+about whether the auditor actually _finds vulnerabilities_. The eval harness
+closes that gap: it audits a fixture whose vulnerabilities are known ahead of
+time and scores the run against that ground truth.
+
+```bash
+bin/castor eval
+```
+
+This audits `examples/vulnerable-app` (real LLM calls, so it costs tokens), then
+scores the JSON report against
+[`examples/vulnerable-app/ground-truth.json`](examples/vulnerable-app/ground-truth.json)
+— a manifest of `{"file", "type"}` seeds. Scoring is at `(file, type)`
+granularity: a seed the run reproduced is a true positive, a seed it missed a
+false negative, and a reported finding with no matching seed a false positive
+(so a safe decoy file the auditor flags lowers precision). Precision, recall,
+and F1 are printed overall and per vulnerability class.
+
+Point it at another fixture and gate a run on minimum quality:
+
+```bash
+bin/castor eval --target=path/to/app --ground-truth=path/to/manifest.json \
+    --min-precision=0.8 --min-recall=0.9
+```
+
+The harness lives in [`tools/Eval/`](tools/Eval/) (namespace `Tooling\Eval`) —
+`GroundTruthManifest` loads and validates the manifest, `EvalScorer` computes
+the `EvalReport`. It is a maintainer tool, not part of the shipped bundle, so it
+is excluded from coverage and mutation scope like the rest of `tools/`.
 
 ## Code Quality
 

--- a/castor.php
+++ b/castor.php
@@ -12,6 +12,9 @@
 declare(strict_types=1);
 
 use Castor\Attribute\AsTask;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\EvalReport;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\EvalScorer;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\GroundTruthManifest;
 
 use function Castor\io;
 use function Castor\run;
@@ -64,6 +67,66 @@ function releaseBump(string $version): void
     }
 
     io()->success(sprintf('All version pins now point at %s.', $version));
+}
+
+#[AsTask(name: 'eval', description: 'Audit a ground-truth fixture and score detection precision/recall against its manifest')]
+function evaluate(
+    string $target = 'examples/vulnerable-app',
+    string $groundTruth = 'examples/vulnerable-app/ground-truth.json',
+    float $minPrecision = 0.0,
+    float $minRecall = 0.0,
+): void {
+    $reportPath = sprintf('%s/ssa-eval-%s.json', sys_get_temp_dir(), bin2hex(random_bytes(4)));
+
+    io()->section('Running the auditor against the fixture (uses real LLM calls)');
+    run(sprintf('docker compose exec php bin/console audit:run %s --format=json --output=%s', $target, $reportPath));
+
+    $manifest = GroundTruthManifest::fromFile($groundTruth);
+    $evalReport = (new EvalScorer())->score($manifest, actualFindingsFromReport($reportPath));
+
+    printEvalReport($evalReport);
+
+    if (!$evalReport->meetsThresholds($minPrecision, $minRecall)) {
+        io()->error(sprintf('Below thresholds: precision >= %.2f and recall >= %.2f required.', $minPrecision, $minRecall));
+
+        exit(1);
+    }
+
+    io()->success('Detection quality meets the configured thresholds.');
+}
+
+/**
+ * @return list<array{file: string, type: string}>
+ */
+function actualFindingsFromReport(string $reportPath): array
+{
+    $decoded = json_decode((string) file_get_contents($reportPath), true, flags: \JSON_THROW_ON_ERROR);
+    $vulnerabilities = is_array($decoded) ? ($decoded['vulnerabilities'] ?? []) : [];
+
+    $findings = [];
+    foreach (is_array($vulnerabilities) ? $vulnerabilities : [] as $vulnerability) {
+        if (is_array($vulnerability) && is_string($vulnerability['file'] ?? null) && is_string($vulnerability['type'] ?? null)) {
+            $findings[] = ['file' => $vulnerability['file'], 'type' => $vulnerability['type']];
+        }
+    }
+
+    return $findings;
+}
+
+function printEvalReport(EvalReport $evalReport): void
+{
+    $rows = [];
+    foreach ([$evalReport->overall, ...$evalReport->perClass] as $classScore) {
+        $rows[] = [
+            $classScore->type,
+            sprintf('%.0f%%', $classScore->precision() * 100),
+            sprintf('%.0f%%', $classScore->recall() * 100),
+            sprintf('%.2f', $classScore->f1()),
+            sprintf('%d / %d / %d', $classScore->truePositives, $classScore->falsePositives, $classScore->falseNegatives),
+        ];
+    }
+
+    io()->table(['Class', 'Precision', 'Recall', 'F1', 'TP / FP / FN'], $rows);
 }
 
 #[AsTask(name: 'lint', description: 'Check code style and analyze code')]

--- a/examples/vulnerable-app/ground-truth.json
+++ b/examples/vulnerable-app/ground-truth.json
@@ -1,0 +1,14 @@
+{
+  "findings": [
+    { "file": "src/Controller/SearchController.php", "type": "sql_injection" },
+    {
+      "file": "src/Controller/UserController.php",
+      "type": "insecure_direct_object_reference"
+    },
+    {
+      "file": "src/Controller/UserController.php",
+      "type": "broken_access_control"
+    },
+    { "file": "src/Entity/User.php", "type": "mass_assignment" }
+  ]
+}

--- a/tests/Phpunit/Unit/Tooling/Eval/EvalScorerTest.php
+++ b/tests/Phpunit/Unit/Tooling/Eval/EvalScorerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Tooling\Eval;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\ClassScore;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\EvalScorer;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\ExpectedFinding;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\GroundTruthManifest;
+
+final class EvalScorerTest extends TestCase
+{
+    public function test_a_perfectly_reproduced_manifest_scores_full_precision_and_recall(): void
+    {
+        $groundTruthManifest = new GroundTruthManifest([
+            new ExpectedFinding('src/A.php', 'sql_injection'),
+            new ExpectedFinding('src/B.php', 'broken_access_control'),
+        ]);
+
+        $evalReport = (new EvalScorer())->score($groundTruthManifest, [
+            ['file' => 'src/A.php', 'type' => 'sql_injection'],
+            ['file' => 'src/B.php', 'type' => 'broken_access_control'],
+        ]);
+
+        self::assertSame(1.0, $evalReport->overall->precision());
+        self::assertSame(1.0, $evalReport->overall->recall());
+        self::assertSame(2, $evalReport->overall->truePositives);
+    }
+
+    public function test_a_missed_seed_is_a_false_negative(): void
+    {
+        $groundTruthManifest = new GroundTruthManifest([new ExpectedFinding('src/A.php', 'sql_injection')]);
+
+        $evalReport = (new EvalScorer())->score($groundTruthManifest, []);
+
+        self::assertSame(0, $evalReport->overall->truePositives);
+        self::assertSame(1, $evalReport->overall->falseNegatives);
+        self::assertSame(0.0, $evalReport->overall->recall());
+    }
+
+    public function test_a_finding_in_an_unseeded_decoy_file_is_a_false_positive(): void
+    {
+        $groundTruthManifest = new GroundTruthManifest([new ExpectedFinding('src/A.php', 'sql_injection')]);
+
+        $evalReport = (new EvalScorer())->score($groundTruthManifest, [
+            ['file' => 'src/A.php', 'type' => 'sql_injection'],
+            ['file' => 'src/SafeDecoy.php', 'type' => 'sql_injection'],
+        ]);
+
+        self::assertSame(1, $evalReport->overall->truePositives);
+        self::assertSame(1, $evalReport->overall->falsePositives);
+        self::assertSame(0.5, $evalReport->overall->precision());
+    }
+
+    public function test_a_seed_reported_with_the_wrong_type_is_both_a_miss_and_a_false_positive(): void
+    {
+        $groundTruthManifest = new GroundTruthManifest([new ExpectedFinding('src/A.php', 'sql_injection')]);
+
+        $evalReport = (new EvalScorer())->score($groundTruthManifest, [['file' => 'src/A.php', 'type' => 'xss']]);
+
+        self::assertSame(0, $evalReport->overall->truePositives);
+        self::assertSame(1, $evalReport->overall->falsePositives);
+        self::assertSame(1, $evalReport->overall->falseNegatives);
+        self::assertSame(0.0, $evalReport->overall->f1());
+    }
+
+    public function test_scores_are_broken_down_per_vulnerability_class_sorted_by_type(): void
+    {
+        $groundTruthManifest = new GroundTruthManifest([
+            new ExpectedFinding('src/A.php', 'sql_injection'),
+            new ExpectedFinding('src/B.php', 'broken_access_control'),
+        ]);
+
+        $evalReport = (new EvalScorer())->score($groundTruthManifest, [['file' => 'src/A.php', 'type' => 'sql_injection']]);
+
+        self::assertSame(
+            ['broken_access_control', 'sql_injection'],
+            array_map(static fn (ClassScore $classScore): string => $classScore->type, $evalReport->perClass),
+        );
+        self::assertSame(0.0, $evalReport->perClass[0]->recall());
+        self::assertSame(1.0, $evalReport->perClass[1]->recall());
+    }
+
+    public function test_repeated_findings_of_the_same_type_in_one_file_are_counted_once(): void
+    {
+        $groundTruthManifest = new GroundTruthManifest([new ExpectedFinding('src/A.php', 'sql_injection')]);
+
+        $evalReport = (new EvalScorer())->score($groundTruthManifest, [
+            ['file' => 'src/A.php', 'type' => 'sql_injection'],
+            ['file' => 'src/A.php', 'type' => 'sql_injection'],
+        ]);
+
+        self::assertSame(1, $evalReport->overall->truePositives);
+        self::assertSame(0, $evalReport->overall->falsePositives);
+    }
+
+    public function test_an_empty_manifest_with_no_findings_scores_perfect_by_convention(): void
+    {
+        $evalReport = (new EvalScorer())->score(new GroundTruthManifest([]), []);
+
+        self::assertSame(1.0, $evalReport->overall->precision());
+        self::assertSame(1.0, $evalReport->overall->recall());
+        self::assertTrue($evalReport->meetsThresholds(1.0, 1.0));
+    }
+
+    public function test_meets_thresholds_is_false_when_recall_is_below_the_floor(): void
+    {
+        $groundTruthManifest = new GroundTruthManifest([
+            new ExpectedFinding('src/A.php', 'sql_injection'),
+            new ExpectedFinding('src/B.php', 'xss'),
+        ]);
+
+        $evalReport = (new EvalScorer())->score($groundTruthManifest, [['file' => 'src/A.php', 'type' => 'sql_injection']]);
+
+        self::assertFalse($evalReport->meetsThresholds(0.9, 0.9));
+        self::assertTrue($evalReport->meetsThresholds(1.0, 0.5));
+    }
+
+    public function test_to_array_exposes_overall_and_per_class_scores(): void
+    {
+        $groundTruthManifest = new GroundTruthManifest([new ExpectedFinding('src/A.php', 'sql_injection')]);
+
+        $array = (new EvalScorer())->score($groundTruthManifest, [['file' => 'src/A.php', 'type' => 'sql_injection']])->toArray();
+
+        self::assertSame('overall', $array['overall']['type']);
+        self::assertSame(1, $array['overall']['true_positives']);
+        self::assertCount(1, $array['per_class']);
+        self::assertSame('sql_injection', $array['per_class'][0]['type']);
+    }
+}

--- a/tests/Phpunit/Unit/Tooling/Eval/GroundTruthManifestTest.php
+++ b/tests/Phpunit/Unit/Tooling/Eval/GroundTruthManifestTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Tooling\Eval;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\Exception\InvalidGroundTruthManifestException;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\GroundTruthManifest;
+
+final class GroundTruthManifestTest extends TestCase
+{
+    private Filesystem $filesystem;
+
+    private string $tmpDir;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir().'/ground_truth_test_'.uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
+    /**
+     * @throws InvalidGroundTruthManifestException
+     */
+    public function test_it_loads_the_seeded_findings(): void
+    {
+        $path = $this->write('{"findings":[{"file":"src/A.php","type":"sql_injection"}]}');
+
+        $groundTruthManifest = GroundTruthManifest::fromFile($path);
+
+        self::assertCount(1, $groundTruthManifest->findings);
+        self::assertSame('src/A.php', $groundTruthManifest->findings[0]->file);
+        self::assertSame('sql_injection', $groundTruthManifest->findings[0]->type);
+        self::assertSame('src/A.php::sql_injection', $groundTruthManifest->findings[0]->key());
+    }
+
+    /**
+     * @throws InvalidGroundTruthManifestException
+     */
+    public function test_the_shipped_example_manifest_is_valid(): void
+    {
+        $groundTruthManifest = GroundTruthManifest::fromFile(__DIR__.'/../../../../../examples/vulnerable-app/ground-truth.json');
+
+        self::assertNotEmpty($groundTruthManifest->findings);
+    }
+
+    /**
+     * @throws InvalidGroundTruthManifestException
+     */
+    public function test_a_missing_file_is_rejected(): void
+    {
+        $this->expectException(InvalidGroundTruthManifestException::class);
+        $this->expectExceptionMessage('does not exist or is not readable');
+
+        GroundTruthManifest::fromFile($this->tmpDir.'/absent.json');
+    }
+
+    /**
+     * @throws InvalidGroundTruthManifestException
+     */
+    public function test_invalid_json_is_rejected(): void
+    {
+        $this->expectException(InvalidGroundTruthManifestException::class);
+        $this->expectExceptionMessage('is not valid JSON');
+
+        GroundTruthManifest::fromFile($this->write('{not json'));
+    }
+
+    /**
+     * @throws InvalidGroundTruthManifestException
+     */
+    public function test_a_document_without_a_findings_array_is_rejected(): void
+    {
+        $this->expectException(InvalidGroundTruthManifestException::class);
+        $this->expectExceptionMessage('must be a JSON object with a "findings" array');
+
+        GroundTruthManifest::fromFile($this->write('{"version":1}'));
+    }
+
+    /**
+     * @throws InvalidGroundTruthManifestException
+     */
+    public function test_a_finding_missing_its_type_is_rejected(): void
+    {
+        $this->expectException(InvalidGroundTruthManifestException::class);
+        $this->expectExceptionMessage('index 0');
+
+        GroundTruthManifest::fromFile($this->write('{"findings":[{"file":"src/A.php"}]}'));
+    }
+
+    /**
+     * @throws InvalidGroundTruthManifestException
+     */
+    public function test_a_finding_with_a_blank_file_is_rejected(): void
+    {
+        $this->expectException(InvalidGroundTruthManifestException::class);
+
+        GroundTruthManifest::fromFile($this->write('{"findings":[{"file":"","type":"sql_injection"}]}'));
+    }
+
+    private function write(string $contents): string
+    {
+        $path = $this->tmpDir.'/ground-truth.json';
+        $this->filesystem->dumpFile($path, $contents);
+
+        return $path;
+    }
+}

--- a/tools/Eval/ClassScore.php
+++ b/tools/Eval/ClassScore.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval;
+
+/**
+ * Precision / recall / F1 for one vulnerability class (or the aggregate),
+ * computed from true-positive, false-positive, and false-negative counts.
+ */
+final readonly class ClassScore
+{
+    public function __construct(
+        public string $type,
+        public int $truePositives,
+        public int $falsePositives,
+        public int $falseNegatives,
+    ) {}
+
+    public function precision(): float
+    {
+        $retrieved = $this->truePositives + $this->falsePositives;
+
+        return 0 === $retrieved ? 1.0 : $this->truePositives / $retrieved;
+    }
+
+    public function recall(): float
+    {
+        $relevant = $this->truePositives + $this->falseNegatives;
+
+        return 0 === $relevant ? 1.0 : $this->truePositives / $relevant;
+    }
+
+    public function f1(): float
+    {
+        $precision = $this->precision();
+        $recall = $this->recall();
+
+        return 0.0 === $precision + $recall ? 0.0 : 2 * $precision * $recall / ($precision + $recall);
+    }
+}

--- a/tools/Eval/EvalReport.php
+++ b/tools/Eval/EvalReport.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval;
+
+/**
+ * The outcome of scoring one audit run against its ground-truth manifest: an
+ * aggregate {@see ClassScore} plus one per vulnerability class.
+ */
+final readonly class EvalReport
+{
+    /**
+     * @param list<ClassScore> $perClass
+     */
+    public function __construct(
+        public ClassScore $overall,
+        public array $perClass,
+    ) {}
+
+    public function meetsThresholds(float $minPrecision, float $minRecall): bool
+    {
+        return $this->overall->precision() >= $minPrecision && $this->overall->recall() >= $minRecall;
+    }
+
+    /**
+     * @return array{
+     *     overall: array{type: string, precision: float, recall: float, f1: float, true_positives: int, false_positives: int, false_negatives: int},
+     *     per_class: list<array{type: string, precision: float, recall: float, f1: float, true_positives: int, false_positives: int, false_negatives: int}>
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'overall' => $this->classToArray($this->overall),
+            'per_class' => array_map($this->classToArray(...), $this->perClass),
+        ];
+    }
+
+    /**
+     * @return array{type: string, precision: float, recall: float, f1: float, true_positives: int, false_positives: int, false_negatives: int}
+     */
+    private function classToArray(ClassScore $classScore): array
+    {
+        return [
+            'type' => $classScore->type,
+            'precision' => $classScore->precision(),
+            'recall' => $classScore->recall(),
+            'f1' => $classScore->f1(),
+            'true_positives' => $classScore->truePositives,
+            'false_positives' => $classScore->falsePositives,
+            'false_negatives' => $classScore->falseNegatives,
+        ];
+    }
+}

--- a/tools/Eval/EvalScorer.php
+++ b/tools/Eval/EvalScorer.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval;
+
+/**
+ * Scores an audit run against its ground-truth manifest at (file, type)
+ * granularity: a seeded finding the run reproduced is a true positive, one it
+ * missed a false negative, and a reported finding with no matching seed a
+ * false positive — so safe "decoy" files raise the false-positive count when
+ * the auditor flags them. Precision and recall are reported overall and per
+ * vulnerability class.
+ */
+final readonly class EvalScorer
+{
+    /**
+     * @param list<array{file: string, type: string}> $actualFindings
+     */
+    public function score(GroundTruthManifest $groundTruthManifest, array $actualFindings): EvalReport
+    {
+        $expectedKeys = $this->keyedByType(array_map(
+            static fn (ExpectedFinding $expectedFinding): array => ['file' => $expectedFinding->file, 'type' => $expectedFinding->type],
+            $groundTruthManifest->findings,
+        ));
+        $actualKeys = $this->keyedByType($actualFindings);
+
+        $types = array_values(array_unique([...array_keys($expectedKeys), ...array_keys($actualKeys)]));
+        sort($types);
+
+        $perClass = array_map(
+            fn (string $type): ClassScore => $this->classScore($type, $expectedKeys[$type] ?? [], $actualKeys[$type] ?? []),
+            $types,
+        );
+
+        return new EvalReport($this->aggregate($perClass), $perClass);
+    }
+
+    /**
+     * @param array<string, true> $expected file-keys seeded for this type
+     * @param array<string, true> $actual   file-keys reported for this type
+     */
+    private function classScore(string $type, array $expected, array $actual): ClassScore
+    {
+        $truePositives = \count(array_intersect_key($expected, $actual));
+
+        return new ClassScore(
+            $type,
+            $truePositives,
+            \count($actual) - $truePositives,
+            \count($expected) - $truePositives,
+        );
+    }
+
+    /**
+     * @param list<ClassScore> $perClass
+     */
+    private function aggregate(array $perClass): ClassScore
+    {
+        $truePositives = 0;
+        $falsePositives = 0;
+        $falseNegatives = 0;
+        foreach ($perClass as $classScore) {
+            $truePositives += $classScore->truePositives;
+            $falsePositives += $classScore->falsePositives;
+            $falseNegatives += $classScore->falseNegatives;
+        }
+
+        return new ClassScore('overall', $truePositives, $falsePositives, $falseNegatives);
+    }
+
+    /**
+     * Deduplicates to a set of file-keys per type, so a class is scored as
+     * present-or-absent per file rather than double-counting repeated findings.
+     *
+     * @param list<array{file: string, type: string}> $findings
+     *
+     * @return array<string, array<string, true>>
+     */
+    private function keyedByType(array $findings): array
+    {
+        $byType = [];
+        foreach ($findings as $finding) {
+            $byType[$finding['type']][$finding['file']] = true;
+        }
+
+        return $byType;
+    }
+}

--- a/tools/Eval/Exception/InvalidGroundTruthManifestException.php
+++ b/tools/Eval/Exception/InvalidGroundTruthManifestException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\Exception;
+
+use RuntimeException;
+use Throwable;
+
+final class InvalidGroundTruthManifestException extends RuntimeException
+{
+    public static function forUnreadablePath(string $path): self
+    {
+        return new self(\sprintf('Ground-truth manifest "%s" does not exist or is not readable.', $path));
+    }
+
+    public static function fromJsonException(string $path, Throwable $throwable): self
+    {
+        return new self(\sprintf('Ground-truth manifest "%s" is not valid JSON: %s', $path, $throwable->getMessage()), previous: $throwable);
+    }
+
+    public static function forMissingFindingsArray(string $path): self
+    {
+        return new self(\sprintf('Ground-truth manifest "%s" must be a JSON object with a "findings" array.', $path));
+    }
+
+    public static function forInvalidFinding(string $path, int $index): self
+    {
+        return new self(\sprintf('Ground-truth manifest "%s" has an invalid finding at index %d: "file" and "type" must both be non-empty strings.', $path, $index));
+    }
+}

--- a/tools/Eval/ExpectedFinding.php
+++ b/tools/Eval/ExpectedFinding.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval;
+
+/**
+ * One seeded ground-truth vulnerability the auditor is expected to find,
+ * identified by the file it lives in and its vulnerability type.
+ */
+final readonly class ExpectedFinding
+{
+    public function __construct(
+        public string $file,
+        public string $type,
+    ) {}
+
+    public function key(): string
+    {
+        return \sprintf('%s::%s', $this->file, $this->type);
+    }
+}

--- a/tools/Eval/GroundTruthManifest.php
+++ b/tools/Eval/GroundTruthManifest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval;
+
+use JsonException;
+use VinceAmstoutz\SymfonySecurityAuditor\Tooling\Eval\Exception\InvalidGroundTruthManifestException;
+
+/**
+ * Loads the seeded ground-truth vulnerabilities for an evaluation fixture from
+ * a JSON manifest shaped `{"findings": [{"file": "...", "type": "..."}, ...]}`.
+ */
+final readonly class GroundTruthManifest
+{
+    /**
+     * @param list<ExpectedFinding> $findings
+     */
+    public function __construct(
+        public array $findings,
+    ) {}
+
+    /**
+     * @throws InvalidGroundTruthManifestException
+     */
+    public static function fromFile(string $path): self
+    {
+        if (!is_file($path)) {
+            throw InvalidGroundTruthManifestException::forUnreadablePath($path);
+        }
+
+        $contents = file_get_contents($path);
+        if (false === $contents) {
+            throw InvalidGroundTruthManifestException::forUnreadablePath($path);
+        }
+
+        try {
+            $decoded = json_decode($contents, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw InvalidGroundTruthManifestException::fromJsonException($path, $jsonException);
+        }
+
+        $findings = \is_array($decoded) ? ($decoded['findings'] ?? null) : null;
+        if (!\is_array($findings)) {
+            throw InvalidGroundTruthManifestException::forMissingFindingsArray($path);
+        }
+
+        return new self(self::parseFindings($findings, $path));
+    }
+
+    /**
+     * @param array<array-key, mixed> $findings
+     *
+     * @return list<ExpectedFinding>
+     *
+     * @throws InvalidGroundTruthManifestException
+     */
+    private static function parseFindings(array $findings, string $path): array
+    {
+        $parsed = [];
+        $index = 0;
+        foreach ($findings as $finding) {
+            $file = \is_array($finding) ? ($finding['file'] ?? null) : null;
+            $type = \is_array($finding) ? ($finding['type'] ?? null) : null;
+            if (!\is_string($file) || '' === $file || !\is_string($type) || '' === $type) {
+                throw InvalidGroundTruthManifestException::forInvalidFinding($path, $index);
+            }
+
+            $parsed[] = new ExpectedFinding($file, $type);
+            ++$index;
+        }
+
+        return $parsed;
+    }
+}


### PR DESCRIPTION
## Summary

Unit and mutation tests prove the code behaves as written but say nothing about whether the auditor actually _finds vulnerabilities_. This adds a ground-truth eval harness that closes that gap: `bin/castor eval` audits a fixture whose vulnerabilities are seeded ahead of time and scores the run against that ground truth.

```text
 Class                          Precision  Recall  F1    TP / FP / FN
 overall                        80%        75%     0.77  3 / 1 / 1
 sql_injection                  100%       100%    1.00  1 / 0 / 0
 broken_access_control          100%       100%    1.00  1 / 0 / 0
 …
```

Design:

- **`GroundTruthManifest`** (+ `ExpectedFinding`) loads and validates a `{"findings":[{"file","type"}]}` manifest, rejecting a missing file, malformed JSON, a missing `findings` array, and blank/absent fields with a named `InvalidGroundTruthManifestException`.
- **`EvalScorer`** scores an audit's reported findings against the manifest at `(file, type)` granularity into an `EvalReport` of `ClassScore`s: a reproduced seed is a true positive, a missed seed a false negative, and a reported finding with no matching seed a false positive — so a flagged safe **decoy** file lowers precision. Precision / recall / F1 are reported overall and per vulnerability class; repeated findings of the same class in one file are counted once.
- **New `eval` castor task** runs the auditor against the fixture (real LLM calls) and prints the score table, failing below optional `--min-precision` / `--min-recall` floors so a CI job can gate on detection quality.
- Seeds [`examples/vulnerable-app/ground-truth.json`](../blob/claude/eval-harness-j7d7d6/examples/vulnerable-app/ground-truth.json) for the shipped vulnerable fixture and documents the workflow under a new **Evaluating Detection Quality** section in `CONTRIBUTING.md`.

The harness lives under `tools/Eval/` (`Tooling\Eval`, **autoload-dev**), so it is not part of the distributed bundle and — like the rest of `tools/` — stays outside coverage and mutation source scope. No public API, config keys, or shipped code change; this is pure maintainer tooling (changelog rule exempts it).

## Type of change

- [x] Tests only

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)