### PR TITLE
ci: spc cannot resolve extensions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,11 +41,13 @@ jobs:
       - name: Verify the PHAR was produced
         run: test -s symfony-security-auditor.phar
 
-      - name: Upload the PHAR build input
+      - name: Upload the PHAR build input with its dependency lock
         uses: actions/upload-artifact@v7
         with:
           name: symfony-security-auditor-phar
-          path: symfony-security-auditor.phar
+          path: |
+            symfony-security-auditor.phar
+            composer.lock
           retention-days: 1
           compression-level: 9
 
@@ -97,7 +99,9 @@ jobs:
 
       - name: Resolve the required extensions
         id: extensions
-        run: echo "list=$(./spc dump-extensions . --format=text)" >> "$GITHUB_OUTPUT"
+        run: |
+          list="$(./spc dump-extensions . --format=text)"
+          echo "list=$list" >> "$GITHUB_OUTPUT"
 
       - name: Build the static micro PHP runtime
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #144: the dispatched Release run for 1.13.0 ([29273709309](https://github.com/vinceAmstoutz/symfony-security-auditor/actions/runs/29273709309)) got past job setup — `spc` downloads and the tag checks out — but every binary job then died in `spc dump-extensions .` with `composer.lock load failed`, because `composer.lock` is gitignored so a plain checkout gives spc nothing to resolve the required extension list from. Worse, `echo "list=$(./spc dump-extensions …)"` swallowed that failure and passed the literal error text on as an extension name (`Package 'ext-composer.lock load failed' does not exist`). This PR uploads the `composer.lock` the phar job generates into the same artifact as the phar — so the binary jobs resolve exactly the extension set the phar was built against — and assigns the `dump-extensions` output to a variable first so a failure aborts the step instead of leaking into the extension list. After merging, re-dispatch the Release workflow from `main` with tag `1.13.0` to ship the binaries (#143).

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)