### PR TITLE
ci: pin stable spc and build zlib into the binary runtime

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,9 @@ jobs:
     needs: phar
     permissions:
       contents: write
+    env:
+      SPC_VERSION: '2.8.5'
+
     strategy:
       fail-fast: false
       matrix:
@@ -85,11 +88,17 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - name: Setup static-php-cli
+      - name: Setup static-php-cli (pinned stable release)
         run: |
-          case "${{ matrix.spc }}" in *.exe) out=spc.exe ;; *) out=spc ;; esac
-          curl -fsSL --retry 3 -o "$out" "https://dl.static-php.dev/v3/spc-bin/nightly/${{ matrix.spc }}"
-          chmod +x "$out"
+          case "${{ matrix.spc }}" in
+            *.exe)
+              curl -fsSL --retry 3 -o spc.exe "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/${{ matrix.spc }}"
+              ;;
+            *)
+              curl -fsSL --retry 3 "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/${{ matrix.spc }}.tar.gz" | tar -xz
+              chmod +x spc
+              ;;
+          esac
           ./spc --version
 
       - name: Download the PHAR build input
@@ -97,11 +106,11 @@ jobs:
         with:
           name: symfony-security-auditor-phar
 
-      - name: Resolve the required extensions
+      - name: Resolve the required extensions plus zlib for the gz-compressed PHAR
         id: extensions
         run: |
           list="$(./spc dump-extensions . --format=text)"
-          echo "list=$list" >> "$GITHUB_OUTPUT"
+          echo "list=${list},zlib" >> "$GITHUB_OUTPUT"
 
       - name: Build the static micro PHP runtime
         run: |


### PR DESCRIPTION
## Summary

Third and (per the run evidence) final round of the 1.13.0 binary-release fix. The re-dispatched run ([29274723555](https://github.com/vinceAmstoutz/symfony-security-auditor/actions/runs/29274723555)) cleared extension resolution — #145 works — but exposed two independent failures. First, `dl.static-php.dev`'s nightly channel now serves **static-php-cli v3.0.0-alpha1 (unstable)**, whose Zig toolchain fails `zlib`'s `./configure --static` on the Linux/Windows/macos-14 runners and ignores `--prefer-pre-built`; the workflow now pins the **stable 2.8.5** release binaries from the `crazywhalecc/static-php-cli` GitHub release (`SPC_VERSION` env, one-line bump). Second, the one binary that did build (darwin-x86_64) died at boot with `PharException: zlib extension is required for gz compressed .phar`: `box.json` sets `"compression": "GZ"`, and `spc dump-extensions` resolves only what `composer.lock` declares — it cannot know the phar wrapper itself needs `ext-zlib` — so the resolved extension list now appends `zlib`. After merging, re-dispatch the Release workflow from `main` with tag `1.13.0` (#143).

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)
