### PR TITLE
feat(command): add audit:baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   bidi-override characters, and — exactly as with `--format=json` — error
   messages move to stderr so stdout carries the document alone. See
   [CLI Reference → `audit:trend`](docs/configuration.md#audittrend--tracking-findings-across-reports).
+- **New `audit:baseline` command maintains the accepted-finding baseline from an
+  existing JSON report — no LLM run required.** Accepting a finding used to mean
+  either hand-editing the baseline or re-running a full (paid) audit with
+  `--generate-baseline`, which also overwrites the file and loses hand-written
+  `reason` annotations. `audit:baseline report.json [baseline.json]` merges
+  instead: existing entries are preserved verbatim — reasons survive — and only
+  findings not yet covered by an entry are appended (matching is count-aware and
+  honors `attacker_fingerprint`, the same rules the audit itself applies).
+  `--prune` drops entries whose findings left the report, and `--annotate` asks
+  a reason for each newly accepted finding, feeding the reviewer-teaching
+  feedback loop. See `src/Command/BaselineCommand.php`, the extracted
+  `ReportFindingsLoader` shared with `audit:diff`, and
+  [CLI Reference → `audit:baseline`](docs/configuration.md#auditbaseline--maintaining-the-accepted-finding-baseline).
+
 - **New `audit:trend` command tracks how finding counts evolve across a series
   of reports.** Given two or more JSON reports produced by
   `audit:run --format=json` (ordered oldest to newest), each consecutive pair is

--- a/config/services.php
+++ b/config/services.php
@@ -153,7 +153,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditExitCodeResolverInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditPresenter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditPresenterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Baseline;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineMerger;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineMergerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineProcessor;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineProcessorInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DiffCommand;
@@ -163,6 +166,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Command\FindingTypeFilter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\FindingTypeFilterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDiffer;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDifferInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoaderInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportTrendAnalyzer;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportTrendAnalyzerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportWriter;
@@ -338,6 +343,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $defaultsConfigurator->set(Baseline::class);
     $defaultsConfigurator->alias(BaselineInterface::class, Baseline::class);
 
+    $defaultsConfigurator->set(BaselineMerger::class)
+        ->args([
+            service(ReportFindingsLoaderInterface::class),
+            service(BaselineInterface::class),
+        ]);
+    $defaultsConfigurator->alias(BaselineMergerInterface::class, BaselineMerger::class);
+
     $defaultsConfigurator->set(BaselineProcessor::class)
         ->args([
             service(BaselineInterface::class),
@@ -352,7 +364,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ]);
     $defaultsConfigurator->alias(FindingTypeFilterInterface::class, FindingTypeFilter::class);
 
-    $defaultsConfigurator->set(ReportDiffer::class);
+    $defaultsConfigurator->set(ReportFindingsLoader::class);
+    $defaultsConfigurator->alias(ReportFindingsLoaderInterface::class, ReportFindingsLoader::class);
+
+    $defaultsConfigurator->set(ReportDiffer::class)
+        ->args([
+            service(ReportFindingsLoaderInterface::class),
+        ]);
     $defaultsConfigurator->alias(ReportDifferInterface::class, ReportDiffer::class);
 
     $defaultsConfigurator->set(DiffPresenter::class);
@@ -631,6 +649,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service(ReportDifferInterface::class),
             service(DiffPresenterInterface::class),
+        ])
+        ->tag('console.command');
+
+    $defaultsConfigurator->set(BaselineCommand::class)
+        ->args([
+            service(BaselineMergerInterface::class),
         ])
         ->tag('console.command');
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ bundle registration, bundle-level configuration, platform wiring via
 - [CLI Reference](#cli-reference)
   - [`audit:diff`](#auditdiff--comparing-two-reports)
   - [`audit:trend`](#audittrend--tracking-findings-across-reports)
+  - [`audit:baseline`](#auditbaseline--maintaining-the-accepted-finding-baseline)
 
 > See also: [Architecture](architecture.md) · [Extending](extending.md) ·
 > [CI](ci.md) · [FAQ](faq.md) · [Troubleshooting](troubleshooting.md)
@@ -627,3 +628,37 @@ bin/console audit:trend nightly-*.json --format=html > trend.html
 Exit codes: `0` on a successful trend (regardless of how the counts evolve), `1`
 if fewer than two reports are given or a report file is missing or is not valid
 JSON.
+
+### `audit:baseline` — maintaining the accepted-finding baseline
+
+Creates or updates a baseline file from a JSON report produced by
+`audit:run --format=json`, **without re-running the audit**. Unlike
+`audit:run --generate-baseline` — which needs a fresh (paid) audit run and
+overwrites the file — this command merges: existing entries are preserved
+verbatim, so hand-written `reason` annotations (the ones that teach the
+reviewer, see [`audit.baseline`](#audit--orchestrator-knobs)) survive, and only
+findings not yet covered by an entry are appended.
+
+```bash
+bin/console audit:baseline report.json .security-baseline.json --prune --annotate
+```
+
+| Argument   | Required | Description                                                            |
+| ---------- | -------- | ---------------------------------------------------------------------- |
+| `report`   | yes      | Path to a JSON report produced by `audit:run --format=json`.           |
+| `baseline` | no       | Baseline file to create or update (default `.security-baseline.json`). |
+
+| Option       | Default | Description                                                                        |
+| ------------ | ------- | ---------------------------------------------------------------------------------- |
+| `--prune`    | off     | Drop baseline entries whose findings no longer appear in the report.               |
+| `--annotate` | off     | Ask a reason for each newly accepted finding; reasoned entries teach the reviewer. |
+
+Each appended entry carries `fingerprint`, `type`, `file`, `title`, `added_at`,
+and — when `--annotate` supplied one — `reason`. Matching is count-aware, the
+same rule the audit itself applies: each entry accepts one occurrence, so a
+finding duplicated beyond its accepted count registers as new again. Entries
+whose `attacker_fingerprint` matches a report finding count as covering it.
+
+Exit codes: `0` on success, `1` if the report is missing or malformed, the
+baseline file is malformed, or the baseline path is a symlink (refused, exactly
+as every other writer in this tool refuses symlinked destinations).

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -106,6 +106,9 @@ is a `MAJOR` change.
   output shape (the `points` array), and its exit codes (`0` on a successful
   trend, `1` when fewer than two reports are given or a report file is missing
   or is not valid JSON).
+- The command name `audit:baseline` (see
+  [CLI Reference → `audit:baseline`](configuration.md#auditbaseline--maintaining-the-accepted-finding-baseline)),
+  its arguments, options, and exit codes.
 
 ### Standalone executable & XDG configuration
 

--- a/src/Command/Baseline.php
+++ b/src/Command/Baseline.php
@@ -42,13 +42,32 @@ final readonly class Baseline implements BaselineInterface
     public function load(string $path): array
     {
         $fingerprints = [];
-        foreach ($this->decodeEntries($path) as $entry) {
-            foreach ($this->fingerprintsOf($entry, $path) as $fingerprint) {
+        foreach ($this->entries($path) as $baselineEntry) {
+            foreach ($baselineEntry->fingerprints() as $fingerprint) {
                 $fingerprints[] = $fingerprint;
             }
         }
 
         return $fingerprints;
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     */
+    #[Override]
+    public function entries(string $path): array
+    {
+        $entries = [];
+        foreach ($this->decodeEntries($path) as $entry) {
+            $fingerprint = $this->fingerprintOf($entry, $path);
+            $entries[] = new BaselineEntry(
+                $fingerprint,
+                $this->attackerFingerprintOf($entry),
+                \is_array($entry) ? $entry : $fingerprint,
+            );
+        }
+
+        return $entries;
     }
 
     /**
@@ -121,27 +140,6 @@ final readonly class Baseline implements BaselineInterface
         $value = $entry[$key] ?? null;
 
         return \is_string($value) ? $value : '';
-    }
-
-    /**
-     * A redundant `attacker_fingerprint` equal to its own `fingerprint` (a
-     * hand-edited or merged baseline file could carry one, though the tool's
-     * own writer never produces this — `BaselineProcessor::entryFor()` only
-     * sets it when the two differ) must not grant a count-aware budget of 2
-     * credits for what is really just 1 accepted occurrence.
-     *
-     * @return list<string>
-     *
-     * @throws MalformedBaselineFileException
-     */
-    private function fingerprintsOf(mixed $entry, string $path): array
-    {
-        $fingerprint = $this->fingerprintOf($entry, $path);
-        $attackerFingerprint = $this->attackerFingerprintOf($entry);
-
-        return null !== $attackerFingerprint && $attackerFingerprint !== $fingerprint
-            ? [$fingerprint, $attackerFingerprint]
-            : [$fingerprint];
     }
 
     private function attackerFingerprintOf(mixed $entry): ?string

--- a/src/Command/BaselineCommand.php
+++ b/src/Command/BaselineCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\TerminalTextSanitizer;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedBaselineFileException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedReportFileException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\ReportFileNotReadableException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\UnsafeBaselineWriteException;
+
+use function Symfony\Component\String\u;
+
+#[AsCommand(name: self::NAME, description: self::DESCRIPTION)]
+/** @internal not part of the BC promise — the command *name* (`audit:baseline`) is public, but the PHP class itself is for internal use only. */
+final readonly class BaselineCommand
+{
+    public const string NAME = 'audit:baseline';
+
+    public const string DESCRIPTION = 'Create or update an accepted-finding baseline from a JSON audit report, preserving existing entries and their reasons';
+
+    public function __construct(
+        private BaselineMergerInterface $baselineMerger,
+    ) {}
+
+    public function __invoke(
+        SymfonyStyle $symfonyStyle,
+        #[Argument(description: 'Path to a JSON report produced by audit:run --format=json.', name: 'report')] string $report,
+        #[Argument(description: 'Baseline file to create or update.', name: 'baseline')] string $baseline = '.security-baseline.json',
+        #[Option(description: 'Drop baseline entries whose findings no longer appear in the report.', name: 'prune')] bool $prune = false,
+        #[Option(description: 'Ask a reason for each newly accepted finding; reasoned entries teach the reviewer the mitigating control.', name: 'annotate')] bool $annotate = false,
+    ): int {
+        try {
+            $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, $prune);
+            $this->baselineMerger->commit($baseline, $baselineMergePlan, $annotate ? $this->reasons($symfonyStyle, $baselineMergePlan) : []);
+        } catch (ReportFileNotReadableException|MalformedReportFileException|MalformedBaselineFileException|UnsafeBaselineWriteException $exception) {
+            $symfonyStyle->error($exception->getMessage());
+
+            return ExitCode::Failure->value;
+        }
+
+        $symfonyStyle->success(\sprintf(
+            'Baseline %s: %d added, %d kept, %d pruned (%d entries).',
+            $this->sanitize($baseline),
+            \count($baselineMergePlan->newFindings),
+            \count($baselineMergePlan->keptEntries),
+            $baselineMergePlan->prunedCount,
+            \count($baselineMergePlan->newFindings) + \count($baselineMergePlan->keptEntries),
+        ));
+
+        return ExitCode::Success->value;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function reasons(SymfonyStyle $symfonyStyle, BaselineMergePlan $baselineMergePlan): array
+    {
+        $reasons = [];
+        foreach ($baselineMergePlan->newFindings as $index => $newFinding) {
+            $reason = $symfonyStyle->ask(\sprintf(
+                'Reason for accepting "%s" in %s (leave empty to skip)',
+                $this->sanitize($newFinding->title),
+                $this->sanitize($newFinding->file),
+            ));
+
+            if (\is_string($reason) && !u($reason)->trim()->isEmpty()) {
+                $reasons[$index] = $reason;
+            }
+        }
+
+        return $reasons;
+    }
+
+    /**
+     * Finding titles and file paths originate in the audited project and the
+     * LLM's output, and the baseline path is echoed back verbatim — exactly
+     * as the trend presenter does, each value is collapsed to a single line
+     * and stripped of control/ANSI/bidi characters so a crafted value cannot
+     * spoof the terminal.
+     */
+    private function sanitize(string $value): string
+    {
+        return TerminalTextSanitizer::collapseToSingleLine(mb_scrub($value, 'UTF-8'));
+    }
+}

--- a/src/Command/BaselineEntry.php
+++ b/src/Command/BaselineEntry.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+/**
+ * One entry of a baseline file: its accepted fingerprint(s) plus the raw
+ * decoded payload, preserved verbatim so merging never loses hand-written
+ * keys such as `reason`.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class BaselineEntry
+{
+    /**
+     * @param array<array-key, mixed>|string $raw
+     */
+    public function __construct(
+        public string $fingerprint,
+        public ?string $attackerFingerprint,
+        public array|string $raw,
+    ) {}
+
+    /**
+     * A redundant `attacker_fingerprint` equal to its own `fingerprint` must
+     * not grant a count-aware budget of 2 credits for what is really just 1
+     * accepted occurrence.
+     *
+     * @return list<string>
+     */
+    public function fingerprints(): array
+    {
+        return null !== $this->attackerFingerprint && $this->attackerFingerprint !== $this->fingerprint
+            ? [$this->fingerprint, $this->attackerFingerprint]
+            : [$this->fingerprint];
+    }
+}

--- a/src/Command/BaselineInterface.php
+++ b/src/Command/BaselineInterface.php
@@ -27,6 +27,16 @@ interface BaselineInterface
     public function load(string $path): array;
 
     /**
+     * Loads the entries of a baseline file with their raw decoded payloads
+     * preserved, so a merge can rewrite the file without losing hand-written
+     * keys such as `reason`. A missing file yields an empty list; a malformed
+     * file throws.
+     *
+     * @return list<BaselineEntry>
+     */
+    public function entries(string $path): array;
+
+    /**
      * Loads the maintainer-authored false-positive feedback from a baseline
      * file: every entry annotated with a non-empty `reason`. A missing file —
      * or one whose entries carry no reasons — yields empty feedback; a
@@ -35,11 +45,12 @@ interface BaselineInterface
     public function feedback(string $path): ReviewerFeedback;
 
     /**
-     * @param list<array<string, string>> $entries accepted-finding entries; each
-     *                                             carries at least a `fingerprint`
-     *                                             plus human-readable metadata
-     *                                             (`type`, `file`, `title`,
-     *                                             `added_at`)
+     * @param list<array<array-key, mixed>|string> $entries accepted-finding entries; each
+     *                                                      carries at least a `fingerprint`
+     *                                                      plus human-readable metadata
+     *                                                      (`type`, `file`, `title`,
+     *                                                      `added_at`) — or, for a legacy
+     *                                                      entry, the bare fingerprint string
      */
     public function save(string $path, array $entries): void;
 }

--- a/src/Command/BaselineMergePlan.php
+++ b/src/Command/BaselineMergePlan.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+/**
+ * The outcome of planning a baseline merge: the existing entries to keep
+ * (raw payloads preserved), the report findings not yet covered by any
+ * entry, and how many stale entries a prune dropped.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class BaselineMergePlan
+{
+    /**
+     * @param list<BaselineEntry> $keptEntries
+     * @param list<DiffFinding>   $newFindings
+     */
+    public function __construct(
+        public array $keptEntries,
+        public array $newFindings,
+        public int $prunedCount,
+    ) {}
+}

--- a/src/Command/BaselineMerger.php
+++ b/src/Command/BaselineMerger.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use Override;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
+
+/**
+ * Merges a JSON report's findings into a baseline file without re-running
+ * the audit: existing entries are preserved verbatim — hand-written keys
+ * such as `reason` survive — and only findings not yet covered by an entry
+ * are appended.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class BaselineMerger implements BaselineMergerInterface
+{
+    public function __construct(
+        private ReportFindingsLoaderInterface $reportFindingsLoader,
+        private BaselineInterface $baseline,
+        private ClockInterface $clock = new Clock(),
+    ) {}
+
+    #[Override]
+    public function plan(string $reportPath, string $baselinePath, bool $prune): BaselineMergePlan
+    {
+        $findings = $this->reportFindingsLoader->load($reportPath);
+        $entries = $this->baseline->entries($baselinePath);
+
+        [$keptEntries, $prunedCount] = $prune ? $this->pruned($entries, $findings) : [$entries, 0];
+
+        return new BaselineMergePlan($keptEntries, $this->notCovered($findings, $keptEntries), $prunedCount);
+    }
+
+    #[Override]
+    public function commit(string $baselinePath, BaselineMergePlan $baselineMergePlan, array $reasons): void
+    {
+        $entries = array_map(
+            static fn (BaselineEntry $baselineEntry): array|string => $baselineEntry->raw,
+            $baselineMergePlan->keptEntries,
+        );
+
+        foreach ($baselineMergePlan->newFindings as $index => $newFinding) {
+            $entries[] = $this->entryFor($newFinding, $reasons[$index] ?? null);
+        }
+
+        $this->baseline->save($baselinePath, $entries);
+    }
+
+    /**
+     * @param list<BaselineEntry> $entries
+     * @param list<DiffFinding>   $findings
+     *
+     * @return array{list<BaselineEntry>, int}
+     */
+    private function pruned(array $entries, array $findings): array
+    {
+        $remaining = $this->fingerprintCounts($findings);
+        $keptEntries = [];
+        $prunedCount = 0;
+
+        foreach ($entries as $entry) {
+            $coveringFingerprint = $this->coveringFingerprint($remaining, $entry);
+            if (null === $coveringFingerprint) {
+                ++$prunedCount;
+
+                continue;
+            }
+
+            --$remaining[$coveringFingerprint];
+            $keptEntries[] = $entry;
+        }
+
+        return [$keptEntries, $prunedCount];
+    }
+
+    /**
+     * @param array<string, int> $remaining
+     */
+    private function coveringFingerprint(array $remaining, BaselineEntry $baselineEntry): ?string
+    {
+        foreach ($baselineEntry->fingerprints() as $fingerprint) {
+            if (($remaining[$fingerprint] ?? 0) > 0) {
+                return $fingerprint;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<DiffFinding>   $findings
+     * @param list<BaselineEntry> $keptEntries
+     *
+     * @return list<DiffFinding>
+     */
+    private function notCovered(array $findings, array $keptEntries): array
+    {
+        $credits = [];
+        foreach ($keptEntries as $keptEntry) {
+            foreach ($keptEntry->fingerprints() as $fingerprint) {
+                $credits[$fingerprint] = ($credits[$fingerprint] ?? 0) + 1;
+            }
+        }
+
+        $newFindings = [];
+        foreach ($findings as $finding) {
+            if (($credits[$finding->fingerprint] ?? 0) > 0) {
+                --$credits[$finding->fingerprint];
+
+                continue;
+            }
+
+            $newFindings[] = $finding;
+        }
+
+        return $newFindings;
+    }
+
+    /**
+     * @param list<DiffFinding> $findings
+     *
+     * @return array<string, int>
+     */
+    private function fingerprintCounts(array $findings): array
+    {
+        $counts = [];
+        foreach ($findings as $finding) {
+            $counts[$finding->fingerprint] = ($counts[$finding->fingerprint] ?? 0) + 1;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function entryFor(DiffFinding $diffFinding, ?string $reason): array
+    {
+        $entry = [
+            'fingerprint' => $diffFinding->fingerprint,
+            'type' => $diffFinding->type,
+            'file' => $diffFinding->file,
+            'title' => $diffFinding->title,
+            'added_at' => $this->clock->now()->format('Y-m-d'),
+        ];
+
+        if (null !== $reason) {
+            $entry['reason'] = $reason;
+        }
+
+        return $entry;
+    }
+}

--- a/src/Command/BaselineMerger.php
+++ b/src/Command/BaselineMerger.php
@@ -92,7 +92,7 @@ final readonly class BaselineMerger implements BaselineMergerInterface
     private function coveringFingerprint(array $remaining, BaselineEntry $baselineEntry): ?string
     {
         foreach ($baselineEntry->fingerprints() as $fingerprint) {
-            if (($remaining[$fingerprint] ?? 0) > 0) {
+            if (\array_key_exists($fingerprint, $remaining) && $remaining[$fingerprint] > 0) {
                 return $fingerprint;
             }
         }
@@ -117,7 +117,7 @@ final readonly class BaselineMerger implements BaselineMergerInterface
 
         $newFindings = [];
         foreach ($findings as $finding) {
-            if (($credits[$finding->fingerprint] ?? 0) > 0) {
+            if (\array_key_exists($finding->fingerprint, $credits) && $credits[$finding->fingerprint] > 0) {
                 --$credits[$finding->fingerprint];
 
                 continue;

--- a/src/Command/BaselineMergerInterface.php
+++ b/src/Command/BaselineMergerInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedBaselineFileException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedReportFileException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\ReportFileNotReadableException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\UnsafeBaselineWriteException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface BaselineMergerInterface
+{
+    /**
+     * Plans a merge of a JSON report's findings into a baseline file: which
+     * existing entries stay, which findings are new, and — with `$prune` —
+     * how many stale entries go. Coverage is count-aware: each entry accepts
+     * one occurrence, so a finding duplicated beyond its accepted count is
+     * new again.
+     *
+     * @throws ReportFileNotReadableException
+     * @throws MalformedReportFileException
+     * @throws MalformedBaselineFileException
+     */
+    public function plan(string $reportPath, string $baselinePath, bool $prune): BaselineMergePlan;
+
+    /**
+     * Writes the planned baseline: kept entries verbatim (hand-written keys
+     * such as `reason` survive), then one dated entry per new finding.
+     *
+     * @param array<int, string> $reasons acceptance reason per `newFindings` index
+     *
+     * @throws MalformedBaselineFileException
+     * @throws UnsafeBaselineWriteException
+     */
+    public function commit(string $baselinePath, BaselineMergePlan $baselineMergePlan, array $reasons): void;
+}

--- a/src/Command/ReportDiffer.php
+++ b/src/Command/ReportDiffer.php
@@ -13,124 +13,29 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
-use JsonException;
 use Override;
-use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
-use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedReportFileException;
-use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\ReportFileNotReadableException;
 
 /**
- * Compares two decoded JSON audit reports by finding fingerprint. A report
- * generated before the `fingerprint` key existed is still accepted: its
- * fingerprint is recomputed from `type`, `file`, and `title` with the exact
- * formula {@see Vulnerability::fingerprintOf()} uses, so it never drifts from
- * the canonical identity.
+ * Compares two decoded JSON audit reports by finding fingerprint.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class ReportDiffer implements ReportDifferInterface
 {
     public function __construct(
-        private Filesystem $filesystem = new Filesystem(),
+        private ReportFindingsLoaderInterface $reportFindingsLoader = new ReportFindingsLoader(),
     ) {}
 
     #[Override]
     public function diff(string $previousReportPath, string $currentReportPath): ReportDiff
     {
-        $previousFindings = $this->indexByFingerprint($this->loadFindings($previousReportPath));
-        $currentFindings = $this->indexByFingerprint($this->loadFindings($currentReportPath));
+        $previousFindings = $this->indexByFingerprint($this->reportFindingsLoader->load($previousReportPath));
+        $currentFindings = $this->indexByFingerprint($this->reportFindingsLoader->load($currentReportPath));
 
         return new ReportDiff(
             $this->only($currentFindings, $previousFindings),
             $this->only($previousFindings, $currentFindings),
             $this->intersect($currentFindings, $previousFindings),
-        );
-    }
-
-    /**
-     * @return list<DiffFinding>
-     *
-     * @throws ReportFileNotReadableException
-     * @throws MalformedReportFileException
-     */
-    private function loadFindings(string $path): array
-    {
-        $findings = [];
-        $index = 0;
-        foreach ($this->decodeVulnerabilities($path) as $vulnerability) {
-            if (!\is_array($vulnerability)) {
-                throw MalformedReportFileException::vulnerabilityEntryNotAnObject($path, $index);
-            }
-
-            $findings[] = $this->toDiffFinding($vulnerability, $path, $index);
-            ++$index;
-        }
-
-        return $findings;
-    }
-
-    /**
-     * @return array<array-key, mixed>
-     *
-     * @throws ReportFileNotReadableException
-     * @throws MalformedReportFileException
-     */
-    private function decodeVulnerabilities(string $path): array
-    {
-        if (!$this->filesystem->exists($path)) {
-            throw ReportFileNotReadableException::forPath($path);
-        }
-
-        try {
-            $content = $this->filesystem->readFile($path);
-        } catch (IOException $ioException) {
-            throw ReportFileNotReadableException::forPath($path, $ioException);
-        }
-
-        try {
-            $decoded = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
-        } catch (JsonException $jsonException) {
-            throw MalformedReportFileException::fromJsonException($path, $jsonException);
-        }
-
-        if (!\is_array($decoded)) {
-            throw MalformedReportFileException::missingVulnerabilitiesArray($path);
-        }
-
-        $vulnerabilities = $decoded['vulnerabilities'] ?? null;
-        if (!\is_array($vulnerabilities)) {
-            throw MalformedReportFileException::missingVulnerabilitiesArray($path);
-        }
-
-        return $vulnerabilities;
-    }
-
-    /**
-     * @param array<array-key, mixed> $vulnerability
-     *
-     * @throws MalformedReportFileException
-     */
-    private function toDiffFinding(array $vulnerability, string $path, int $index): DiffFinding
-    {
-        $type = $vulnerability['type'] ?? null;
-        $file = $vulnerability['file'] ?? null;
-        $title = $vulnerability['title'] ?? null;
-        $severity = $vulnerability['severity'] ?? null;
-
-        if (!\is_string($type) || !\is_string($file) || !\is_string($title) || !\is_string($severity)) {
-            throw MalformedReportFileException::invalidVulnerabilityEntry($path, $index);
-        }
-
-        $fingerprint = $vulnerability['fingerprint'] ?? null;
-
-        return new DiffFinding(
-            \is_string($fingerprint) ? $fingerprint : Vulnerability::fingerprintOf($type, $file, $title),
-            $type,
-            $file,
-            $title,
-            $severity,
         );
     }
 

--- a/src/Command/ReportFindingsLoader.php
+++ b/src/Command/ReportFindingsLoader.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use JsonException;
+use Override;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedReportFileException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\ReportFileNotReadableException;
+
+/**
+ * Loads the findings of a JSON audit report. A report generated before the
+ * `fingerprint` key existed is still accepted: its fingerprint is recomputed
+ * from `type`, `file`, and `title` with the exact formula
+ * {@see Vulnerability::fingerprintOf()} uses, so it never drifts from the
+ * canonical identity.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class ReportFindingsLoader implements ReportFindingsLoaderInterface
+{
+    public function __construct(
+        private Filesystem $filesystem = new Filesystem(),
+    ) {}
+
+    #[Override]
+    public function load(string $path): array
+    {
+        $findings = [];
+        $index = 0;
+        foreach ($this->decodeVulnerabilities($path) as $vulnerability) {
+            if (!\is_array($vulnerability)) {
+                throw MalformedReportFileException::vulnerabilityEntryNotAnObject($path, $index);
+            }
+
+            $findings[] = $this->toDiffFinding($vulnerability, $path, $index);
+            ++$index;
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     *
+     * @throws ReportFileNotReadableException
+     * @throws MalformedReportFileException
+     */
+    private function decodeVulnerabilities(string $path): array
+    {
+        if (!$this->filesystem->exists($path)) {
+            throw ReportFileNotReadableException::forPath($path);
+        }
+
+        try {
+            $content = $this->filesystem->readFile($path);
+        } catch (IOException $ioException) {
+            throw ReportFileNotReadableException::forPath($path, $ioException);
+        }
+
+        try {
+            $decoded = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw MalformedReportFileException::fromJsonException($path, $jsonException);
+        }
+
+        if (!\is_array($decoded)) {
+            throw MalformedReportFileException::missingVulnerabilitiesArray($path);
+        }
+
+        $vulnerabilities = $decoded['vulnerabilities'] ?? null;
+        if (!\is_array($vulnerabilities)) {
+            throw MalformedReportFileException::missingVulnerabilitiesArray($path);
+        }
+
+        return $vulnerabilities;
+    }
+
+    /**
+     * @param array<array-key, mixed> $vulnerability
+     *
+     * @throws MalformedReportFileException
+     */
+    private function toDiffFinding(array $vulnerability, string $path, int $index): DiffFinding
+    {
+        $type = $vulnerability['type'] ?? null;
+        $file = $vulnerability['file'] ?? null;
+        $title = $vulnerability['title'] ?? null;
+        $severity = $vulnerability['severity'] ?? null;
+
+        if (!\is_string($type) || !\is_string($file) || !\is_string($title) || !\is_string($severity)) {
+            throw MalformedReportFileException::invalidVulnerabilityEntry($path, $index);
+        }
+
+        $fingerprint = $vulnerability['fingerprint'] ?? null;
+
+        return new DiffFinding(
+            \is_string($fingerprint) ? $fingerprint : Vulnerability::fingerprintOf($type, $file, $title),
+            $type,
+            $file,
+            $title,
+            $severity,
+        );
+    }
+}

--- a/src/Command/ReportFindingsLoaderInterface.php
+++ b/src/Command/ReportFindingsLoaderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedReportFileException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\ReportFileNotReadableException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface ReportFindingsLoaderInterface
+{
+    /**
+     * @return list<DiffFinding>
+     *
+     * @throws ReportFileNotReadableException
+     * @throws MalformedReportFileException
+     */
+    public function load(string $path): array;
+}

--- a/tests/Phpunit/EndToEnd/DiffCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/DiffCommandEndToEndTest.php
@@ -73,6 +73,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Command\DiffCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DiffPresenter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\FindingTypeFilter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDiffer;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportWriter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\UnpricedModelBudgetGuard;
 
@@ -120,7 +121,7 @@ final class DiffCommandEndToEndTest extends TestCase
         $previousReport = $this->runAuditAndCapture('previous.json', [$persistingFinding, $fixedFinding]);
         $currentReport = $this->runAuditAndCapture('current.json', [$persistingFinding, $newFinding]);
 
-        $diffCommandTester = new CommandTester(new DiffCommand(new ReportDiffer($this->filesystem), new DiffPresenter()));
+        $diffCommandTester = new CommandTester(new DiffCommand(new ReportDiffer(new ReportFindingsLoader($this->filesystem)), new DiffPresenter()));
         $diffCommandTester->execute(['previous-report' => $previousReport, 'current-report' => $currentReport]);
 
         self::assertSame(Command::SUCCESS, $diffCommandTester->getStatusCode());
@@ -140,7 +141,7 @@ final class DiffCommandEndToEndTest extends TestCase
         $previousReport = $this->runAuditAndCapture('previous.json', [$this->finding($markupTitle, 'src/View1.php')]);
         $currentReport = $this->runAuditAndCapture('current.json', [$this->finding($markupTitle, 'src/View1.php')]);
 
-        $diffCommandTester = new CommandTester(new DiffCommand(new ReportDiffer($this->filesystem), new DiffPresenter()));
+        $diffCommandTester = new CommandTester(new DiffCommand(new ReportDiffer(new ReportFindingsLoader($this->filesystem)), new DiffPresenter()));
         $diffCommandTester->execute([
             'previous-report' => $previousReport,
             'current-report' => $currentReport,

--- a/tests/Phpunit/Integration/Command/BaselineCommandTest.php
+++ b/tests/Phpunit/Integration/Command/BaselineCommandTest.php
@@ -180,6 +180,58 @@ final class BaselineCommandTest extends TestCase
         );
     }
 
+    public function test_without_prune_a_stale_entry_survives(): void
+    {
+        $report = $this->writeReport([]);
+        $baseline = $this->tmpDir.'/baseline.json';
+        $this->filesystem->dumpFile($baseline, json_encode([
+            [
+                'fingerprint' => $this->fingerprint('Long Fixed'),
+                'type' => 'sql_injection',
+                'file' => 'src/Foo.php',
+                'title' => 'Long Fixed',
+                'added_at' => '2026-07-01',
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $commandTester = $this->commandTester();
+        $commandTester->execute(['report' => $report, 'baseline' => $baseline]);
+
+        self::assertStringContainsString('0 added, 1 kept, 0 pruned (1 entries).', $commandTester->getDisplay());
+    }
+
+    public function test_annotate_records_a_distinct_reason_per_new_finding(): void
+    {
+        $report = $this->writeReport([$this->vulnerability('SQL Injection'), $this->vulnerability('XSS')]);
+        $baseline = $this->tmpDir.'/baseline.json';
+
+        $commandTester = $this->commandTester();
+        $commandTester->setInputs(['bound parameters', 'autoescaped output']);
+        $commandTester->execute(['report' => $report, 'baseline' => $baseline, '--annotate' => true]);
+
+        self::assertSame(
+            [
+                [
+                    'fingerprint' => $this->fingerprint('SQL Injection'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'SQL Injection',
+                    'added_at' => '2026-07-13',
+                    'reason' => 'bound parameters',
+                ],
+                [
+                    'fingerprint' => $this->fingerprint('XSS'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'XSS',
+                    'added_at' => '2026-07-13',
+                    'reason' => 'autoescaped output',
+                ],
+            ],
+            $this->decode($baseline),
+        );
+    }
+
     public function test_a_missing_report_fails_with_a_clear_error(): void
     {
         $commandTester = $this->commandTester();

--- a/tests/Phpunit/Integration/Command/BaselineCommandTest.php
+++ b/tests/Phpunit/Integration/Command/BaselineCommandTest.php
@@ -1,0 +1,254 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Baseline;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineMerger;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
+
+final class BaselineCommandTest extends TestCase
+{
+    private Filesystem $filesystem;
+
+    private string $tmpDir;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir().'/baseline_command_test_'.uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
+    public function test_it_creates_a_baseline_from_a_report(): void
+    {
+        $report = $this->writeReport([$this->vulnerability('SQL Injection')]);
+        $baseline = $this->tmpDir.'/baseline.json';
+
+        $commandTester = $this->commandTester();
+        $commandTester->execute(['report' => $report, 'baseline' => $baseline]);
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        self::assertStringContainsString('1 added, 0 kept, 0 pruned (1 entries).', $commandTester->getDisplay());
+        self::assertSame(
+            [
+                [
+                    'fingerprint' => $this->fingerprint('SQL Injection'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'SQL Injection',
+                    'added_at' => '2026-07-13',
+                ],
+            ],
+            $this->decode($baseline),
+        );
+    }
+
+    public function test_updating_a_baseline_preserves_the_reason_of_an_existing_entry(): void
+    {
+        $report = $this->writeReport([$this->vulnerability('SQL Injection'), $this->vulnerability('XSS')]);
+        $baseline = $this->tmpDir.'/baseline.json';
+        $this->filesystem->dumpFile($baseline, json_encode([
+            [
+                'fingerprint' => $this->fingerprint('SQL Injection'),
+                'type' => 'sql_injection',
+                'file' => 'src/Foo.php',
+                'title' => 'SQL Injection',
+                'added_at' => '2026-07-01',
+                'reason' => 'input is validated upstream',
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $commandTester = $this->commandTester();
+        $commandTester->execute(['report' => $report, 'baseline' => $baseline]);
+
+        self::assertStringContainsString('1 added, 1 kept, 0 pruned (2 entries).', $commandTester->getDisplay());
+        self::assertSame(
+            [
+                [
+                    'fingerprint' => $this->fingerprint('SQL Injection'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'SQL Injection',
+                    'added_at' => '2026-07-01',
+                    'reason' => 'input is validated upstream',
+                ],
+                [
+                    'fingerprint' => $this->fingerprint('XSS'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'XSS',
+                    'added_at' => '2026-07-13',
+                ],
+            ],
+            $this->decode($baseline),
+        );
+    }
+
+    public function test_prune_reports_how_many_stale_entries_were_dropped(): void
+    {
+        $report = $this->writeReport([]);
+        $baseline = $this->tmpDir.'/baseline.json';
+        $this->filesystem->dumpFile($baseline, json_encode([
+            [
+                'fingerprint' => $this->fingerprint('Long Fixed'),
+                'type' => 'sql_injection',
+                'file' => 'src/Foo.php',
+                'title' => 'Long Fixed',
+                'added_at' => '2026-07-01',
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $commandTester = $this->commandTester();
+        $commandTester->execute(['report' => $report, 'baseline' => $baseline, '--prune' => true]);
+
+        self::assertStringContainsString('0 added, 0 kept, 1 pruned (0 entries).', $commandTester->getDisplay());
+        self::assertSame([], $this->decode($baseline));
+    }
+
+    public function test_annotate_asks_a_reason_per_new_finding_and_records_it(): void
+    {
+        $report = $this->writeReport([$this->vulnerability('SQL Injection')]);
+        $baseline = $this->tmpDir.'/baseline.json';
+
+        $commandTester = $this->commandTester();
+        $commandTester->setInputs(['handled by Doctrine parameter binding']);
+        $commandTester->execute(['report' => $report, 'baseline' => $baseline, '--annotate' => true]);
+
+        $display = $commandTester->getDisplay();
+        self::assertStringContainsString('Reason for accepting "SQL Injection" in src/Foo.php', $display);
+        self::assertSame(
+            [
+                [
+                    'fingerprint' => $this->fingerprint('SQL Injection'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'SQL Injection',
+                    'added_at' => '2026-07-13',
+                    'reason' => 'handled by Doctrine parameter binding',
+                ],
+            ],
+            $this->decode($baseline),
+        );
+    }
+
+    public function test_an_empty_annotate_answer_skips_the_reason(): void
+    {
+        $report = $this->writeReport([$this->vulnerability('SQL Injection')]);
+        $baseline = $this->tmpDir.'/baseline.json';
+
+        $commandTester = $this->commandTester();
+        $commandTester->setInputs(['']);
+        $commandTester->execute(['report' => $report, 'baseline' => $baseline, '--annotate' => true]);
+
+        self::assertSame(
+            [
+                [
+                    'fingerprint' => $this->fingerprint('SQL Injection'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'SQL Injection',
+                    'added_at' => '2026-07-13',
+                ],
+            ],
+            $this->decode($baseline),
+        );
+    }
+
+    public function test_a_missing_report_fails_with_a_clear_error(): void
+    {
+        $commandTester = $this->commandTester();
+        $commandTester->execute(['report' => $this->tmpDir.'/absent.json', 'baseline' => $this->tmpDir.'/baseline.json']);
+
+        self::assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        self::assertStringContainsString('exist or is not readable', $commandTester->getDisplay());
+    }
+
+    public function test_a_malformed_baseline_fails_with_a_clear_error(): void
+    {
+        $report = $this->writeReport([]);
+        $baseline = $this->tmpDir.'/baseline.json';
+        $this->filesystem->dumpFile($baseline, '{not json');
+
+        $commandTester = $this->commandTester();
+        $commandTester->execute(['report' => $report, 'baseline' => $baseline]);
+
+        self::assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        self::assertStringContainsString('not valid JSON', $commandTester->getDisplay());
+    }
+
+    /**
+     * @return array{type: string, file: string, title: string, severity: string, fingerprint: string}
+     */
+    private function vulnerability(string $title): array
+    {
+        return [
+            'type' => 'sql_injection',
+            'file' => 'src/Foo.php',
+            'title' => $title,
+            'severity' => 'high',
+            'fingerprint' => $this->fingerprint($title),
+        ];
+    }
+
+    private function fingerprint(string $title): string
+    {
+        return Vulnerability::fingerprintOf('sql_injection', 'src/Foo.php', $title);
+    }
+
+    /**
+     * @param list<array<string, string>> $vulnerabilities
+     */
+    private function writeReport(array $vulnerabilities): string
+    {
+        $path = $this->tmpDir.'/report.json';
+        $this->filesystem->dumpFile($path, json_encode(['vulnerabilities' => $vulnerabilities], \JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+
+    /**
+     * @return array<mixed, mixed>
+     */
+    private function decode(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true, flags: \JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function commandTester(): CommandTester
+    {
+        return new CommandTester(new BaselineCommand(new BaselineMerger(
+            new ReportFindingsLoader($this->filesystem),
+            new Baseline($this->filesystem),
+            new MockClock('2026-07-13 12:00:00'),
+        )));
+    }
+}

--- a/tests/Phpunit/Integration/Command/DiffCommandTest.php
+++ b/tests/Phpunit/Integration/Command/DiffCommandTest.php
@@ -22,6 +22,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DiffCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DiffPresenter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDiffer;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
 
 final class DiffCommandTest extends TestCase
 {
@@ -184,6 +185,6 @@ final class DiffCommandTest extends TestCase
 
     private function commandTester(): CommandTester
     {
-        return new CommandTester(new DiffCommand(new ReportDiffer($this->filesystem), new DiffPresenter()));
+        return new CommandTester(new DiffCommand(new ReportDiffer(new ReportFindingsLoader($this->filesystem)), new DiffPresenter()));
     }
 }

--- a/tests/Phpunit/Integration/Command/TrendCommandTest.php
+++ b/tests/Phpunit/Integration/Command/TrendCommandTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDiffer;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportTrendAnalyzer;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\TrendCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\TrendPresenter;
@@ -189,6 +190,6 @@ final class TrendCommandTest extends TestCase
 
     private function commandTester(): CommandTester
     {
-        return new CommandTester(new TrendCommand(new ReportTrendAnalyzer(new ReportDiffer($this->filesystem)), new TrendPresenter()));
+        return new CommandTester(new TrendCommand(new ReportTrendAnalyzer(new ReportDiffer(new ReportFindingsLoader($this->filesystem))), new TrendPresenter()));
     }
 }

--- a/tests/Phpunit/Unit/Command/BaselineMergerTest.php
+++ b/tests/Phpunit/Unit/Command/BaselineMergerTest.php
@@ -1,0 +1,345 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Baseline;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineMerger;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedBaselineFileException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedReportFileException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\ReportFileNotReadableException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\UnsafeBaselineWriteException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
+
+final class BaselineMergerTest extends TestCase
+{
+    private Filesystem $filesystem;
+
+    private string $tmpDir;
+
+    private BaselineMerger $baselineMerger;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tmpDir = sys_get_temp_dir().'/baseline_merger_test_'.uniqid('', true);
+        $this->filesystem->mkdir($this->tmpDir);
+        $this->baselineMerger = new BaselineMerger(
+            new ReportFindingsLoader($this->filesystem),
+            new Baseline($this->filesystem),
+            new MockClock('2026-07-13 12:00:00'),
+        );
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     */
+    public function test_every_finding_of_a_report_is_new_when_no_baseline_exists(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection'), $this->finding('XSS')]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $this->tmpDir.'/absent.json', false);
+
+        self::assertCount(2, $baselineMergePlan->newFindings);
+        self::assertSame([], $baselineMergePlan->keptEntries);
+        self::assertSame(0, $baselineMergePlan->prunedCount);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     */
+    public function test_a_finding_already_in_the_baseline_is_kept_not_added_again(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection'), $this->finding('XSS')]);
+        $baseline = $this->writeBaseline([$this->baselineEntry('SQL Injection')]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, false);
+
+        self::assertCount(1, $baselineMergePlan->newFindings);
+        self::assertSame('XSS', $baselineMergePlan->newFindings[0]->title);
+        self::assertCount(1, $baselineMergePlan->keptEntries);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     */
+    public function test_coverage_is_count_aware_for_findings_sharing_a_fingerprint(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection'), $this->finding('SQL Injection')]);
+        $baseline = $this->writeBaseline([$this->baselineEntry('SQL Injection')]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, false);
+
+        self::assertCount(1, $baselineMergePlan->newFindings);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     */
+    public function test_an_entry_also_covers_a_finding_through_its_attacker_fingerprint(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection')]);
+        $baseline = $this->writeBaseline([
+            [...$this->baselineEntry('Corrected Title'), 'attacker_fingerprint' => $this->fingerprint('SQL Injection')],
+        ]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, false);
+
+        self::assertSame([], $baselineMergePlan->newFindings);
+        self::assertCount(1, $baselineMergePlan->keptEntries);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     */
+    public function test_a_stale_entry_survives_without_prune(): void
+    {
+        $report = $this->writeReport([]);
+        $baseline = $this->writeBaseline([$this->baselineEntry('Long Fixed')]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, false);
+
+        self::assertCount(1, $baselineMergePlan->keptEntries);
+        self::assertSame(0, $baselineMergePlan->prunedCount);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     */
+    public function test_prune_drops_entries_whose_findings_left_the_report(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection')]);
+        $baseline = $this->writeBaseline([
+            $this->baselineEntry('SQL Injection'),
+            $this->baselineEntry('Long Fixed'),
+        ]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, true);
+
+        self::assertCount(1, $baselineMergePlan->keptEntries);
+        self::assertSame(1, $baselineMergePlan->prunedCount);
+        self::assertSame([], $baselineMergePlan->newFindings);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     */
+    public function test_prune_is_count_aware_for_entries_sharing_a_fingerprint(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection')]);
+        $baseline = $this->writeBaseline([
+            $this->baselineEntry('SQL Injection'),
+            $this->baselineEntry('SQL Injection'),
+        ]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, true);
+
+        self::assertCount(1, $baselineMergePlan->keptEntries);
+        self::assertSame(1, $baselineMergePlan->prunedCount);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     * @throws UnsafeBaselineWriteException
+     */
+    public function test_commit_preserves_kept_entries_verbatim_including_their_reasons(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection'), $this->finding('XSS')]);
+        $baseline = $this->writeBaseline([
+            [...$this->baselineEntry('SQL Injection'), 'reason' => 'input is validated upstream'],
+        ]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, false);
+        $this->baselineMerger->commit($baseline, $baselineMergePlan, []);
+
+        self::assertSame(
+            [
+                [...$this->baselineEntry('SQL Injection'), 'reason' => 'input is validated upstream'],
+                [
+                    'fingerprint' => $this->fingerprint('XSS'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'XSS',
+                    'added_at' => '2026-07-13',
+                ],
+            ],
+            $this->decode($baseline),
+        );
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     * @throws UnsafeBaselineWriteException
+     */
+    public function test_commit_appends_a_dated_entry_for_each_new_finding(): void
+    {
+        $report = $this->writeReport([$this->finding('XSS')]);
+        $baseline = $this->tmpDir.'/baseline.json';
+
+        $this->baselineMerger->commit($baseline, $this->baselineMerger->plan($report, $baseline, false), []);
+
+        self::assertSame(
+            [
+                [
+                    'fingerprint' => $this->fingerprint('XSS'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'XSS',
+                    'added_at' => '2026-07-13',
+                ],
+            ],
+            $this->decode($baseline),
+        );
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     * @throws UnsafeBaselineWriteException
+     */
+    public function test_commit_records_the_reason_given_for_a_new_finding(): void
+    {
+        $report = $this->writeReport([$this->finding('XSS')]);
+        $baseline = $this->tmpDir.'/baseline.json';
+
+        $this->baselineMerger->commit($baseline, $this->baselineMerger->plan($report, $baseline, false), [0 => 'escaped by Twig autoescape']);
+
+        self::assertSame(
+            [
+                [
+                    'fingerprint' => $this->fingerprint('XSS'),
+                    'type' => 'sql_injection',
+                    'file' => 'src/Foo.php',
+                    'title' => 'XSS',
+                    'added_at' => '2026-07-13',
+                    'reason' => 'escaped by Twig autoescape',
+                ],
+            ],
+            $this->decode($baseline),
+        );
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     * @throws UnsafeBaselineWriteException
+     */
+    public function test_commit_preserves_a_legacy_plain_string_entry_as_a_string(): void
+    {
+        $report = $this->writeReport([]);
+        $baseline = $this->tmpDir.'/baseline.json';
+        $this->filesystem->dumpFile($baseline, '["SSA-LEGACY"]');
+
+        $this->baselineMerger->commit($baseline, $this->baselineMerger->plan($report, $baseline, false), []);
+
+        self::assertSame(['SSA-LEGACY'], $this->decode($baseline));
+    }
+
+    /**
+     * @return array{type: string, file: string, title: string, severity: string, fingerprint: string}
+     */
+    private function finding(string $title): array
+    {
+        return [
+            'type' => 'sql_injection',
+            'file' => 'src/Foo.php',
+            'title' => $title,
+            'severity' => 'high',
+            'fingerprint' => $this->fingerprint($title),
+        ];
+    }
+
+    private function fingerprint(string $title): string
+    {
+        return Vulnerability::fingerprintOf('sql_injection', 'src/Foo.php', $title);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function baselineEntry(string $title): array
+    {
+        return [
+            'fingerprint' => $this->fingerprint($title),
+            'type' => 'sql_injection',
+            'file' => 'src/Foo.php',
+            'title' => $title,
+            'added_at' => '2026-07-03',
+        ];
+    }
+
+    /**
+     * @param list<array<string, string>> $vulnerabilities
+     */
+    private function writeReport(array $vulnerabilities): string
+    {
+        $path = $this->tmpDir.'/report.json';
+        $this->filesystem->dumpFile($path, json_encode(['vulnerabilities' => $vulnerabilities], \JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+
+    /**
+     * @param list<array<string, string>> $entries
+     */
+    private function writeBaseline(array $entries): string
+    {
+        $path = $this->tmpDir.'/baseline.json';
+        $this->filesystem->dumpFile($path, json_encode($entries, \JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+
+    /**
+     * @return array<mixed, mixed>
+     */
+    private function decode(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true, flags: \JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/Phpunit/Unit/Command/BaselineMergerTest.php
+++ b/tests/Phpunit/Unit/Command/BaselineMergerTest.php
@@ -178,6 +178,45 @@ final class BaselineMergerTest extends TestCase
      * @throws MalformedBaselineFileException
      * @throws MalformedReportFileException
      * @throws ReportFileNotReadableException
+     */
+    public function test_prune_keeps_entries_that_follow_a_pruned_one(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection')]);
+        $baseline = $this->writeBaseline([
+            $this->baselineEntry('Long Fixed'),
+            $this->baselineEntry('SQL Injection'),
+        ]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, true);
+
+        self::assertCount(1, $baselineMergePlan->keptEntries);
+        self::assertSame($this->fingerprint('SQL Injection'), $baselineMergePlan->keptEntries[0]->fingerprint);
+        self::assertSame(1, $baselineMergePlan->prunedCount);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
+     */
+    public function test_prune_keeps_every_entry_matched_by_a_distinct_finding(): void
+    {
+        $report = $this->writeReport([$this->finding('SQL Injection'), $this->finding('XSS')]);
+        $baseline = $this->writeBaseline([
+            $this->baselineEntry('SQL Injection'),
+            $this->baselineEntry('XSS'),
+        ]);
+
+        $baselineMergePlan = $this->baselineMerger->plan($report, $baseline, true);
+
+        self::assertCount(2, $baselineMergePlan->keptEntries);
+        self::assertSame(0, $baselineMergePlan->prunedCount);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws MalformedReportFileException
+     * @throws ReportFileNotReadableException
      * @throws UnsafeBaselineWriteException
      */
     public function test_commit_preserves_kept_entries_verbatim_including_their_reasons(): void

--- a/tests/Phpunit/Unit/Command/BaselineTest.php
+++ b/tests/Phpunit/Unit/Command/BaselineTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AcceptedFindingFeedback;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Baseline;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\BaselineEntry;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedBaselineFileException;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\UnsafeBaselineWriteException;
 
@@ -372,6 +373,69 @@ final class BaselineTest extends TestCase
         $this->expectException(MalformedBaselineFileException::class);
 
         (new Baseline($this->filesystem))->feedback($path);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     */
+    public function test_entries_returns_an_empty_list_for_a_missing_file(): void
+    {
+        self::assertSame([], (new Baseline($this->filesystem))->entries($this->tmpDir.'/absent.json'));
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws UnsafeBaselineWriteException
+     */
+    public function test_entries_exposes_each_entry_with_its_fingerprint_and_raw_payload(): void
+    {
+        $path = $this->tmpDir.'/baseline.json';
+        $baseline = new Baseline($this->filesystem);
+        $baseline->save($path, [$this->entry('SSA-AAA')]);
+
+        $entries = $baseline->entries($path);
+
+        self::assertCount(1, $entries);
+        self::assertSame('SSA-AAA', $entries[0]->fingerprint);
+        self::assertNull($entries[0]->attackerFingerprint);
+        self::assertSame($this->entry('SSA-AAA'), $entries[0]->raw);
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     * @throws UnsafeBaselineWriteException
+     */
+    public function test_entries_carries_the_attacker_fingerprint_of_a_type_corrected_entry(): void
+    {
+        $path = $this->tmpDir.'/baseline.json';
+        $baseline = new Baseline($this->filesystem);
+        $baseline->save($path, [[...$this->entry('SSA-CORRECTED'), 'attacker_fingerprint' => 'SSA-ORIGINAL']]);
+
+        $entries = $baseline->entries($path);
+
+        self::assertSame(['SSA-CORRECTED', 'SSA-ORIGINAL'], $entries[0]->fingerprints());
+    }
+
+    /**
+     * @throws MalformedBaselineFileException
+     */
+    public function test_entries_preserves_a_legacy_plain_string_entry_as_its_raw_payload(): void
+    {
+        $path = $this->tmpDir.'/baseline.json';
+        $this->filesystem->dumpFile($path, '["SSA-LEGACY"]');
+
+        $entries = (new Baseline($this->filesystem))->entries($path);
+
+        self::assertSame('SSA-LEGACY', $entries[0]->fingerprint);
+        self::assertSame('SSA-LEGACY', $entries[0]->raw);
+        self::assertSame(['SSA-LEGACY'], $entries[0]->fingerprints());
+    }
+
+    public function test_a_baseline_entry_lists_a_redundant_attacker_fingerprint_only_once(): void
+    {
+        $baselineEntry = new BaselineEntry('SSA-SAME', 'SSA-SAME', 'SSA-SAME');
+
+        self::assertSame(['SSA-SAME'], $baselineEntry->fingerprints());
     }
 
     /**

--- a/tests/Phpunit/Unit/Command/ReportDifferTest.php
+++ b/tests/Phpunit/Unit/Command/ReportDifferTest.php
@@ -23,6 +23,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Command\DiffFinding;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedReportFileException;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\ReportFileNotReadableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDiffer;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
 
 final class ReportDifferTest extends TestCase
 {
@@ -53,7 +54,7 @@ final class ReportDifferTest extends TestCase
         $previous = $this->writeReport('previous.json', []);
         $current = $this->writeReport('current.json', [$this->vulnerability('SQL Injection')]);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertCount(1, $reportDiff->newFindings);
         self::assertSame('SQL Injection', $reportDiff->newFindings[0]->title);
@@ -73,7 +74,7 @@ final class ReportDifferTest extends TestCase
             $this->vulnerability('Mass Assignment'),
         ]);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertCount(2, $reportDiff->newFindings);
         $titles = array_map(static fn (DiffFinding $diffFinding): string => $diffFinding->title, $reportDiff->newFindings);
@@ -90,7 +91,7 @@ final class ReportDifferTest extends TestCase
         $previous = $this->writeReport('previous.json', [$this->vulnerability('SQL Injection')]);
         $current = $this->writeReport('current.json', []);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertSame([], $reportDiff->newFindings);
         self::assertCount(1, $reportDiff->fixedFindings);
@@ -108,7 +109,7 @@ final class ReportDifferTest extends TestCase
         $previous = $this->writeReport('previous.json', [$vulnerability]);
         $current = $this->writeReport('current.json', [$vulnerability]);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertSame([], $reportDiff->newFindings);
         self::assertSame([], $reportDiff->fixedFindings);
@@ -126,7 +127,7 @@ final class ReportDifferTest extends TestCase
         $previous = $this->writeReport('previous.json', [$vulnerability]);
         $current = $this->writeReport('current.json', [$vulnerability]);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertSame([], $reportDiff->newFindings);
         self::assertSame([], $reportDiff->fixedFindings);
@@ -141,7 +142,7 @@ final class ReportDifferTest extends TestCase
         $previous = $this->writeReport('previous.json', []);
         $current = $this->writeReport('current.json', []);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertSame([], $reportDiff->newFindings);
         self::assertSame([], $reportDiff->fixedFindings);
@@ -159,7 +160,7 @@ final class ReportDifferTest extends TestCase
         $previous = $this->writeReport('previous.json', [$collidingLow]);
         $current = $this->writeReport('current.json', [$collidingLow, $collidingHigh]);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertCount(1, $reportDiff->newFindings);
         self::assertCount(1, $reportDiff->persistingFindings);
@@ -177,7 +178,7 @@ final class ReportDifferTest extends TestCase
         $previous = $this->writeReport('previous.json', [$collidingLow, $collidingHigh]);
         $current = $this->writeReport('current.json', [$collidingLow]);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertSame([], $reportDiff->newFindings);
         self::assertCount(1, $reportDiff->fixedFindings);
@@ -208,7 +209,7 @@ final class ReportDifferTest extends TestCase
             $this->vulnerability('SQL Injection', 'critical'),
         ]);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertSame(['low', 'medium'], $this->severitiesOf($reportDiff->persistingFindings));
         self::assertSame(['high', 'critical'], $this->severitiesOf($reportDiff->newFindings));
@@ -236,7 +237,7 @@ final class ReportDifferTest extends TestCase
         $previous = $this->writeReport('previous.json', [$vulnerability]);
         $current = $this->writeReport('current.json', [$vulnerability]);
 
-        $reportDiff = (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        $reportDiff = (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
 
         self::assertCount(1, $reportDiff->persistingFindings);
         self::assertSame(
@@ -255,7 +256,7 @@ final class ReportDifferTest extends TestCase
 
         $this->expectException(ReportFileNotReadableException::class);
 
-        (new ReportDiffer($this->filesystem))->diff($this->tmpDir.'/absent.json', $current);
+        (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($this->tmpDir.'/absent.json', $current);
     }
 
     /**
@@ -267,7 +268,7 @@ final class ReportDifferTest extends TestCase
         $current = $this->writeReport('current.json', []);
 
         try {
-            (new ReportDiffer($this->filesystem))->diff($this->tmpDir, $current);
+            (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($this->tmpDir, $current);
             self::fail('Expected a ReportFileNotReadableException for a directory path.');
         } catch (ReportFileNotReadableException $reportFileNotReadableException) {
             self::assertInstanceOf(IOException::class, $reportFileNotReadableException->getPrevious());
@@ -286,7 +287,7 @@ final class ReportDifferTest extends TestCase
 
         $this->expectException(MalformedReportFileException::class);
 
-        (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
     }
 
     /**
@@ -301,7 +302,7 @@ final class ReportDifferTest extends TestCase
 
         $this->expectException(MalformedReportFileException::class);
 
-        (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
     }
 
     /**
@@ -316,7 +317,7 @@ final class ReportDifferTest extends TestCase
 
         $this->expectException(MalformedReportFileException::class);
 
-        (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
     }
 
     /**
@@ -332,7 +333,7 @@ final class ReportDifferTest extends TestCase
         $this->expectException(MalformedReportFileException::class);
         $this->expectExceptionMessage('has a vulnerability entry at index 0 that is not a JSON object');
 
-        (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
     }
 
     /**
@@ -351,7 +352,7 @@ final class ReportDifferTest extends TestCase
         $this->expectException(MalformedReportFileException::class);
         $this->expectExceptionMessage('has a vulnerability entry at index 1 that is not a JSON object');
 
-        (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
     }
 
     /**
@@ -369,7 +370,7 @@ final class ReportDifferTest extends TestCase
 
         $this->expectException(MalformedReportFileException::class);
 
-        (new ReportDiffer($this->filesystem))->diff($previous, $current);
+        (new ReportDiffer(new ReportFindingsLoader($this->filesystem)))->diff($previous, $current);
     }
 
     /**

--- a/tests/Phpunit/Unit/Command/ReportTrendAnalyzerTest.php
+++ b/tests/Phpunit/Unit/Command/ReportTrendAnalyzerTest.php
@@ -21,6 +21,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\InsufficientTrendRepo
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\MalformedReportFileException;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\ReportFileNotReadableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDiffer;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportTrendAnalyzer;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\TrendPoint;
 
@@ -38,7 +39,7 @@ final class ReportTrendAnalyzerTest extends TestCase
         $this->filesystem = new Filesystem();
         $this->tmpDir = sys_get_temp_dir().'/report_trend_analyzer_test_'.uniqid('', true);
         $this->filesystem->mkdir($this->tmpDir);
-        $this->reportTrendAnalyzer = new ReportTrendAnalyzer(new ReportDiffer($this->filesystem));
+        $this->reportTrendAnalyzer = new ReportTrendAnalyzer(new ReportDiffer(new ReportFindingsLoader($this->filesystem)));
     }
 
     #[Override]


### PR DESCRIPTION
## Summary

Adds the `audit:baseline` command: create or update the accepted-finding baseline from an existing `audit:run --format=json` report, **without re-running the audit**. Today accepting a finding means hand-editing the baseline or re-running a full (paid) audit with `--generate-baseline` — which also overwrites the file, losing the hand-written `reason` annotations that feed the reviewer's false-positive feedback. `audit:baseline report.json [baseline.json]` merges instead: existing entries are preserved verbatim (reasons survive), only findings not yet covered by an entry are appended, `--prune` drops entries whose findings left the report, and `--annotate` interactively asks a reason per newly accepted finding. Matching is count-aware and honors `attacker_fingerprint` — the same rules the audit applies. Internally, report parsing moves from `ReportDiffer` into the extracted `ReportFindingsLoader` (shared by `audit:diff`, `audit:trend`, and `audit:baseline`), and `Baseline` gains `entries()` exposing each entry with its fingerprints and raw payload for verbatim round-tripping. Full-file Infection over every touched class: 189/189 mutants killed; suite coverage stays at 100.00%.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)