### PR TITLE
test(eval): expand ground-truth corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ application-level logic flaws they cannot see**.
 Side-by-side comparison with PHPStan, Psalm, Progpilot, Dependabot, and Snyk:
 [FAQ](docs/faq.md#comparisons).
 
+## Detection benchmark
+
+Detection quality is measured against a ground-truth fixture
+([`examples/vulnerable-app`](examples/vulnerable-app)) whose every planted flaw
+is enumerated in a
+[`ground-truth.json`](examples/vulnerable-app/ground-truth.json) manifest — nine
+flaws spanning classic controller bugs and the newer surfaces (file uploads, API
+Platform, Messenger webhooks, Twig extensions, Live Components).
+`bin/castor eval` runs the real auditor against the fixture and scores precision
+(of what it flagged, how much was real) and recall (of the real flaws, how many
+it caught) per vulnerability class. It makes real, paid LLM calls, so it is a
+local, on-demand tool — run it yourself when you want fresh numbers (there is no
+CI job burning tokens on every push):
+
+```bash
+bin/castor up
+ANTHROPIC_API_KEY=… bin/castor eval
+```
+
+| Model             | Precision                           | Recall | Fixture                    |
+| ----------------- | ----------------------------------- | ------ | -------------------------- |
+| `claude-opus-4-8` | _run `bin/castor eval` to populate_ |        | `vulnerable-app` (9 flaws) |
+
+> Scores depend on the model and vary run to run — the LLM is non-deterministic.
+> Treat them as a directional quality signal, not a guarantee.
+
 ## What it does
 
 An adversarial **Attacker** agent hunts for vulnerabilities; a skeptical

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
         PHP_VERSION: "8.3"
     environment:
       COMPOSER_ROOT_VERSION: "1.0.0"
+      # Forwarded from the host so `bin/castor eval` can reach the LLM platform;
+      # empty by default, so ordinary `bin/castor up` needs no key.
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
     command: sleep infinity
     volumes:
       - .:/app

--- a/examples/vulnerable-app/README.md
+++ b/examples/vulnerable-app/README.md
@@ -6,17 +6,27 @@
 > `vinceamstoutz/symfony-security-auditor` against realistic-looking flaws. **Do
 > not deploy it. Do not import any of its source files into a real project.**
 
-A tiny Symfony 7 skeleton with deliberate flaws across four OWASP categories.
-Run the auditor against it and observe the report.
+A tiny Symfony 7 skeleton with deliberate flaws spanning classic controller bugs
+and the newer attack surfaces the auditor learned to recognize (file uploads,
+API Platform resources, Messenger webhook handlers, Twig extensions, and UX Live
+Components). Run the auditor against it and observe the report. The
+[`ground-truth.json`](ground-truth.json) manifest lists the expected findings,
+one per row below, and `bin/castor eval` scores the auditor's detection against
+it.
 
 ## Embedded flaws
 
-| Where                                                | Flaw                                                                         | OWASP                       |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------- |
-| `src/Controller/UserController.php::deleteAction()`  | Missing `#[IsGranted]` / no `denyAccessUnlessGranted()` on a `DELETE` route. | A01 — Broken Access Control |
-| `src/Controller/UserController.php::showAction()`    | Direct object reference (`$id` from URL → `find()`) with no ownership check. | A01 — Broken Access Control |
-| `src/Controller/SearchController.php::queryAction()` | Raw `$request->get('q')` concatenated into a DQL/SQL string.                 | A03 — Injection             |
-| `src/Entity/User.php::fromRequest()`                 | Mass-assigning every request field, including `isAdmin`, into the entity.    | A04 — Insecure Design       |
+| Where                                                       | Flaw                                                                                                   | OWASP                         |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| `src/Controller/UserController.php::deleteAction()`         | Missing `#[IsGranted]` / no `denyAccessUnlessGranted()` on a `DELETE` route.                           | A01 — Broken Access Control   |
+| `src/Controller/UserController.php::showAction()`           | Direct object reference (`$id` from URL → `find()`) with no ownership check.                           | A01 — Broken Access Control   |
+| `src/Controller/SearchController.php::queryAction()`        | Raw `$request->get('q')` concatenated into a DQL/SQL string.                                           | A03 — Injection               |
+| `src/Entity/User.php::fromRequest()`                        | Mass-assigning every request field, including `isAdmin`, into the entity.                              | A04 — Insecure Design         |
+| `src/Controller/AvatarUploadController.php::uploadAction()` | Client filename trusted for the extension check and destination path — upload lands under the docroot. | A04 — Insecure Design         |
+| `src/Api/Invoice.php`                                       | API Platform resource with no `security` and every property serialized, including `costPrice`.         | A01 — Broken Access Control   |
+| `src/Messenger/GitHubWebhookHandler.php`                    | Webhook handler acts on the payload with no HMAC signature check or replay de-duplication.             | A08 — Data Integrity Failures |
+| `src/Twig/MarkupExtension.php`                              | Filter declared `is_safe => ['html']` echoes caller input verbatim, disabling autoescaping.            | A03 — Injection (XSS)         |
+| `src/Twig/Components/UserCard.php::promote()`               | `#[LiveAction]` promotes to admin with no `#[IsGranted]` and trusts a client-writable `LiveProp`.      | A01 — Broken Access Control   |
 
 ## Running the auditor against it
 
@@ -31,7 +41,7 @@ Expected outcome:
 
 - Exit code **1** (risk level `CRITICAL` once the controller findings are
   validated).
-- Report lists ≈ 4 findings, one per row of the table above. Severity and
+- Report lists ≈ 9 findings, one per row of the table above. Severity and
   wording vary by model.
 
 To try a different provider, edit

--- a/examples/vulnerable-app/ground-truth.json
+++ b/examples/vulnerable-app/ground-truth.json
@@ -9,6 +9,23 @@
       "file": "src/Controller/UserController.php",
       "type": "broken_access_control"
     },
-    { "file": "src/Entity/User.php", "type": "mass_assignment" }
+    { "file": "src/Entity/User.php", "type": "mass_assignment" },
+    {
+      "file": "src/Controller/AvatarUploadController.php",
+      "type": "path_traversal"
+    },
+    {
+      "file": "src/Api/Invoice.php",
+      "type": "over_permissive_serializer_group"
+    },
+    {
+      "file": "src/Messenger/GitHubWebhookHandler.php",
+      "type": "webhook_replay"
+    },
+    { "file": "src/Twig/MarkupExtension.php", "type": "twig_injection" },
+    {
+      "file": "src/Twig/Components/UserCard.php",
+      "type": "broken_access_control"
+    }
   ]
 }

--- a/examples/vulnerable-app/src/Api/Invoice.php
+++ b/examples/vulnerable-app/src/Api/Invoice.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Api;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+
+// INTENTIONALLY VULNERABLE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+
+// VULN: over-permissive serializer group / broken object-level authorization —
+// the resource exposes a collection endpoint with no `security` attribute and
+// serializes every property, including the internal `costPrice` and the owning
+// customer's identifier, to any caller. A real fix scopes a normalization group
+// to the public fields and adds `security: "is_granted('VIEW', object)"`.
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+    ],
+)]
+final class Invoice
+{
+    public int $id = 0;
+
+    public string $reference = '';
+
+    public int $amountDue = 0;
+
+    public int $costPrice = 0;
+
+    public int $customerId = 0;
+}

--- a/examples/vulnerable-app/src/Controller/AvatarUploadController.php
+++ b/examples/vulnerable-app/src/Controller/AvatarUploadController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+// INTENTIONALLY VULNERABLE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+final class AvatarUploadController extends AbstractController
+{
+    // VULN: unrestricted file upload — the client-supplied original filename
+    // is trusted for both the extension check and the destination path, so an
+    // attacker uploads `avatar.php` (or `../../public/shell.php`) and the file
+    // lands under the web root, executable. A real fix validates the MIME type
+    // server-side, generates a random basename, and stores outside the docroot.
+    #[Route('/account/avatar', name: 'avatar_upload', methods: ['POST'])]
+    public function uploadAction(Request $request): JsonResponse
+    {
+        $file = $request->files->get('avatar');
+        $name = $file->getClientOriginalName();
+
+        $file->move($this->getParameter('kernel.project_dir').'/public/uploads', $name);
+
+        return new JsonResponse(['stored' => '/uploads/'.$name]);
+    }
+}

--- a/examples/vulnerable-app/src/Message/GitHubWebhookReceived.php
+++ b/examples/vulnerable-app/src/Message/GitHubWebhookReceived.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+// INTENTIONALLY VULNERABLE FIXTURE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+final readonly class GitHubWebhookReceived
+{
+    public function __construct(
+        public string $event,
+        public string $repository,
+        public string $deliveryId,
+    ) {}
+}

--- a/examples/vulnerable-app/src/Messenger/GitHubWebhookHandler.php
+++ b/examples/vulnerable-app/src/Messenger/GitHubWebhookHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Messenger;
+
+use App\Message\GitHubWebhookReceived;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+// INTENTIONALLY VULNERABLE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+#[AsMessageHandler]
+final class GitHubWebhookHandler
+{
+    // VULN: missing webhook signature verification / no replay protection — the
+    // handler acts on the payload without ever checking the `X-Hub-Signature`
+    // HMAC or de-duplicating the delivery id, so anyone who learns the endpoint
+    // can forge or replay a deploy event. A real fix verifies the signature with
+    // `hash_equals()` and records the delivery id to reject replays.
+    public function __invoke(GitHubWebhookReceived $message): void
+    {
+        if ('push' === $message->event) {
+            $this->triggerDeploy($message->repository);
+        }
+    }
+
+    private function triggerDeploy(string $repository): void
+    {
+        // deploy $repository …
+    }
+}

--- a/examples/vulnerable-app/src/Twig/Components/UserCard.php
+++ b/examples/vulnerable-app/src/Twig/Components/UserCard.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+
+// INTENTIONALLY VULNERABLE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+#[AsLiveComponent]
+final class UserCard
+{
+    #[LiveProp(writable: true)]
+    public int $userId = 0;
+
+    public function __construct(private readonly EntityManagerInterface $entityManager) {}
+
+    // VULN: unauthenticated live action / broken access control — `#[LiveAction]`
+    // methods are HTTP endpoints, yet this one promotes any user to admin with no
+    // `#[IsGranted]` check and trusts the client-writable `$userId` LiveProp. Any
+    // visitor can POST the component action and escalate privileges. A real fix
+    // guards the action with `#[IsGranted('ROLE_ADMIN')]` and never derives the
+    // target from a writable prop.
+    #[LiveAction]
+    public function promote(): void
+    {
+        $user = $this->entityManager->getRepository(User::class)->find($this->userId);
+        $user->roles[] = 'ROLE_ADMIN';
+        $this->entityManager->flush();
+    }
+}

--- a/examples/vulnerable-app/src/Twig/MarkupExtension.php
+++ b/examples/vulnerable-app/src/Twig/MarkupExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+// INTENTIONALLY VULNERABLE — for demonstrating symfony-security-auditor.
+// Do not deploy. Do not copy any of this into a real codebase.
+final class MarkupExtension extends AbstractExtension
+{
+    /**
+     * @return list<TwigFilter>
+     */
+    public function getFilters(): array
+    {
+        return [
+            // VULN: cross-site scripting via a filter declared
+            // `is_safe => ['html']` while echoing caller-supplied input
+            // verbatim. Marking output safe tells Twig to skip autoescaping, so
+            // `{{ userBio|render_markup }}` injects unescaped attacker HTML. A
+            // real fix drops `is_safe` (let Twig escape) or sanitizes with an
+            // allow-list before returning.
+            new TwigFilter('render_markup', $this->renderMarkup(...), ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function renderMarkup(string $value): string
+    {
+        return '<div class="markup">'.$value.'</div>';
+    }
+}


### PR DESCRIPTION
## Summary

The eval fixture covered four classic controller flaws, but the auditor has since learned five newer attack surfaces with no ground-truth coverage. This adds one intentionally-vulnerable fixture per surface — an unrestricted avatar upload (`path_traversal`), an unsecured API Platform resource (`over_permissive_serializer_group`), a signature-less Messenger webhook handler (`webhook_replay`), an `is_safe: html` Twig filter (`twig_injection`), and an unauthenticated Live Component `#[LiveAction]` (`broken_access_control`) — and enumerates all nine flaws in `ground-truth.json` so `bin/castor eval` scores detection across the modern attack surface. Adds a README **Detection benchmark** section pointing at the fixture.

**`bin/castor eval` is a local, on-demand tool — there is deliberately no CI job.** Scoring runs the real auditor and makes paid LLM calls, so it's something you run yourself when you want fresh numbers; nothing in CI spends tokens on every push. `docker-compose.yml` forwards `ANTHROPIC_API_KEY` into the container so a local run can reach the provider. The benchmark table ships with a placeholder cell — the LLM is non-deterministic, so real precision/recall numbers come from running `bin/castor eval` locally.

Fixtures live under `examples/`, which is excluded from PHP CS Fixer and PHPStan, so this is a docs/tooling change with no bearing on the code gates (no CHANGELOG entry per the changelog rule's docs/CI/tooling exemption). Rebased onto current `main`.

## Type of change

- [x] Tests only

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — eval fixtures + manifest
- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)