### PR TITLE
ci: drop PHP-core extensions from the resolved spc build list

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,8 +109,15 @@ jobs:
       - name: Resolve the required extensions plus zlib for the gz-compressed PHAR
         id: extensions
         run: |
-          list="$(./spc dump-extensions . --format=text)"
-          echo "list=${list},zlib" >> "$GITHUB_OUTPUT"
+          # `spc dump-extensions` scans source usage and emits always-compiled
+          # PHP core extensions (date, …) that `spc download`/`build` reject as
+          # non-buildable packages; drop them, then append zlib for the
+          # GZ-compressed PHAR wrapper (box.json `compression: GZ`).
+          raw="$(./spc dump-extensions . --format=text)"
+          filtered="$(printf '%s' "$raw" | tr ',' '\n' \
+            | grep -vxE 'core|standard|date|hash|json|pcre|spl|reflection|random|zlib' \
+            | paste -sd, -)"
+          echo "list=${filtered},zlib" >> "$GITHUB_OUTPUT"
 
       - name: Build the static micro PHP runtime
         run: |


### PR DESCRIPTION
## Summary

Next layer of the 1.13.0 binary-release fix. Run [29276771446](https://github.com/vinceAmstoutz/symfony-security-auditor/actions/runs/29276771446) (with the pinned stable spc + zlib fix from #147) now aborts every binary job at `spc download --for-extensions` with `Extension [date] not exist!`. `spc dump-extensions` scans the source for extension usage and emits always-compiled PHP-core extensions — `date`, `hash`, `json`, `pcre`, … — that stable spc 2.8.5 has no separate package for and refuses to download or build. The v3 nightly silently filtered these, which is why earlier runs cleared resolution. This strips the known core extensions from the resolved list before appending `zlib`, so only genuinely buildable extensions reach spc. Verified the filter pipeline locally against a representative `dump-extensions` list (drops `date`/`hash`/`json`/`pcre`, keeps `ctype`/`curl`/`dom`/`mbstring`/`phar`/…). After merging, re-dispatch the Release workflow from `main` with tag `1.13.0` (#143).

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)
