### PR TITLE
ci: run spc doctor --auto-fix before building the binary runtime

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,9 @@ jobs:
           esac
           ./spc --version
 
+      - name: Prepare the build environment (installs pkg-config, autoconf, …)
+        run: ./spc doctor --auto-fix
+
       - name: Download the PHAR build input
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary

Next layer of the 1.13.0 binary-release fix. With #150 merged, run [29278778243](https://github.com/vinceAmstoutz/symfony-security-auditor/actions/runs/29278778243) clears extension resolution **and** source download (`Download complete`), then every binary job aborts at `Cannot find pkg-config executable. Please run doctor to fix this.` Downloading the raw `spc` binary skips the build-environment setup the (nonexistent) `setup-spc` action would have performed — `spc` compiles its dependencies from source and needs `pkg-config`, `autoconf`, and friends on the runner. This adds `spc doctor --auto-fix` — spc's own environment-preparation command — before the build; the `[W] Please run spc doctor first to verify your build environment` warning spc printed on every prior run pointed straight at it. After merging, re-dispatch the Release workflow from `main` with tag `1.13.0` (#143).

## Type of change

- [x] Bug fix

## Checklist

- [ ] Tests added or updated (unit + integration where applicable) — n/a, CI workflow only
- [x] All checks pass: `bin/castor lint`
- [ ] 100% MSI maintained: `docker compose exec php bin/infection` — n/a, no PHP change
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)