### PR TITLE
ci: target the release tag explicitly when attaching binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,6 +149,10 @@ jobs:
       - name: Attach the binary and checksum to the release
         uses: softprops/action-gh-release@v3
         with:
+          # A release event carries its own tag context; a workflow_dispatch
+          # rebuild does not, so target the tag explicitly (the input on
+          # dispatch, the pushed tag on a release event).
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: |
             ${{ matrix.asset }}
             ${{ matrix.asset }}.sha256


### PR DESCRIPTION
## Summary

The last step of the 1.13.0 binary-release fix. With the `spc doctor` toolchain fix (#151) merged, run [29284473655](https://github.com/vinceAmstoutz/symfony-security-auditor/actions/runs/29284473655) **builds every binary successfully**, smoke-tests it (`symfony-security-auditor 1.13.0`), and generates its `.sha256` — then fails only at the upload with `⚠️ GitHub Releases requires a tag`. `softprops/action-gh-release` infers the target release from the event context, which exists on a `release: published` run but **not** on the `workflow_dispatch` rebuild used to repair an already-published release. This passes `tag_name` explicitly — the dispatch `inputs.tag` when present, else the pushed tag (`github.ref_name`) on a release event — so both paths attach to the right release. After merging, re-dispatch the Release workflow from `main` with tag `1.13.0`; this should finally publish the five binaries + `.sha256` files and close #143.

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)