### PR TITLE
ci: authenticate spc pre-built downloads 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,6 +123,11 @@ jobs:
           echo "list=${filtered},zlib" >> "$GITHUB_OUTPUT"
 
       - name: Build the static micro PHP runtime
+        env:
+          # Authenticate spc's --prefer-pre-built queries to the GitHub API
+          # (static-php-cli-hosted/releases); the unauthenticated 60-req/hour
+          # limit intermittently 403s a subset of the matrix.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./spc download --for-extensions="${{ steps.extensions.outputs.list }}" --with-php=8.3 --prefer-pre-built
           ./spc build "${{ steps.extensions.outputs.list }}" --build-micro
@@ -153,6 +158,10 @@ jobs:
           # rebuild does not, so target the tag explicitly (the input on
           # dispatch, the pushed tag on a release event).
           tag_name: ${{ inputs.tag || github.ref_name }}
+          # Replace an asset of the same name instead of erroring or
+          # accumulating duplicates when the workflow is re-dispatched to
+          # repair a partially-published release.
+          overwrite_files: true
           files: |
             ${{ matrix.asset }}
             ${{ matrix.asset }}.sha256


### PR DESCRIPTION
## Summary

With #152 merged, the Release run finally attaches binaries — run [29286746095](https://github.com/vinceAmstoutz/symfony-security-auditor/actions/runs/29286746095) published Linux x86_64/aarch64 and macOS Intel (6 assets) — but two jobs still go red and re-dispatches risk asset churn. Two fixes:

1. **Flaky `curl: (56) 403` on windows + darwin-arm64.** `spc download --prefer-pre-built` queries `static-php/static-php-cli-hosted/releases` on the GitHub API **unauthenticated** (60 req/hour); across the six-job matrix a subset trips the limit non-deterministically. Passing the job's `GITHUB_TOKEN` moves spc onto the 5000/hour authenticated quota.
2. **Asset duplication across re-dispatches.** The attach step didn't pin `overwrite_files`, so repairing a partially-published release relied on the action default. Setting `overwrite_files: true` makes re-runs replace same-named assets rather than accumulate or 422.

After merging, one more dispatch of the Release workflow (tag `1.13.0`) should publish all five platforms cleanly and close #143. (The release currently holds 3 of 5 platforms from the prior run; `overwrite_files` makes the final run idempotent over them.)

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)