### PR TITLE
ci: tolerate spc doctor's Windows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,17 @@ jobs:
           ./spc --version
 
       - name: Prepare the build environment (installs pkg-config, autoconf, …)
-        run: ./spc doctor --auto-fix
+        run: |
+          # On Unix runners doctor installs the missing toolchain (pkg-config,
+          # autoconf) and must pass. On Windows its VS-2019/2022 probe is a
+          # false negative on the current runner image — which does ship VS
+          # 2022 with the C++ tools — and hard-fails with "can not be fixed",
+          # so there tolerate the report and let the build use the runner's VS.
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            ./spc doctor --auto-fix || echo "spc doctor flagged Windows (VS detection); continuing — the runner provides VS 2022"
+          else
+            ./spc doctor --auto-fix
+          fi
 
       - name: Download the PHAR build input
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

After #153, four of the five platforms build and attach cleanly — only the Windows job fails, and no longer at download: `spc doctor --auto-fix` aborts with `Visual Studio not installed, please install VS 2022/2019. This check item can not be fixed !`. GitHub's `windows-latest` image **does** ship Visual Studio 2022 with the C++ build tools; spc 2.8.5 predates the current runner image and its VS-detection probe returns a false negative, then exits non-zero and kills the job. `doctor` was added (in #151) to install `pkg-config`/`autoconf` on the **Unix** runners, so this keeps it strict there and, on Windows only, lets the report through so the build proceeds against the runner's real VS toolchain. If the Windows build then hits a genuine VS gap downstream, the next run will surface it concretely rather than pre-failing on detection.

After merging, re-dispatch the Release workflow (tag `1.13.0`); the run should complete all five platforms and, with `overwrite_files` from #153, leave a clean set of 10 assets — closing #143.

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)