### PR TITLE
ci: make the Windows binary non-blocking

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,6 +111,11 @@ jobs:
           ./spc --version
 
       - name: Prepare the build environment (installs pkg-config, autoconf, …)
+        env:
+          # doctor --auto-fix downloads pkg-config from the GitHub API too;
+          # authenticate it for the same reason the build step is (avoid the
+          # unauthenticated 60-req/hour limit intermittently 403-ing the fix).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # On Unix runners doctor installs the missing toolchain (pkg-config,
           # autoconf) and must pass. On Windows its VS-2019/2022 probe is a

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,14 @@ jobs:
     needs: phar
     permissions:
       contents: write
+    # The Windows leg is best-effort: static-php-cli 2.8.5 (the latest stable)
+    # crashes building php-src on Windows in its own libxml patch hook
+    # (SourcePatcher::patchPhpLibxml212 reads main/php_version.h before it
+    # exists — https://github.com/crazywhalecc/static-php-cli/issues). Until a
+    # fixed spc ships, let that one leg fail without failing the release, so the
+    # four working platforms still publish; the Windows asset attaches
+    # automatically once spc is fixed.
+    continue-on-error: ${{ matrix.experimental || false }}
     env:
       SPC_VERSION: '2.8.5'
 
@@ -79,6 +87,7 @@ jobs:
           - runner: windows-latest
             asset: symfony-security-auditor-windows-x86_64.exe
             spc: spc-windows-x64.exe
+            experimental: true
     defaults:
       run:
         shell: bash

--- a/README.md
+++ b/README.md
@@ -104,13 +104,18 @@ irm https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/mai
 Or download the binary for your platform straight from the
 [latest release](https://github.com/vinceAmstoutz/symfony-security-auditor/releases/latest):
 
-| Platform            | Asset                                         |
-| ------------------- | --------------------------------------------- |
-| Linux x86-64        | `symfony-security-auditor-linux-x86_64`       |
-| Linux arm64         | `symfony-security-auditor-linux-aarch64`      |
-| macOS Intel         | `symfony-security-auditor-darwin-x86_64`      |
-| macOS Apple Silicon | `symfony-security-auditor-darwin-arm64`       |
-| Windows x86-64      | `symfony-security-auditor-windows-x86_64.exe` |
+| Platform            | Asset                                           |
+| ------------------- | ----------------------------------------------- |
+| Linux x86-64        | `symfony-security-auditor-linux-x86_64`         |
+| Linux arm64         | `symfony-security-auditor-linux-aarch64`        |
+| macOS Intel         | `symfony-security-auditor-darwin-x86_64`        |
+| macOS Apple Silicon | `symfony-security-auditor-darwin-arm64`         |
+| Windows x86-64      | `symfony-security-auditor-windows-x86_64.exe` ¹ |
+
+¹ A native Windows binary is temporarily unavailable pending an upstream
+static-php-cli fix. On Windows, use the
+[Symfony bundle](#use-it-as-a-symfony-bundle) via Composer, or run the Linux
+installer inside WSL, until it returns.
 
 Every binary ships with a `.sha256` checksum, and the install scripts **abort**
 rather than install a binary they cannot verify. To check a manual download

--- a/install.ps1
+++ b/install.ps1
@@ -61,7 +61,25 @@ function Install-Binary {
     New-Item -ItemType Directory -Path $tmp | Out-Null
     try {
         Write-Host "Downloading $asset ($Version)…"
-        Get-Asset "$base/$asset" "$tmp\$asset"
+        try {
+            Get-Asset "$base/$asset" "$tmp\$asset"
+        }
+        catch [System.Net.WebException] {
+            $status = [int]$_.Exception.Response.StatusCode
+            if ($status -eq 404) {
+                throw @"
+No Windows binary is published for this release yet.
+
+A native Windows build is not currently available (tracked upstream in
+static-php-cli). In the meantime, run the auditor on Windows via:
+  - Composer:  composer require --dev $Repo   (as a Symfony bundle, needs PHP 8.3+)
+  - WSL:       run the Linux installer inside WSL
+
+See https://github.com/$Repo/releases for available assets.
+"@
+            }
+            throw
+        }
         Get-Asset "$base/$asset.sha256" "$tmp\$asset.sha256"
         Test-Checksum "$tmp\$asset" "$tmp\$asset.sha256"
 


### PR DESCRIPTION
## Summary

The four Unix binaries build and publish cleanly, and #154 got Windows **past** spc's doctor — but the Windows build now hits a **bug inside static-php-cli 2.8.5 itself** (the latest stable, so nothing to bump to): building php-src on Windows, `SourcePatcher::patchPhpLibxml212` reads `main/php_version.h` before it exists and `preg_match()` throws `TypeError: Argument #2 ($subject) must be of type string, false given`. spc prints *"Please report this exception to static-php-cli/issues."*

Per the maintainer's call, this makes the Windows leg **best-effort** rather than blocking:

- `continue-on-error: ${{ matrix.experimental || false }}` on the binary job, with `experimental: true` only on the Windows matrix entry. The four working platforms publish and the run goes green; the Windows asset will attach automatically once a fixed spc ships.
- `install.ps1` turns the resulting 404 into a clear message pointing Windows users at the Composer bundle or WSL instead of a raw download error.
- The README download table footnotes Windows as temporarily unavailable with the same guidance.

After merging, re-dispatching the Release (tag `1.13.0`) publishes the four Unix binaries + `.sha256` (8 assets) and completes with success. This resolves the user-facing part of #143 (the `curl | sh` Linux/macOS install works); the Windows binary is tracked separately pending the upstream spc fix.

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)