### PR TITLE
ci: from darwin to macOS binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,10 +79,10 @@ jobs:
             asset: symfony-security-auditor-linux-aarch64
             spc: spc-linux-aarch64
           - runner: macos-15-intel
-            asset: symfony-security-auditor-darwin-x86_64
+            asset: symfony-security-auditor-macos-x86_64
             spc: spc-macos-x86_64
           - runner: macos-14
-            asset: symfony-security-auditor-darwin-arm64
+            asset: symfony-security-auditor-macos-arm64
             spc: spc-macos-aarch64
           - runner: windows-latest
             asset: symfony-security-auditor-windows-x86_64.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   alerts by) plus a `cvssV4_0Vector` property. This is an estimate for
   triage/dashboards, not an analyst-scored vector.
 
+### Changed
+
+- **Standalone macOS binaries are now named `…-macos-…` instead of
+  `…-darwin-…`.** The download assets and the `install.sh` OS detection use
+  `symfony-security-auditor-macos-x86_64` / `-macos-arm64`, matching the
+  human-facing "macOS" labels in the README and the platform name users expect
+  (`darwin` is the kernel name). `install.sh` selects the new name
+  automatically; anyone hardcoding a download URL should switch `darwin` →
+  `macos`. Linux and Windows asset names are unchanged. See
+  [`docs/versioning.md`](docs/versioning.md).
+
 ## [1.13.0] — 2026-07-12 — Groundtruth
 
 A precision release: the auditor's picture of the audited codebase now matches

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Or download the binary for your platform straight from the
 | ------------------- | ----------------------------------------------- |
 | Linux x86-64        | `symfony-security-auditor-linux-x86_64`         |
 | Linux arm64         | `symfony-security-auditor-linux-aarch64`        |
-| macOS Intel         | `symfony-security-auditor-darwin-x86_64`        |
-| macOS Apple Silicon | `symfony-security-auditor-darwin-arm64`         |
+| macOS Intel         | `symfony-security-auditor-macos-x86_64`         |
+| macOS Apple Silicon | `symfony-security-auditor-macos-arm64`          |
 | Windows x86-64      | `symfony-security-auditor-windows-x86_64.exe` ¹ |
 
 ¹ A native Windows binary is temporarily unavailable pending an upstream

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -113,7 +113,7 @@ The standalone tool is a supported install method alongside the bundle, and the
 following surface is BC-protected:
 
 - The published per-platform binary assets and their release-asset names
-  (`symfony-security-auditor-{linux-x86_64,linux-aarch64,darwin-x86_64,darwin-arm64}`
+  (`symfony-security-auditor-{linux-x86_64,linux-aarch64,macos-x86_64,macos-arm64}`
   and `symfony-security-auditor-windows-x86_64.exe`), each accompanied by a
   `.sha256` checksum, plus the `install.sh` (Linux/macOS) and `install.ps1`
   (Windows) installer contracts and their `SSA_VERSION` / `SSA_INSTALL_DIR`

--- a/install.sh
+++ b/install.sh
@@ -36,13 +36,13 @@ detect_asset() {
 
   case "$os" in
     Linux) os_slug="linux" ;;
-    Darwin) os_slug="darwin" ;;
+    Darwin) os_slug="macos" ;;
     *) fail "unsupported OS '$os' — on Windows download symfony-security-auditor-windows-x86_64.exe from the releases page" ;;
   esac
 
   case "$arch" in
     x86_64 | amd64) arch_slug="x86_64" ;;
-    aarch64 | arm64) [ "$os_slug" = "darwin" ] && arch_slug="arm64" || arch_slug="aarch64" ;;
+    aarch64 | arm64) [ "$os_slug" = "macos" ] && arch_slug="arm64" || arch_slug="aarch64" ;;
     *) fail "unsupported architecture '$arch'" ;;
   esac
 

--- a/tests/Shell/install_script_test.sh
+++ b/tests/Shell/install_script_test.sh
@@ -53,9 +53,9 @@ assert_asset Linux x86_64 symfony-security-auditor-linux-x86_64
 assert_asset Linux amd64 symfony-security-auditor-linux-x86_64
 assert_asset Linux aarch64 symfony-security-auditor-linux-aarch64
 assert_asset Linux arm64 symfony-security-auditor-linux-aarch64
-assert_asset Darwin x86_64 symfony-security-auditor-darwin-x86_64
-assert_asset Darwin arm64 symfony-security-auditor-darwin-arm64
-assert_asset Darwin aarch64 symfony-security-auditor-darwin-arm64
+assert_asset Darwin x86_64 symfony-security-auditor-macos-x86_64
+assert_asset Darwin arm64 symfony-security-auditor-macos-arm64
+assert_asset Darwin aarch64 symfony-security-auditor-macos-arm64
 
 FAKE_OS=Windows_NT FAKE_ARCH=x86_64
 expect_failure "detect_asset rejects an unsupported OS" detect_asset


### PR DESCRIPTION
## Summary

The release attaches the macOS binaries as `symfony-security-auditor-darwin-{x86_64,arm64}`, but `darwin` is the kernel name — users look for `macos`, which is also how the README download table labels them. This renames the artifacts to `symfony-security-auditor-macos-x86_64` / `-macos-arm64` across every place they're referenced:

- release matrix `asset` names (`.github/workflows/release.yaml`);
- `install.sh` OS detection — `uname -s` still returns `Darwin` and now maps to a `macos` slug, so detection is unchanged for users;
- the `install_script_test.sh` expectations (run locally, green);
- the asset list in `docs/versioning.md`;
- the README download table.

Linux and Windows asset names are unchanged. `install.sh` picks the new name automatically; a `CHANGELOG` **Changed** entry notes that anyone hardcoding a download URL should switch `darwin` → `macos`.

Note: since the 1.13.0 release already carries `darwin`-named macOS assets from earlier repair runs, after this merges I'll re-dispatch the Release (tag `1.13.0`) to publish the `macos`-named assets and delete the stale `darwin`-named ones so the release isn't left with both.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — install-script shell test updated
- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)