### PR TITLE
ci: prune stale release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -189,3 +189,48 @@ jobs:
           files: |
             ${{ matrix.asset }}
             ${{ matrix.asset }}.sha256
+
+  prune:
+    name: Prune stale release assets
+    runs-on: ubuntu-latest
+    needs: binary
+    permissions:
+      contents: write
+    steps:
+      - name: Delete release assets no longer produced by the build matrix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          # Assets this release should carry — keep in sync with the binary
+          # matrix above. Any other asset under our own name prefix (e.g. a
+          # binary from a since-renamed platform slug like the old `darwin-*`)
+          # is an orphan left behind by overwrite_files and gets pruned, so a
+          # rebuild after a rename/removal self-heals instead of accumulating
+          # duplicates.
+          keep='
+          symfony-security-auditor-linux-x86_64
+          symfony-security-auditor-linux-aarch64
+          symfony-security-auditor-macos-x86_64
+          symfony-security-auditor-macos-arm64
+          symfony-security-auditor-windows-x86_64.exe
+          '
+          allow=""
+          for name in $keep; do
+            allow="${allow} ${name} ${name}.sha256"
+          done
+
+          gh release view "$TAG" --json assets --jq '.assets[].name' | while IFS= read -r asset; do
+            case "$asset" in
+              symfony-security-auditor-*) ;;
+              *) continue ;;
+            esac
+            case " $allow " in
+              *" $asset "*) ;;
+              *)
+                echo "Pruning stale asset: $asset"
+                gh release delete-asset "$TAG" "$asset" --yes
+                ;;
+            esac
+          done


### PR DESCRIPTION
## Summary

Renaming a matrix asset (like the `darwin` → `macos` rename in #158) leaves the old-named binaries behind on the release: `softprops/action-gh-release` overwrites *same-named* assets but never removes ones the matrix no longer produces, so 1.13.0 currently carries both `darwin-*` and `macos-*` macOS binaries (the duplication reported). This adds a final **`prune`** job that runs after the binary matrix and deletes any asset under the `symfony-security-auditor-` prefix not in the current keep-list (the five platform binaries + their `.sha256`), via `gh` with the Actions token. A rebuild after any rename or platform removal now self-heals instead of accumulating orphans; the prefix guard means it never touches unrelated release attachments.

After merging, re-dispatching the Release (tag `1.13.0`) will publish the current matrix and prune the leftover `darwin-arm64` / `darwin-x86_64` (+ `.sha256`) assets, leaving a clean 8-asset set (linux + macos, each + `.sha256`; Windows still non-blocking).

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)