### PR TITLE
chore: release 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.14.0] — 2026-07-14 — Beacon
+
+A release about sharper signals in and more actionable output out. External SAST
+results now feed the attacker through SARIF import, and projects can teach it
+new attack surfaces from configuration alone — no PHP required. On the way out,
+every finding carries a heuristic CVSS v4.0 score for triage, findings at or
+above the configured floor gain a suggested-fix patch, and `audit:trend` renders
+a self-contained HTML dashboard. Baselines get smarter too: their `reason`
+annotations now coach the reviewer, and the new `audit:baseline` command
+maintains them from a report without spending a token. The standalone macOS
+binaries ship under the clearer `macos` name, and the standalone `init` command
+now installs the correct provider bridge for every platform and stays writable
+in non-root containers via the new `SYMFONY_SECURITY_AUDITOR_HOME` override.
+
 ### Added
 
 - **`audit:trend` can now render its timeline as a self-contained HTML
@@ -2101,6 +2115,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.14.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.14.0
 [1.13.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.13.0
 [1.12.0]:

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ bin/console audit:run --dry-run
   report and exit code so only new findings fail CI.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.13.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.14.0`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **DDD architecture** — strict layering and a sole `LLMClientInterface` seam

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -264,7 +264,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.13.0
+        uses: vinceamstoutz/symfony-security-auditor@1.14.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -149,7 +149,7 @@ deprecated by the other.
   `MINOR`; renaming or removing one is a `MAJOR`. The Marketplace `name`
   (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.13.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.14.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.13.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.14.0/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",


### PR DESCRIPTION
## Summary

Prepares the **1.14.0 — Beacon** release (MINOR: all additive features + one non-breaking asset rename; no public API removed). Follows the documented release process:

- `CHANGELOG.md`: renamed `## [Unreleased]` → `## [1.14.0] — 2026-07-14 — Beacon` with a release-theme intro, recreated an empty `## [Unreleased]`, and added the `[1.14.0]` link reference.
- Version pins bumped `1.13.0` → `1.14.0` (the `release:bump` set): config-schema `$id` in `resources/schema.json`, and the GitHub Action `uses:` examples in `README.md`, `docs/ci.md`, `docs/versioning.md`. (The `Release Guard` workflow re-checks these against the tag on push.)

**Rebuilt on top of current `main`** so it integrates the two most recently merged PRs — #161 (the `init` fixes: correct provider-bridge resolution and the `SYMFONY_SECURITY_AUDITOR_HOME` config-home override) and #163 (setup-node bump). #161's user-facing entries are folded into the `[1.14.0]` changelog section (Added + Fixed). MCP server mode (#162) is intentionally **excluded** — it is not merged and ships in a later release.

Merge this, then tag `1.14.0` to trigger the Release workflow (which now reliably ships the Linux + macOS binaries; Windows remains best-effort pending the upstream spc fix).

## Type of change

- [x] Documentation _(release chore: changelog + version pins)_

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)