### PR TITLE
fix(standalone): correct bridge resolution and config-home override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   alerts by) plus a `cvssV4_0Vector` property. This is an estimate for
   triage/dashboards, not an analyst-scored vector.
 
+- **New `SYMFONY_SECURITY_AUDITOR_HOME` environment variable redirects the
+  standalone binary's config, cache, and bridge directories.** Container base
+  images that export `XDG_CONFIG_HOME` to a root-owned path (Caddy and
+  FrankenPHP both set it to `/config`) made `symfony-security-auditor init` fail
+  with `mkdir(): Permission denied` for a non-root user, with no way to point it
+  elsewhere. Setting `SYMFONY_SECURITY_AUDITOR_HOME` to a writable directory now
+  overrides the base location — it outranks the XDG variables and `$HOME`, so
+  `$SYMFONY_SECURITY_AUDITOR_HOME/.config`, `/.cache`, and `/.local/share`
+  become the roots. Resolution lives in
+  `XdgConfigPathResolver::fromEnvironment()`; see
+  [Standalone Configuration](docs/configuration.md#standalone-configuration).
+
 ### Changed
 
 - **Standalone macOS binaries are now named `…-macos-…` instead of
@@ -116,6 +128,32 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   automatically; anyone hardcoding a download URL should switch `darwin` →
   `macos`. Linux and Windows asset names are unchanged. See
   [`docs/versioning.md`](docs/versioning.md).
+
+### Fixed
+
+- **`symfony-security-auditor init` now installs the correct provider bridge for
+  platforms whose package slug is hyphenated.** The `symfony/ai` platform
+  _config_ key `openai` maps to the composer package
+  `symfony/ai-open-ai-platform` (note the hyphens), but `init` built the package
+  name straight from the config key and ran
+  `composer require symfony/ai-openai-platform`, which does not exist — so
+  choosing `openai` (as the prompt suggests) failed, and the `open-ai`
+  workaround wrote a `platform: open-ai` key `symfony/ai` then rejects.
+  `ComposerBridgeInstaller` now maps the config key to the package slug
+  (`openai` → `open-ai`, `deepseek` → `deep-seek`, `vertexai` → `vertex-ai`,
+  `openresponses` → `open-responses`, `huggingface` → `hugging-face`,
+  `elevenlabs` → `eleven-labs`, `amazeeai` → `amazee-ai`), so the config key the
+  audit needs and the package `init` installs finally agree.
+- **`init` no longer proposes an invalid API-key variable for hyphenated
+  provider names.** Deriving the default from a name like `open-ai` produced
+  `OPEN-AI_API_KEY`, which the shell rejects (`-` is not a valid identifier
+  character). `InitCommand` now strips non-alphanumeric characters when deriving
+  the default, yielding `OPENAI_API_KEY`.
+- **Config-write failures now tell you how to recover.** When `init` cannot
+  create the config file (e.g. a read-only or root-owned XDG directory in a
+  container), `StandaloneConfigWriteException` now names the
+  `SYMFONY_SECURITY_AUDITOR_HOME` override alongside the underlying error
+  instead of only reporting `mkdir(): Permission denied`.
 
 ## [1.13.0] — 2026-07-12 — Groundtruth
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -425,6 +425,19 @@ uses the native app-data directories:
 > uses `git`, so those tools must be present on the host when you use those
 > features (the audit itself needs only the binary).
 
+**Redirecting the base directory (`SYMFONY_SECURITY_AUDITOR_HOME`).** Some
+container base images export `XDG_CONFIG_HOME` to a root-owned path — Caddy and
+FrankenPHP set it to `/config`, for example — so a non-root user running `init`
+there hits `mkdir(): Permission denied`. Set `SYMFONY_SECURITY_AUDITOR_HOME` to
+any writable directory to override where the config, cache, and bridge
+directories live; it outranks the XDG variables and `$HOME`, giving `~/.config`,
+`~/.cache`, and `~/.local/share` beneath it:
+
+```bash
+SYMFONY_SECURITY_AUDITOR_HOME=/app/var/ssa symfony-security-auditor init
+# → /app/var/ssa/.config/symfony-security-auditor/config.yaml
+```
+
 Run `symfony-security-auditor init` to generate the file interactively and fetch
 the provider bridge. The file is **rootless** — the same keys as the bundle
 configuration above, without the `symfony_security_auditor:` wrapper — plus two

--- a/src/Audit/Infrastructure/Bridge/ComposerBridgeInstaller.php
+++ b/src/Audit/Infrastructure/Bridge/ComposerBridgeInstaller.php
@@ -22,15 +22,32 @@ use Symfony\Component\Process\Process;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\Exception\BridgeInstallationFailedException;
 
 /**
- * Installs a `symfony/ai-<provider>-platform` bridge into a writable directory
- * via `composer require`. The same convention applies to every provider, so
- * there is no per-provider branching.
+ * Installs a `symfony/ai-<slug>-platform` bridge into a writable directory via
+ * `composer require`. The provider name is the `symfony/ai` platform *config*
+ * key (`openai`, `deepseek`, …); a handful of packages spell that key with
+ * hyphens (`symfony/ai-open-ai-platform` for the `openai` platform), so those
+ * are mapped to their package slug before the package name is built.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class ComposerBridgeInstaller implements BridgeInstallerInterface
 {
     private const string PACKAGE_TEMPLATE = 'symfony/ai-%s-platform';
+
+    /**
+     * Platform config keys whose bridge package slug is hyphenated.
+     *
+     * @var array<string, string>
+     */
+    private const array PACKAGE_SLUG_OVERRIDES = [
+        'openai' => 'open-ai',
+        'openresponses' => 'open-responses',
+        'deepseek' => 'deep-seek',
+        'vertexai' => 'vertex-ai',
+        'huggingface' => 'hugging-face',
+        'elevenlabs' => 'eleven-labs',
+        'amazeeai' => 'amazee-ai',
+    ];
 
     private const string MANIFEST_FILENAME = 'composer.json';
 
@@ -65,7 +82,7 @@ final readonly class ComposerBridgeInstaller implements BridgeInstallerInterface
     {
         $this->ensureComposerProject($targetDirectory);
 
-        $package = \sprintf(self::PACKAGE_TEMPLATE, $provider);
+        $package = \sprintf(self::PACKAGE_TEMPLATE, self::PACKAGE_SLUG_OVERRIDES[$provider] ?? $provider);
         $process = ($this->processBuilder)($package, $targetDirectory);
 
         try {

--- a/src/Audit/Infrastructure/Config/Exception/StandaloneConfigWriteException.php
+++ b/src/Audit/Infrastructure/Config/Exception/StandaloneConfigWriteException.php
@@ -15,12 +15,21 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Excep
 
 use RuntimeException;
 use Symfony\Component\Filesystem\Exception\IOException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 
 /** @internal not part of the BC promise — see docs/versioning.md */
 final class StandaloneConfigWriteException extends RuntimeException
 {
     public static function fromIOException(string $configFile, IOException $ioException): self
     {
-        return new self(\sprintf('Failed to write configuration to "%s": %s', $configFile, $ioException->getMessage()), previous: $ioException);
+        return new self(
+            \sprintf(
+                'Failed to write configuration to "%s": %s. If this location is not writable (e.g. a read-only or root-owned XDG directory inside a container), set the %s environment variable to a writable directory and retry.',
+                $configFile,
+                $ioException->getMessage(),
+                XdgConfigPathResolver::HOME_OVERRIDE_VARIABLE,
+            ),
+            previous: $ioException,
+        );
     }
 }

--- a/src/Audit/Infrastructure/Config/XdgConfigPathResolver.php
+++ b/src/Audit/Infrastructure/Config/XdgConfigPathResolver.php
@@ -24,17 +24,25 @@ final readonly class XdgConfigPathResolver
 
     private const string CONFIG_FILENAME = 'config.yaml';
 
+    public const string HOME_OVERRIDE_VARIABLE = 'SYMFONY_SECURITY_AUDITOR_HOME';
+
     public function __construct(
         private ?string $xdgConfigHome,
         private ?string $xdgCacheHome,
         private ?string $home,
         private ?string $xdgDataHome = null,
+        private ?string $applicationHome = null,
     ) {}
 
     /**
-     * XDG variables always win; on Windows the base directories fall back to the
-     * native `%APPDATA%` (config) and `%LOCALAPPDATA%` (cache/data) locations,
-     * with `%USERPROFILE%` as the home, since Windows has no `$HOME`/XDG dirs.
+     * `SYMFONY_SECURITY_AUDITOR_HOME` is a tool-specific home that outranks the
+     * XDG variables and `$HOME`, so a container whose base image hijacks
+     * `XDG_CONFIG_HOME` to a root-owned directory (e.g. Caddy/FrankenPHP's
+     * `/config`) can still redirect the config, cache, and bridge dirs to a
+     * writable location. XDG variables win over the OS home; on Windows the
+     * base directories fall back to the native `%APPDATA%` (config) and
+     * `%LOCALAPPDATA%` (cache/data) locations, with `%USERPROFILE%` as the
+     * home, since Windows has no `$HOME`/XDG dirs.
      *
      * @param array<string, string> $environment
      */
@@ -47,6 +55,7 @@ final readonly class XdgConfigPathResolver
             $environment['XDG_CACHE_HOME'] ?? ($windows ? ($environment['LOCALAPPDATA'] ?? null) : null),
             $environment['HOME'] ?? ($windows ? ($environment['USERPROFILE'] ?? null) : null),
             $environment['XDG_DATA_HOME'] ?? ($windows ? ($environment['LOCALAPPDATA'] ?? null) : null),
+            $environment[self::HOME_OVERRIDE_VARIABLE] ?? null,
         );
     }
 
@@ -86,15 +95,27 @@ final readonly class XdgConfigPathResolver
      */
     private function baseDirectory(?string $xdgBase, string $homeRelativeFallback): string
     {
-        if (null !== $xdgBase && '' !== $xdgBase && $this->isAbsolutePath($xdgBase)) {
-            return $xdgBase;
-        }
+        return $this->applicationHomeBase($homeRelativeFallback)
+            ?? $this->absoluteBase($xdgBase)
+            ?? $this->osHomeBase($homeRelativeFallback)
+            ?? throw UnresolvableConfigPathException::missingHome();
+    }
 
-        if (null !== $this->home && '' !== $this->home) {
-            return \sprintf('%s/%s', $this->home, $homeRelativeFallback);
-        }
+    private function applicationHomeBase(string $homeRelativeFallback): ?string
+    {
+        $applicationHome = $this->absoluteBase($this->applicationHome);
 
-        throw UnresolvableConfigPathException::missingHome();
+        return null !== $applicationHome ? \sprintf('%s/%s', $applicationHome, $homeRelativeFallback) : null;
+    }
+
+    private function osHomeBase(string $homeRelativeFallback): ?string
+    {
+        return null !== $this->home && '' !== $this->home ? \sprintf('%s/%s', $this->home, $homeRelativeFallback) : null;
+    }
+
+    private function absoluteBase(?string $path): ?string
+    {
+        return null !== $path && '' !== $path && $this->isAbsolutePath($path) ? $path : null;
     }
 
     /**

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -56,9 +56,9 @@ final readonly class InitCommand
             return Command::SUCCESS;
         }
 
-        $provider = $this->ask($symfonyStyle, 'Which AI provider do you want to use? (any symfony/ai platform — e.g. anthropic, openai, gemini, ollama)', 'anthropic');
+        $provider = $this->ask($symfonyStyle, 'Which AI provider do you want to use? (any symfony/ai platform — e.g. anthropic, openai, gemini, mistral, ollama)', 'anthropic');
         $model = $this->ask($symfonyStyle, 'Which model should the auditor use?', 'claude-opus-4-8');
-        $environmentVariable = $this->ask($symfonyStyle, 'Which environment variable holds the API key?', \sprintf('%s_API_KEY', u($provider)->upper()));
+        $environmentVariable = $this->ask($symfonyStyle, 'Which environment variable holds the API key?', $this->defaultApiKeyVariable($provider));
 
         $this->standaloneConfigWriter->write($configFile, $this->standaloneConfigFactory->create($provider, $model, $environmentVariable));
         $this->bridgeInstaller->install($provider, $this->xdgConfigPathResolver->dataDir());
@@ -80,5 +80,10 @@ final readonly class InitCommand
         \assert(\is_string($answer));
 
         return $answer;
+    }
+
+    private function defaultApiKeyVariable(string $provider): string
+    {
+        return \sprintf('%s_API_KEY', u($provider)->upper()->replaceMatches('/[^A-Z0-9]+/', ''));
     }
 }

--- a/tests/Phpunit/Integration/Bridge/ComposerBridgeInstallerTest.php
+++ b/tests/Phpunit/Integration/Bridge/ComposerBridgeInstallerTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Bridge;
 
 use Closure;
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
@@ -96,7 +97,8 @@ final class ComposerBridgeInstallerTest extends TestCase
     /**
      * @throws BridgeInstallationFailedException
      */
-    public function test_it_requires_the_provider_specific_bridge_package(): void
+    #[DataProvider('providerPackageCases')]
+    public function test_it_requires_the_provider_specific_bridge_package(string $provider, string $expectedPackage): void
     {
         $captured = [];
         $composerBridgeInstaller = new ComposerBridgeInstaller(processBuilder: static function (string $package, string $targetDirectory) use (&$captured): Process {
@@ -105,9 +107,20 @@ final class ComposerBridgeInstallerTest extends TestCase
             return new Process(['true']);
         });
 
-        $composerBridgeInstaller->install('gemini', $this->targetDirectory);
+        $composerBridgeInstaller->install($provider, $this->targetDirectory);
 
-        self::assertSame(['symfony/ai-gemini-platform'], $captured);
+        self::assertSame([$expectedPackage], $captured);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function providerPackageCases(): iterable
+    {
+        yield 'verbatim slug' => ['gemini', 'symfony/ai-gemini-platform'];
+        yield 'openai maps to the hyphenated open-ai package' => ['openai', 'symfony/ai-open-ai-platform'];
+        yield 'deepseek maps to the hyphenated deep-seek package' => ['deepseek', 'symfony/ai-deep-seek-platform'];
+        yield 'vertexai maps to the hyphenated vertex-ai package' => ['vertexai', 'symfony/ai-vertex-ai-platform'];
     }
 
     /**

--- a/tests/Phpunit/Integration/Command/InitCommandTest.php
+++ b/tests/Phpunit/Integration/Command/InitCommandTest.php
@@ -84,6 +84,19 @@ final class InitCommandTest extends TestCase
         );
     }
 
+    public function test_it_strips_invalid_characters_when_deriving_the_api_key_variable_from_the_provider(): void
+    {
+        $commandTester = $this->commandTester();
+        $commandTester->setInputs(['open-ai', 'gpt-5.4', '']);
+
+        $commandTester->execute([]);
+
+        self::assertSame(
+            ['provider' => 'open-ai', 'platform' => ['open-ai' => ['api_key' => '%env(OPENAI_API_KEY)%']], 'model' => 'gpt-5.4'],
+            Yaml::parseFile($this->configFile()),
+        );
+    }
+
     public function test_it_leaves_an_existing_configuration_untouched_when_the_overwrite_is_declined(): void
     {
         (new Filesystem())->dumpFile($this->configFile(), "model: keep-me\n");

--- a/tests/Phpunit/Integration/Config/YamlStandaloneConfigWriterTest.php
+++ b/tests/Phpunit/Integration/Config/YamlStandaloneConfigWriterTest.php
@@ -118,6 +118,7 @@ final class YamlStandaloneConfigWriterTest extends TestCase
         $filesystem->dumpFile($blockingFile, 'x');
 
         $this->expectException(StandaloneConfigWriteException::class);
+        $this->expectExceptionMessage('SYMFONY_SECURITY_AUDITOR_HOME');
 
         (new YamlStandaloneConfigWriter())->write($blockingFile.'/config.yaml', ['model' => 'claude-opus-4-8']);
     }

--- a/tests/Phpunit/Unit/Infrastructure/Config/XdgConfigPathResolverTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Config/XdgConfigPathResolverTest.php
@@ -192,4 +192,49 @@ final class XdgConfigPathResolverTest extends TestCase
 
         self::assertSame('/xdg/config/symfony-security-auditor/config.yaml', $xdgConfigPathResolver->configFile());
     }
+
+    /**
+     * @throws UnresolvableConfigPathException
+     */
+    public function test_the_application_home_override_outranks_xdg_and_home_for_every_directory(): void
+    {
+        $xdgConfigPathResolver = new XdgConfigPathResolver('/xdg/config', '/xdg/cache', '/home/dev', '/xdg/data', '/writable');
+
+        self::assertSame('/writable/.config/symfony-security-auditor/config.yaml', $xdgConfigPathResolver->configFile());
+        self::assertSame('/writable/.cache/symfony-security-auditor', $xdgConfigPathResolver->cacheDir());
+        self::assertSame('/writable/.local/share/symfony-security-auditor', $xdgConfigPathResolver->dataDir());
+    }
+
+    /**
+     * @throws UnresolvableConfigPathException
+     */
+    public function test_it_ignores_an_empty_application_home_override(): void
+    {
+        $xdgConfigPathResolver = new XdgConfigPathResolver('/xdg/config', null, '/home/dev', null, '');
+
+        self::assertSame('/xdg/config/symfony-security-auditor/config.yaml', $xdgConfigPathResolver->configFile());
+    }
+
+    /**
+     * @throws UnresolvableConfigPathException
+     */
+    public function test_it_ignores_a_relative_application_home_override(): void
+    {
+        $xdgConfigPathResolver = new XdgConfigPathResolver('/xdg/config', null, '/home/dev', null, 'relative/dir');
+
+        self::assertSame('/xdg/config/symfony-security-auditor/config.yaml', $xdgConfigPathResolver->configFile());
+    }
+
+    /**
+     * @throws UnresolvableConfigPathException
+     */
+    public function test_it_reads_the_application_home_override_from_the_environment_above_a_hijacked_xdg_config_home(): void
+    {
+        $xdgConfigPathResolver = XdgConfigPathResolver::fromEnvironment([
+            'XDG_CONFIG_HOME' => '/config',
+            'SYMFONY_SECURITY_AUDITOR_HOME' => '/app/.ssa',
+        ], 'Linux');
+
+        self::assertSame('/app/.ssa/.config/symfony-security-auditor/config.yaml', $xdgConfigPathResolver->configFile());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two standalone-binary `init` UX bugs reported this morning.

**`openai` never produced a working setup (#156).** The `symfony/ai` platform _config_ key is `openai`, but the composer bridge package is `symfony/ai-open-ai-platform` (hyphenated). `init` built the package name straight from the config key, so:

- typing `openai` (as the prompt suggests) ran `composer require symfony/ai-openai-platform`, which does not exist → _"provider does not exist"_;
- the `open-ai` workaround installed the bridge but wrote a `platform: open-ai` key that `symfony/ai` then rejects at audit time.

`ComposerBridgeInstaller` now maps the config key to its package slug (`openai` → `open-ai`, `deepseek` → `deep-seek`, `vertexai` → `vertex-ai`, `openresponses` → `open-responses`, `huggingface` → `hugging-face`, `elevenlabs` → `eleven-labs`, `amazeeai` → `amazee-ai`; every other provider is verbatim), so the config key the audit needs and the package `init` installs finally agree. The derived default API-key variable is also stripped of invalid characters, so a hyphenated provider name no longer proposes an invalid `OPEN-AI_API_KEY`.

**`init` failed in a non-root container with no escape hatch (#157).** Caddy/FrankenPHP base images export `XDG_CONFIG_HOME=/config` (root-owned), which the resolver correctly honours — but a non-root user can't write there and hits `mkdir(): Permission denied`. A new **`SYMFONY_SECURITY_AUDITOR_HOME`** environment variable overrides the base location (config, cache, and bridge dirs); it outranks the XDG variables and `$HOME`. The config-write failure message now names it too, so the error is self-explanatory.

Closes #156
Closes #157

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection` (74 mutants, 100% MSI on the changed classes)
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)