### PR TITLE
feat(command): add MCP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
+- **New `mcp:serve` command runs a Model Context Protocol (MCP) server, exposing
+  the auditor as a tool to AI assistants.** `bin/console mcp:serve` starts an
+  [MCP](https://modelcontextprotocol.io) server over stdio — built on the
+  official [`mcp/sdk`](https://github.com/modelcontextprotocol/php-sdk) — that
+  advertises an `audit` tool taking a project `path` and returning the JSON
+  vulnerability report, so an MCP client (Claude Desktop, an IDE agent, …) can
+  run a full audit on demand through the same pipeline `audit:run` uses. The
+  server building lives in `src/Command/Mcp/` behind `McpServerFactoryInterface`
+  and `McpTransportFactoryInterface`; the audit runs with the bundle's
+  configured platform, models, and profile. See
+  [CLI Reference → `mcp:serve`](docs/configuration.md#mcpserve--model-context-protocol-server).
 - **`audit:trend` can now render its timeline as a self-contained HTML
   dashboard.** `audit:trend --format=html` emits a single HTML page — no
   external assets, light and dark mode — with an SVG line chart of finding

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "require": {
         "php": ">=8.3",
         "composer-runtime-api": "^2.0",
+        "mcp/sdk": "^0.6.0",
         "nikic/php-parser": "^5.3",
         "psr/clock": "^1.0",
         "psr/log": "^3.0",

--- a/config/services.php
+++ b/config/services.php
@@ -136,6 +136,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\HtmlReportR
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JsonReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JunitReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\MarkdownReportRenderer;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRendererInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\SarifReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan\PhpParserControllerAccessControlParser;
@@ -164,6 +165,12 @@ use VinceAmstoutz\SymfonySecurityAuditor\Command\DiffPresenter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DiffPresenterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\FindingTypeFilter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\FindingTypeFilterInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\AuditTool;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\McpServeCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\McpServerFactory;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\McpServerFactoryInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\McpTransportFactoryInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\StdioMcpTransportFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDiffer;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportDifferInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ReportFindingsLoader;
@@ -662,6 +669,29 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service(ReportTrendAnalyzerInterface::class),
             service(TrendPresenterInterface::class),
+        ])
+        ->tag('console.command');
+
+    $defaultsConfigurator->set(AuditTool::class)
+        ->args([
+            service(RunAuditUseCase::class),
+            service(JsonReportRenderer::class),
+        ]);
+
+    $defaultsConfigurator->set(McpServerFactory::class)
+        ->args([
+            service(AuditTool::class),
+            inline_service(ReportPackage::class),
+        ]);
+    $defaultsConfigurator->alias(McpServerFactoryInterface::class, McpServerFactory::class);
+
+    $defaultsConfigurator->set(StdioMcpTransportFactory::class);
+    $defaultsConfigurator->alias(McpTransportFactoryInterface::class, StdioMcpTransportFactory::class);
+
+    $defaultsConfigurator->set(McpServeCommand::class)
+        ->args([
+            service(McpServerFactoryInterface::class),
+            service(McpTransportFactoryInterface::class),
         ])
         ->tag('console.command');
 };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ bundle registration, bundle-level configuration, platform wiring via
   - [`audit:diff`](#auditdiff--comparing-two-reports)
   - [`audit:trend`](#audittrend--tracking-findings-across-reports)
   - [`audit:baseline`](#auditbaseline--maintaining-the-accepted-finding-baseline)
+  - [`mcp:serve`](#mcpserve--model-context-protocol-server)
 
 > See also: [Architecture](architecture.md) · [Extending](extending.md) ·
 > [CI](ci.md) · [FAQ](faq.md) · [Troubleshooting](troubleshooting.md)
@@ -662,3 +663,40 @@ whose `attacker_fingerprint` matches a report finding count as covering it.
 Exit codes: `0` on success, `1` if the report is missing or malformed, the
 baseline file is malformed, or the baseline path is a symlink (refused, exactly
 as every other writer in this tool refuses symlinked destinations).
+
+### `mcp:serve` — Model Context Protocol server
+
+Starts a [Model Context Protocol](https://modelcontextprotocol.io) server over
+stdio, exposing the auditor as MCP **tools** so an MCP client (Claude Desktop,
+an IDE agent, …) can run an audit on demand. The server is built on the official
+[`mcp/sdk`](https://github.com/modelcontextprotocol/php-sdk) and speaks JSON-RPC
+on stdin/stdout — so the command prints nothing else to stdout.
+
+```bash
+bin/console mcp:serve
+```
+
+Register it with your MCP client by pointing the client at the command. For
+Claude Desktop (`claude_desktop_config.json`):
+
+```json
+{
+    "mcpServers": {
+        "symfony-security-auditor": {
+            "command": "php",
+            "args": ["bin/console", "mcp:serve"]
+        }
+    }
+}
+```
+
+Exposed tools:
+
+| Tool    | Arguments             | Description                                                                                              |
+| ------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `audit` | `path` (string, req.) | Runs the multi-agent audit on the project directory at `path` and returns the JSON vulnerability report. |
+
+> The audit runs with the bundle's configured platform, models, and profile —
+> `mcp:serve` is a transport in front of the same pipeline `audit:run` uses, so
+> an audit triggered over MCP bills the configured LLM provider exactly as a CLI
+> run would.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -109,6 +109,9 @@ is a `MAJOR` change.
 - The command name `audit:baseline` (see
   [CLI Reference → `audit:baseline`](configuration.md#auditbaseline--maintaining-the-accepted-finding-baseline)),
   its arguments, options, and exit codes.
+- The command name `mcp:serve` (see
+  [CLI Reference → `mcp:serve`](configuration.md#mcpserve--model-context-protocol-server))
+  and the names and input schemas of the MCP tools it exposes (`audit`).
 
 ### Standalone executable & XDG configuration
 

--- a/src/Command/Mcp/AuditTool.php
+++ b/src/Command/Mcp/AuditTool.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByBudgetException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByProviderException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditContextException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCostException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidTokenUsageException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRendererInterface;
+
+/** @internal not part of the BC promise — the MCP tool *name* (`audit`) is public, but the PHP class itself is for internal use only. */
+final readonly class AuditTool
+{
+    public function __construct(
+        private RunAuditUseCase $runAuditUseCase,
+        private ReportRendererInterface $reportRenderer,
+    ) {}
+
+    /**
+     * @throws AuditAbortedByBudgetException
+     * @throws AuditAbortedByProviderException
+     * @throws InvalidAuditContextException
+     * @throws InvalidAuditCostException
+     * @throws InvalidTokenUsageException
+     */
+    public function audit(string $path): string
+    {
+        return $this->reportRenderer->render($this->runAuditUseCase->execute($path));
+    }
+}

--- a/src/Command/Mcp/McpServeCommand.php
+++ b/src/Command/Mcp/McpServeCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+
+/** @internal not part of the BC promise — the command *name* (`mcp:serve`) is public, but the PHP class itself is for internal use only. */
+#[AsCommand(name: self::NAME, description: self::DESCRIPTION)]
+final readonly class McpServeCommand
+{
+    public const string NAME = 'mcp:serve';
+
+    public const string DESCRIPTION = 'Start a Model Context Protocol (MCP) server over stdio exposing the auditor as tools';
+
+    public function __construct(
+        private McpServerFactoryInterface $mcpServerFactory,
+        private McpTransportFactoryInterface $mcpTransportFactory,
+    ) {}
+
+    public function __invoke(): int
+    {
+        $this->mcpServerFactory->create()->run($this->mcpTransportFactory->create());
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/Mcp/McpServerFactory.php
+++ b/src/Command/Mcp/McpServerFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp;
+
+use Mcp\Server;
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class McpServerFactory implements McpServerFactoryInterface
+{
+    private const string SERVER_NAME = 'symfony-security-auditor';
+
+    private const string AUDIT_TOOL_NAME = 'audit';
+
+    private const string AUDIT_TOOL_DESCRIPTION = 'Run the AI-powered multi-agent security audit on a Symfony project directory and return the JSON report of the vulnerabilities found.';
+
+    public function __construct(
+        private AuditTool $auditTool,
+        private ReportPackage $reportPackage,
+    ) {}
+
+    #[Override]
+    public function create(): Server
+    {
+        return Server::builder()
+            ->setServerInfo(self::SERVER_NAME, $this->reportPackage->version())
+            ->addTool(
+                fn (string $path): string => $this->auditTool->audit($path),
+                self::AUDIT_TOOL_NAME,
+                description: self::AUDIT_TOOL_DESCRIPTION,
+                inputSchema: [
+                    'type' => 'object',
+                    'properties' => [
+                        'path' => [
+                            'type' => 'string',
+                            'description' => 'Absolute path to the Symfony project directory to audit.',
+                        ],
+                    ],
+                    'required' => ['path'],
+                ],
+            )
+            ->build();
+    }
+}

--- a/src/Command/Mcp/McpServerFactoryInterface.php
+++ b/src/Command/Mcp/McpServerFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp;
+
+use Mcp\Server;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface McpServerFactoryInterface
+{
+    public function create(): Server;
+}

--- a/src/Command/Mcp/McpTransportFactoryInterface.php
+++ b/src/Command/Mcp/McpTransportFactoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp;
+
+use Mcp\Server\Transport\TransportInterface;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface McpTransportFactoryInterface
+{
+    /**
+     * @return TransportInterface<mixed>
+     */
+    public function create(): TransportInterface;
+}

--- a/src/Command/Mcp/StdioMcpTransportFactory.php
+++ b/src/Command/Mcp/StdioMcpTransportFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp;
+
+use Mcp\Server\Transport\StdioTransport;
+use Mcp\Server\Transport\TransportInterface;
+use Override;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class StdioMcpTransportFactory implements McpTransportFactoryInterface
+{
+    /**
+     * @return TransportInterface<mixed>
+     */
+    #[Override]
+    public function create(): TransportInterface
+    {
+        return new StdioTransport();
+    }
+}

--- a/tests/Phpunit/Integration/Command/Mcp/AuditToolTest.php
+++ b/tests/Phpunit/Integration/Command/Mcp/AuditToolTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Mcp;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByBudgetException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByProviderException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditContextException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCostException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidTokenUsageException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\PipelineInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JsonReportRenderer;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRendererInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\AuditTool;
+
+final class AuditToolTest extends TestCase
+{
+    private string $projectPath;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->projectPath = sys_get_temp_dir().'/ssa-mcp-audit-'.bin2hex(random_bytes(6));
+        (new Filesystem())->mkdir($this->projectPath);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->projectPath);
+    }
+
+    /**
+     * @throws AuditAbortedByBudgetException
+     * @throws AuditAbortedByProviderException
+     * @throws InvalidAuditContextException
+     * @throws InvalidAuditCostException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_it_audits_the_given_path_and_returns_the_rendered_json_report(): void
+    {
+        $auditTool = new AuditTool($this->runAuditUseCase(), new JsonReportRenderer());
+
+        $report = json_decode($auditTool->audit($this->projectPath), true, flags: \JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($report);
+        self::assertSame($this->projectPath, $report['project']);
+    }
+
+    /**
+     * @throws AuditAbortedByBudgetException
+     * @throws AuditAbortedByProviderException
+     * @throws InvalidAuditContextException
+     * @throws InvalidAuditCostException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_it_returns_the_report_as_rendered_by_the_report_renderer(): void
+    {
+        $renderer = self::createStub(ReportRendererInterface::class);
+        $renderer->method('render')->willReturn('RENDERED-REPORT');
+
+        $auditTool = new AuditTool($this->runAuditUseCase(), $renderer);
+
+        self::assertSame('RENDERED-REPORT', $auditTool->audit($this->projectPath));
+    }
+
+    private function runAuditUseCase(): RunAuditUseCase
+    {
+        return new RunAuditUseCase(self::createStub(PipelineInterface::class), new NullLogger());
+    }
+}

--- a/tests/Phpunit/Integration/Command/Mcp/Fixture/PreloadedStdioTransportFactory.php
+++ b/tests/Phpunit/Integration/Command/Mcp/Fixture/PreloadedStdioTransportFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Mcp\Fixture;
+
+use Mcp\Server\Transport\StdioTransport;
+use Mcp\Server\Transport\TransportInterface;
+use Override;
+use RuntimeException;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\McpTransportFactoryInterface;
+
+final class PreloadedStdioTransportFactory implements McpTransportFactoryInterface
+{
+    public string $outputPath = '';
+
+    /**
+     * @param list<string> $messages
+     */
+    public function __construct(private readonly array $messages) {}
+
+    /**
+     * @return TransportInterface<mixed>
+     */
+    #[Override]
+    public function create(): TransportInterface
+    {
+        $inputPath = tempnam(sys_get_temp_dir(), 'ssa-mcp-in');
+        $outputPath = tempnam(sys_get_temp_dir(), 'ssa-mcp-out');
+        if (false === $inputPath || false === $outputPath) {
+            throw new RuntimeException('Unable to create temporary MCP transport streams.');
+        }
+
+        file_put_contents($inputPath, implode("\n", $this->messages)."\n");
+        $this->outputPath = $outputPath;
+
+        $input = fopen($inputPath, 'r');
+        $output = fopen($outputPath, 'w');
+        if (false === $input || false === $output) {
+            throw new RuntimeException('Unable to open temporary MCP transport streams.');
+        }
+
+        return new StdioTransport($input, $output);
+    }
+
+    public function capturedOutput(): string
+    {
+        $output = file_get_contents($this->outputPath);
+        if (false === $output) {
+            throw new RuntimeException('Unable to read captured MCP transport output.');
+        }
+
+        return $output;
+    }
+}

--- a/tests/Phpunit/Integration/Command/Mcp/McpServeCommandTest.php
+++ b/tests/Phpunit/Integration/Command/Mcp/McpServeCommandTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Mcp;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\PipelineInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JsonReportRenderer;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\AuditTool;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\McpServeCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\McpServerFactory;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Mcp\Fixture\PreloadedStdioTransportFactory;
+
+final class McpServeCommandTest extends TestCase
+{
+    private string $projectPath;
+
+    private PreloadedStdioTransportFactory $preloadedStdioTransportFactory;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->projectPath = sys_get_temp_dir().'/ssa-mcp-cmd-'.bin2hex(random_bytes(6));
+        (new Filesystem())->mkdir($this->projectPath);
+        $this->preloadedStdioTransportFactory = new PreloadedStdioTransportFactory([
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}',
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+            \sprintf('{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"audit","arguments":{"path":%s}}}', json_encode($this->projectPath, \JSON_THROW_ON_ERROR)),
+        ]);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->projectPath);
+    }
+
+    public function test_it_reports_success_after_serving(): void
+    {
+        self::assertSame(Command::SUCCESS, (new CommandTester($this->command()))->execute([]));
+    }
+
+    public function test_it_serves_the_audit_tool_over_the_transport(): void
+    {
+        (new CommandTester($this->command()))->execute([]);
+
+        $output = $this->preloadedStdioTransportFactory->capturedOutput();
+
+        self::assertStringContainsString('AUDIT-', $output);
+    }
+
+    private function command(): McpServeCommand
+    {
+        $mcpServerFactory = new McpServerFactory(
+            new AuditTool(new RunAuditUseCase(self::createStub(PipelineInterface::class), new NullLogger()), new JsonReportRenderer()),
+            new ReportPackage(),
+        );
+
+        return new McpServeCommand($mcpServerFactory, $this->preloadedStdioTransportFactory);
+    }
+}

--- a/tests/Phpunit/Integration/Command/Mcp/McpServerFactoryTest.php
+++ b/tests/Phpunit/Integration/Command/Mcp/McpServerFactoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Mcp;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\PipelineInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JsonReportRenderer;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\AuditTool;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\McpServerFactory;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Mcp\Fixture\PreloadedStdioTransportFactory;
+
+final class McpServerFactoryTest extends TestCase
+{
+    private string $projectPath;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->projectPath = sys_get_temp_dir().'/ssa-mcp-factory-'.bin2hex(random_bytes(6));
+        (new Filesystem())->mkdir($this->projectPath);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->projectPath);
+    }
+
+    public function test_it_advertises_the_server_under_the_auditor_name(): void
+    {
+        self::assertStringContainsString('"name":"symfony-security-auditor"', $this->converse());
+    }
+
+    public function test_it_registers_the_audit_tool_with_its_description(): void
+    {
+        $output = $this->converse();
+
+        self::assertStringContainsString('"name":"audit"', $output);
+        self::assertStringContainsString('return the JSON report', $output);
+    }
+
+    public function test_it_declares_a_required_string_path_argument_on_the_audit_tool(): void
+    {
+        $output = $this->converse();
+
+        self::assertStringContainsString('"path":{"type":"string"', $output);
+        self::assertStringContainsString('"required":["path"]', $output);
+    }
+
+    public function test_calling_the_audit_tool_runs_an_audit_and_returns_a_report(): void
+    {
+        $output = $this->converse();
+
+        self::assertStringContainsString('"isError":false', $output);
+        self::assertStringContainsString('AUDIT-', $output);
+    }
+
+    private function converse(): string
+    {
+        $server = (new McpServerFactory(
+            new AuditTool(new RunAuditUseCase(self::createStub(PipelineInterface::class), new NullLogger()), new JsonReportRenderer()),
+            new ReportPackage(),
+        ))->create();
+
+        $preloadedStdioTransportFactory = new PreloadedStdioTransportFactory([
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}',
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list"}',
+            \sprintf('{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"audit","arguments":{"path":%s}}}', json_encode($this->projectPath, \JSON_THROW_ON_ERROR)),
+        ]);
+
+        $server->run($preloadedStdioTransportFactory->create());
+
+        return $preloadedStdioTransportFactory->capturedOutput();
+    }
+}

--- a/tests/Phpunit/Unit/Command/Mcp/StdioMcpTransportFactoryTest.php
+++ b/tests/Phpunit/Unit/Command/Mcp/StdioMcpTransportFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command\Mcp;
+
+use Mcp\Server\Transport\StdioTransport;
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\StdioMcpTransportFactory;
+
+final class StdioMcpTransportFactoryTest extends TestCase
+{
+    public function test_it_creates_a_stdio_transport(): void
+    {
+        self::assertInstanceOf(StdioTransport::class, (new StdioMcpTransportFactory())->create());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **`mcp:serve`** command that runs a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio, so an MCP client (Claude Desktop, an IDE agent, …) can run a security audit on demand. Built on the official [`mcp/sdk`](https://github.com/modelcontextprotocol/php-sdk) (a PHP Foundation + Symfony collaboration).

The server advertises one tool:

| Tool    | Arguments             | Returns                                            |
| ------- | --------------------- | -------------------------------------------------- |
| `audit` | `path` (string, req.) | The JSON vulnerability report for the project path |

`audit` runs through the **same pipeline `audit:run` uses**, with the bundle's configured platform, models, and profile — `mcp:serve` is just a transport in front of it.

```jsonc
// claude_desktop_config.json
{
  "mcpServers": {
    "symfony-security-auditor": {
      "command": "php",
      "args": ["bin/console", "mcp:serve"]
    }
  }
}
```

### Design

Everything lives under `src/Command/Mcp/` (Command is the top DDD layer, so it may depend on the Application use case, the report renderer, and the third-party SDK without crossing a deptrac boundary):

- **`AuditTool`** — delegates to `RunAuditUseCase` and renders with `JsonReportRenderer`.
- **`McpServerFactory`** (`McpServerFactoryInterface`) — wires the tool onto an `mcp/sdk` `Server` via a closure handler + explicit input schema.
- **`StdioMcpTransportFactory`** (`McpTransportFactoryInterface`) — provides the stdio transport. Injecting the transport behind an interface is what makes the server loop drivable in tests over in-memory streams rather than real STDIN/STDOUT.
- **`McpServeCommand`** — builds the server and runs it over the transport.

Tests drive the real `Server` end-to-end over an `StdioTransport` backed by temp-file streams (feeding a real `initialize` + `tools/list` + `tools/call` handshake and asserting the responses), plus a unit test on the transport factory. `AuditTool` is exercised with a real `RunAuditUseCase` backed by a stubbed `PipelineInterface` (no LLM calls).

Adds `mcp/sdk` to `require` (php `^8.1`, `symfony/uid ^7.3 || ^8.0` — covers the CI matrix).

Follow-ups (not in this PR): `audit_diff` / `audit_trend` tools, and exposing the server from the standalone binary.

Closes the "MCP server mode" item.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection` (100% MSI on the new classes)
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)