### PR TITLE
fix(standalone): resolve the provider bridge for the binary's bundled PHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Fixed
+
+- **The standalone binary's `init` now installs a provider bridge that its own
+  bundled PHP can load.** `ComposerBridgeInstaller` ran `composer require`
+  without constraining the platform, so the bridge tree resolved against the
+  _host's_ PHP (e.g. 8.5) and pulled dependencies requiring PHP `>= 8.4`. The
+  binary — which bundles PHP 8.3 — then aborted at startup in
+  `vendor/composer/platform_check.php`, since the resolved dependencies required
+  a newer PHP than the binary runs. The generated `composer.json` now pins
+  `config.platform.php` to the running runtime's version (`PHP_VERSION`, the
+  binary's bundled PHP), so `composer require` resolves versions the binary can
+  actually run.
+
 ## [1.14.0] — 2026-07-14 — Beacon
 
 A release about sharper signals in and more actionable output out. External SAST

--- a/src/Audit/Infrastructure/Bridge/ComposerBridgeInstaller.php
+++ b/src/Audit/Infrastructure/Bridge/ComposerBridgeInstaller.php
@@ -51,14 +51,14 @@ final readonly class ComposerBridgeInstaller implements BridgeInstallerInterface
 
     private const string MANIFEST_FILENAME = 'composer.json';
 
-    private const string EMPTY_MANIFEST = "{}\n";
-
     /**
-     * @param Closure(string, string): Process $processBuilder the composer-require command builder (use self::defaultProcessBuilder() in production); tests inject a stub
+     * @param Closure(string, string): Process $processBuilder     the composer-require command builder (use self::defaultProcessBuilder() in production); tests inject a stub
+     * @param string                           $platformPhpVersion the PHP version the bridge tree must resolve for — defaults to the running runtime (`PHP_VERSION`), which for the standalone binary is its own bundled PHP, not the host's
      */
     public function __construct(
         private Closure $processBuilder,
         private Filesystem $filesystem = new Filesystem(),
+        private string $platformPhpVersion = \PHP_VERSION,
     ) {}
 
     /**
@@ -109,10 +109,27 @@ final readonly class ComposerBridgeInstaller implements BridgeInstallerInterface
         }
 
         try {
-            $this->filesystem->dumpFile($manifest, self::EMPTY_MANIFEST);
+            $this->filesystem->dumpFile($manifest, $this->manifestContents());
         } catch (IOException $ioException) {
             throw BridgeInstallationFailedException::forManifestWriteFailure($targetDirectory, $ioException);
         }
+    }
+
+    /**
+     * Pins `config.platform.php` so `composer require` resolves the bridge for
+     * the runtime that will load it. The standalone binary bundles its own PHP;
+     * without this, `init` resolves against the host's (possibly newer) PHP and
+     * the binary then aborts in `vendor/composer/platform_check.php`.
+     */
+    private function manifestContents(): string
+    {
+        return \sprintf(
+            "%s\n",
+            json_encode(
+                ['config' => ['platform' => ['php' => $this->platformPhpVersion]]],
+                \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR,
+            ),
+        );
     }
 
     /**

--- a/tests/Phpunit/Integration/Bridge/ComposerBridgeInstallerTest.php
+++ b/tests/Phpunit/Integration/Bridge/ComposerBridgeInstallerTest.php
@@ -44,11 +44,13 @@ final class ComposerBridgeInstallerTest extends TestCase
     /**
      * @throws BridgeInstallationFailedException
      */
-    public function test_it_initialises_the_target_directory_as_a_composer_project(): void
+    public function test_it_initialises_the_target_directory_as_a_composer_project_pinned_to_the_runtime_php(): void
     {
-        (new ComposerBridgeInstaller(processBuilder: $this->succeedingProcess()))->install('anthropic', $this->targetDirectory);
+        (new ComposerBridgeInstaller(processBuilder: $this->succeedingProcess(), platformPhpVersion: '8.3.99'))->install('anthropic', $this->targetDirectory);
 
-        self::assertSame("{}\n", file_get_contents($this->targetDirectory.'/composer.json'));
+        $manifest = file_get_contents($this->targetDirectory.'/composer.json');
+        self::assertNotFalse($manifest);
+        self::assertSame(['config' => ['platform' => ['php' => '8.3.99']]], json_decode($manifest, true, flags: \JSON_THROW_ON_ERROR));
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #161 for the remaining part of #156 (the `platform_check.php` failure @Toflar hit).

The standalone binary bundles its own PHP (currently **8.3**), but `init` ran `composer require` for the provider bridge **without constraining the platform**. So the dependency tree resolved against the **host's** PHP (e.g. 8.5) and pulled packages requiring PHP `>= 8.4`. When the binary then loaded that vendor tree under its bundled 8.3, it aborted at startup:

```
Fatal error: Uncaught RuntimeException: Composer detected issues in your platform:
Your Composer dependencies require a PHP version ">= 8.4.1". You are running 8.3.32.
in .../.local/share/symfony-security-auditor/vendor/composer/platform_check.php:22
```

**Fix:** `ComposerBridgeInstaller` now seeds the generated `composer.json` with `config.platform.php` set to the running runtime's version (`PHP_VERSION` — for the binary, its own bundled PHP; injectable so tests pin a known version). `composer require` then resolves versions the binary can actually run, and the generated `platform_check.php` matches the runtime.

This is the robust fix regardless of which PHP the binary bundles: the bridge is always resolved for the PHP that will load it, not the host's.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection` (100% MSI on `ComposerBridgeInstaller`)
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)