### PR TITLE
chore: release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.15.0] — 2026-07-14 — Conduit
+
+A release about reaching the auditor from anywhere. The new `mcp:serve` command
+exposes the audit as a Model Context Protocol tool, so an MCP client can run it
+on demand over the same pipeline as `audit:run`. Alongside it, the standalone
+binary's `init` now resolves the provider bridge for its own bundled PHP, so a
+fresh install no longer aborts on a host-versus-binary PHP mismatch.
+
+### Added
+
+- **New `mcp:serve` command runs a Model Context Protocol (MCP) server, exposing
+  the auditor as a tool to AI assistants.** `bin/console mcp:serve` starts an
+  [MCP](https://modelcontextprotocol.io) server over stdio — built on the
+  official [`mcp/sdk`](https://github.com/modelcontextprotocol/php-sdk) — that
+  advertises an `audit` tool taking a project `path` and returning the JSON
+  vulnerability report, so an MCP client (Claude Desktop, an IDE agent, …) can
+  run a full audit on demand through the same pipeline `audit:run` uses. The
+  server building lives in `src/Command/Mcp/` behind `McpServerFactoryInterface`
+  and `McpTransportFactoryInterface`; the audit runs with the bundle's
+  configured platform, models, and profile. See
+  [CLI Reference → `mcp:serve`](docs/configuration.md#mcpserve--model-context-protocol-server).
+
 ### Fixed
 
 - **The standalone binary's `init` now installs a provider bridge that its own
@@ -39,17 +61,6 @@ in non-root containers via the new `SYMFONY_SECURITY_AUDITOR_HOME` override.
 
 ### Added
 
-- **New `mcp:serve` command runs a Model Context Protocol (MCP) server, exposing
-  the auditor as a tool to AI assistants.** `bin/console mcp:serve` starts an
-  [MCP](https://modelcontextprotocol.io) server over stdio — built on the
-  official [`mcp/sdk`](https://github.com/modelcontextprotocol/php-sdk) — that
-  advertises an `audit` tool taking a project `path` and returning the JSON
-  vulnerability report, so an MCP client (Claude Desktop, an IDE agent, …) can
-  run a full audit on demand through the same pipeline `audit:run` uses. The
-  server building lives in `src/Command/Mcp/` behind `McpServerFactoryInterface`
-  and `McpTransportFactoryInterface`; the audit runs with the bundle's
-  configured platform, models, and profile. See
-  [CLI Reference → `mcp:serve`](docs/configuration.md#mcpserve--model-context-protocol-server).
 - **`audit:trend` can now render its timeline as a self-contained HTML
   dashboard.** `audit:trend --format=html` emits a single HTML page — no
   external assets, light and dark mode — with an SVG line chart of finding
@@ -2139,6 +2150,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.15.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.15.0
 [1.14.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.14.0
 [1.13.0]:

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ bin/console audit:run --dry-run
   report and exit code so only new findings fail CI.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.14.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.15.0`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **DDD architecture** — strict layering and a sole `LLMClientInterface` seam

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -264,7 +264,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.14.0
+        uses: vinceamstoutz/symfony-security-auditor@1.15.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -152,7 +152,7 @@ deprecated by the other.
   `MINOR`; renaming or removing one is a `MAJOR`. The Marketplace `name`
   (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.14.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.15.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.14.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.15.0/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",


### PR DESCRIPTION
## Summary

Prepares the **1.15.0 — Conduit** release (MINOR: adds the `mcp:serve` feature, plus a standalone-binary bug fix; no public API removed). It ships the two PRs merged **after** the `1.14.0` tag, so cutting this release gets the fix for #156 (@Toflar's `platform_check.php` failure) into users' hands:

- **#162** — `mcp:serve` MCP server command.
- **#164** — the standalone `init` bridge PHP-platform fix (**closes out #156**).

Release process:

- `CHANGELOG.md`: renamed `## [Unreleased]` → `## [1.15.0] — 2026-07-14 — Conduit` with a release intro, recreated an empty `## [Unreleased]`, and added the `[1.15.0]` link reference. Also **moved the `mcp:serve` entry out of `## [1.14.0]`** — it had landed there because #162 branched before the 1.14.0 release PR, but MCP merged after the `1.14.0` tag and was never part of that release.
- Version pins bumped `1.14.0` → `1.15.0`: config-schema `$id` in `resources/schema.json`, and the GitHub Action `uses:` examples in `README.md`, `docs/ci.md`, `docs/versioning.md`. (The `Release Guard` workflow re-checks these against the tag on push.)

Merge this, then tag `1.15.0` to trigger the Release workflow.

## Type of change

- [x] Documentation _(release chore: changelog + version pins)_

## Checklist

- [x] All checks pass: `bin/castor lint`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org)