### PR TITLE
feat(standalone): add a self-update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Added
+
+- **New `self-update` command updates the standalone binary in place.**
+  `symfony-security-auditor self-update` queries the GitHub releases API for the
+  latest version and, when a newer one exists, downloads the asset matching the
+  running platform (mirroring `install.sh`'s OS/arch detection), **verifies its
+  `.sha256` checksum before touching anything**, and atomically replaces the
+  running binary; `--check` only reports whether an update is available without
+  modifying anything. Downloads go through `curl` via Symfony `Process` (no new
+  runtime dependency), and the binary refuses to update when it is not writable,
+  pointing at `sudo`/reinstall instead. Standalone-only — it is not registered
+  in the bundle. Implementation lives in `src/Audit/Infrastructure/SelfUpdate/`.
+  See
+  [CLI Reference → `self-update`](docs/configuration.md#self-update--updating-the-standalone-binary).
+
 ## [1.15.0] — 2026-07-14 — Conduit
 
 A release about reaching the auditor from anywhere. The new `mcp:serve` command

--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ symfony-security-auditor audit /path/to/your/symfony/project
 [CLI reference](docs/configuration.md#cli-reference) (`--format`, `--output`,
 `--dry-run`, `--since`, `--fail-on`, …) works identically.
 
+### 4. Keep it up to date
+
+```bash
+symfony-security-auditor self-update          # download + verify + replace, if newer
+symfony-security-auditor self-update --check  # only report whether a newer version exists
+```
+
+`self-update` fetches the latest release for your platform, **verifies its
+checksum before replacing the binary**, and swaps it in place — see the
+[CLI reference](docs/configuration.md#self-update--updating-the-standalone-binary).
+
 ## Use it as a Symfony bundle
 
 ### 1. Install — Symfony Flex wires everything

--- a/bin/symfony-security-auditor
+++ b/bin/symfony-security-auditor
@@ -43,4 +43,6 @@ $environment = getenv();
     }
 })($environment);
 
-exit(StandaloneApplicationFactory::fromEnvironment($environment)->create()->run());
+$runningBinaryPath = \is_string($_SERVER['SCRIPT_FILENAME'] ?? null) ? $_SERVER['SCRIPT_FILENAME'] : '';
+
+exit(StandaloneApplicationFactory::fromEnvironment($environment, $runningBinaryPath)->create()->run());

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ bundle registration, bundle-level configuration, platform wiring via
   - [`audit:trend`](#audittrend--tracking-findings-across-reports)
   - [`audit:baseline`](#auditbaseline--maintaining-the-accepted-finding-baseline)
   - [`mcp:serve`](#mcpserve--model-context-protocol-server)
+  - [`self-update`](#self-update--updating-the-standalone-binary)
 
 > See also: [Architecture](architecture.md) · [Extending](extending.md) ·
 > [CI](ci.md) · [FAQ](faq.md) · [Troubleshooting](troubleshooting.md)
@@ -713,3 +714,28 @@ Exposed tools:
 > `mcp:serve` is a transport in front of the same pipeline `audit:run` uses, so
 > an audit triggered over MCP bills the configured LLM provider exactly as a CLI
 > run would.
+
+### `self-update` — updating the standalone binary
+
+Updates the [standalone binary](#standalone-configuration) in place to the
+latest released version. This command exists **only in the standalone binary**
+(the Composer bundle updates through `composer update`).
+
+```bash
+symfony-security-auditor self-update          # download + verify + replace, if newer
+symfony-security-auditor self-update --check  # only report whether a newer version exists
+```
+
+It queries the GitHub releases API for the latest version and, when the running
+binary is older, downloads the asset for your platform (the same OS/arch
+detection `install.sh` uses), **verifies its `.sha256` checksum before replacing
+anything**, and atomically swaps the running executable. Downloads use `curl`,
+so it must be on the host (as it already is for the install script).
+
+| Option    | Default | Description                                                                 |
+| --------- | ------- | --------------------------------------------------------------------------- |
+| `--check` | off     | Report whether a newer version is available; make no changes to the binary. |
+
+If the binary is not writable (e.g. installed in `/usr/local/bin` without write
+access), the command refuses to update and tells you to re-run with the
+necessary permissions (`sudo`) or reinstall with the install script.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -127,6 +127,8 @@ following surface is BC-protected:
 - The `init` command name. The standalone exposes the **identical** `audit:run`
   command (and its `audit` alias), arguments, options, and exit-code surface
   listed above.
+- The `self-update` command name and its `--check` option (see
+  [CLI Reference → `self-update`](configuration.md#self-update--updating-the-standalone-binary)).
 - The configuration path contract. On Linux/macOS the XDG Base Directory spec:
   the config file `$XDG_CONFIG_HOME/symfony-security-auditor/config.yaml`
   (falling back to `~/.config/…`), the cache directory

--- a/src/Audit/Infrastructure/SelfUpdate/Exception/SelfUpdateFailedException.php
+++ b/src/Audit/Infrastructure/SelfUpdate/Exception/SelfUpdateFailedException.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception;
+
+use RuntimeException;
+use Throwable;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final class SelfUpdateFailedException extends RuntimeException
+{
+    public static function forUnresolvableLatestVersion(string $source, ?Throwable $throwable = null): self
+    {
+        return new self(\sprintf('Could not determine the latest released version from "%s".', $source), previous: $throwable);
+    }
+
+    public static function forFailedDownload(string $url, ?Throwable $throwable = null): self
+    {
+        return new self(\sprintf('Failed to download "%s".', $url), previous: $throwable);
+    }
+
+    public static function forUndeterminedBinaryPath(): self
+    {
+        return new self('Could not determine the path of the running binary to replace; self-update is only supported for the standalone binary.');
+    }
+
+    public static function forChecksumMismatch(string $asset): self
+    {
+        return new self(\sprintf('Checksum verification failed for "%s"; the download was not trusted and has been discarded.', $asset));
+    }
+
+    public static function forUnwritableBinary(string $binaryPath): self
+    {
+        return new self(\sprintf('The binary at "%s" is not writable; re-run the update with the necessary permissions (e.g. sudo) or reinstall with the install script.', $binaryPath));
+    }
+
+    public static function forFailedReplacement(string $binaryPath, Throwable $throwable): self
+    {
+        return new self(\sprintf('Failed to replace the binary at "%s": %s', $binaryPath, $throwable->getMessage()), previous: $throwable);
+    }
+}

--- a/src/Audit/Infrastructure/SelfUpdate/Exception/UnsupportedSelfUpdatePlatformException.php
+++ b/src/Audit/Infrastructure/SelfUpdate/Exception/UnsupportedSelfUpdatePlatformException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception;
+
+use RuntimeException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final class UnsupportedSelfUpdatePlatformException extends RuntimeException
+{
+    public static function forPlatform(string $osFamily, string $machine): self
+    {
+        return new self(\sprintf('Self-update does not support the "%s" / "%s" platform; download the binary for your platform from the releases page instead.', $osFamily, $machine));
+    }
+}

--- a/src/Audit/Infrastructure/SelfUpdate/GitHubBinaryAsset.php
+++ b/src/Audit/Infrastructure/SelfUpdate/GitHubBinaryAsset.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class GitHubBinaryAsset
+{
+    public function __construct(
+        public string $name,
+        public string $downloadUrl,
+        public string $checksumUrl,
+    ) {}
+}

--- a/src/Audit/Infrastructure/SelfUpdate/GitHubBinaryAssetResolver.php
+++ b/src/Audit/Infrastructure/SelfUpdate/GitHubBinaryAssetResolver.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\UnsupportedSelfUpdatePlatformException;
+
+/**
+ * Resolves the release asset for the running platform, mirroring the OS/arch
+ * detection in `install.sh` so the binary self-updates to the same asset the
+ * installer would have fetched.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class GitHubBinaryAssetResolver
+{
+    private const string REPOSITORY = 'vinceAmstoutz/symfony-security-auditor';
+
+    private const string BINARY_NAME = 'symfony-security-auditor';
+
+    private const string DOWNLOAD_URL_TEMPLATE = 'https://github.com/%s/releases/download/%s/%s';
+
+    public function __construct(
+        private string $osFamily,
+        private string $machine,
+    ) {}
+
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function resolve(string $version): GitHubBinaryAsset
+    {
+        $assetName = \sprintf('%s-%s-%s', self::BINARY_NAME, $this->osSlug(), $this->architectureSlug());
+        $downloadUrl = \sprintf(self::DOWNLOAD_URL_TEMPLATE, self::REPOSITORY, $version, $assetName);
+
+        return new GitHubBinaryAsset($assetName, $downloadUrl, \sprintf('%s.sha256', $downloadUrl));
+    }
+
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    private function osSlug(): string
+    {
+        return match ($this->osFamily) {
+            'Linux' => 'linux',
+            'Darwin' => 'macos',
+            default => throw UnsupportedSelfUpdatePlatformException::forPlatform($this->osFamily, $this->machine),
+        };
+    }
+
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    private function architectureSlug(): string
+    {
+        return match ($this->machine) {
+            'x86_64', 'amd64' => 'x86_64',
+            'aarch64', 'arm64' => 'Darwin' === $this->osFamily ? 'arm64' : 'aarch64',
+            default => throw UnsupportedSelfUpdatePlatformException::forPlatform($this->osFamily, $this->machine),
+        };
+    }
+}

--- a/src/Audit/Infrastructure/SelfUpdate/ProcessReleaseClient.php
+++ b/src/Audit/Infrastructure/SelfUpdate/ProcessReleaseClient.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use Closure;
+use Override;
+use Symfony\Component\Process\Exception\ExceptionInterface;
+use Symfony\Component\Process\Process;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+
+/**
+ * Fetches release metadata and assets with `curl` through Symfony `Process` —
+ * the same subprocess-only convention `ComposerBridgeInstaller` uses — so the
+ * binary needs no bundled HTTP client.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class ProcessReleaseClient implements ReleaseClientInterface
+{
+    private const string USER_AGENT = 'symfony-security-auditor-self-update';
+
+    /**
+     * @param Closure(list<string>): Process $processBuilder the curl command builder (use self::defaultProcessBuilder() in production); tests inject a stub
+     */
+    public function __construct(
+        private Closure $processBuilder,
+    ) {}
+
+    /**
+     * @return Closure(list<string>): Process
+     */
+    public static function defaultProcessBuilder(): Closure
+    {
+        return
+            /** @param list<string> $arguments */
+            static function (array $arguments): Process {
+                /** @var list<string> $command */
+                $command = ['curl', '-fsSL', '-H', \sprintf('User-Agent: %s', self::USER_AGENT), ...$arguments];
+                $process = new Process($command);
+                $process->setTimeout(null);
+
+                return $process;
+            };
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    #[Override]
+    public function get(string $url): string
+    {
+        return $this->run([$url], $url)->getOutput();
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    #[Override]
+    public function download(string $url, string $destination): void
+    {
+        $this->run(['--output', $destination, $url], $url);
+    }
+
+    /**
+     * @param list<string> $arguments
+     *
+     * @throws SelfUpdateFailedException
+     */
+    private function run(array $arguments, string $url): Process
+    {
+        $process = ($this->processBuilder)($arguments);
+
+        try {
+            $process->run();
+        } catch (ExceptionInterface $exception) {
+            throw SelfUpdateFailedException::forFailedDownload($url, $exception);
+        }
+
+        if (!$process->isSuccessful()) {
+            throw SelfUpdateFailedException::forFailedDownload($url);
+        }
+
+        return $process;
+    }
+}

--- a/src/Audit/Infrastructure/SelfUpdate/ReleaseClientInterface.php
+++ b/src/Audit/Infrastructure/SelfUpdate/ReleaseClientInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface ReleaseClientInterface
+{
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function get(string $url): string;
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function download(string $url, string $destination): void;
+}

--- a/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocator.php
+++ b/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocator.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+
+/**
+ * Locates the running executable to replace. On Linux the kernel exposes it at
+ * `/proc/self/exe`; elsewhere it falls back to the resolved entry-script path.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class RunningBinaryLocator implements RunningBinaryLocatorInterface
+{
+    public function __construct(
+        private string $procSelfExePath = '/proc/self/exe',
+        private string $invokedScriptPath = '',
+    ) {}
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    #[Override]
+    public function path(): string
+    {
+        return $this->kernelReportedPath()
+            ?? $this->resolvedInvokedScriptPath()
+            ?? throw SelfUpdateFailedException::forUndeterminedBinaryPath();
+    }
+
+    private function kernelReportedPath(): ?string
+    {
+        if (!is_link($this->procSelfExePath)) {
+            return null;
+        }
+
+        $resolved = readlink($this->procSelfExePath);
+
+        return \is_string($resolved) ? $resolved : null;
+    }
+
+    private function resolvedInvokedScriptPath(): ?string
+    {
+        if ('' === $this->invokedScriptPath) {
+            return null;
+        }
+
+        $resolved = realpath($this->invokedScriptPath);
+
+        return false !== $resolved ? $resolved : null;
+    }
+}

--- a/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocatorInterface.php
+++ b/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocatorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface RunningBinaryLocatorInterface
+{
+    /**
+     * Absolute path to the currently-running executable — the file self-update
+     * replaces.
+     *
+     * @throws SelfUpdateFailedException
+     */
+    public function path(): string;
+}

--- a/src/Audit/Infrastructure/SelfUpdate/SelfUpdateResult.php
+++ b/src/Audit/Infrastructure/SelfUpdate/SelfUpdateResult.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class SelfUpdateResult
+{
+    public function __construct(
+        public SelfUpdateStatus $status,
+        public string $currentVersion,
+        public string $latestVersion,
+    ) {}
+}

--- a/src/Audit/Infrastructure/SelfUpdate/SelfUpdateStatus.php
+++ b/src/Audit/Infrastructure/SelfUpdate/SelfUpdateStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+enum SelfUpdateStatus
+{
+    case AlreadyUpToDate;
+    case UpdateAvailable;
+    case Updated;
+}

--- a/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
+++ b/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use JsonException;
+use Override;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\UnsupportedSelfUpdatePlatformException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class SelfUpdater implements SelfUpdaterInterface
+{
+    private const string LATEST_RELEASE_API_URL = 'https://api.github.com/repos/vinceAmstoutz/symfony-security-auditor/releases/latest';
+
+    public function __construct(
+        private ReleaseClientInterface $releaseClient,
+        private GitHubBinaryAssetResolver $gitHubBinaryAssetResolver,
+        private RunningBinaryLocatorInterface $runningBinaryLocator,
+        private Filesystem $filesystem = new Filesystem(),
+    ) {}
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    #[Override]
+    public function run(string $currentVersion, bool $checkOnly): SelfUpdateResult
+    {
+        $latestVersion = $this->latestVersion();
+
+        if (!version_compare($latestVersion, $currentVersion, '>')) {
+            return new SelfUpdateResult(SelfUpdateStatus::AlreadyUpToDate, $currentVersion, $latestVersion);
+        }
+
+        if ($checkOnly) {
+            return new SelfUpdateResult(SelfUpdateStatus::UpdateAvailable, $currentVersion, $latestVersion);
+        }
+
+        $this->replaceBinary($this->gitHubBinaryAssetResolver->resolve($latestVersion));
+
+        return new SelfUpdateResult(SelfUpdateStatus::Updated, $currentVersion, $latestVersion);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    private function latestVersion(): string
+    {
+        $payload = $this->releaseClient->get(self::LATEST_RELEASE_API_URL);
+
+        try {
+            $decoded = json_decode($payload, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw SelfUpdateFailedException::forUnresolvableLatestVersion(self::LATEST_RELEASE_API_URL, $jsonException);
+        }
+
+        if (!\is_array($decoded) || !\array_key_exists('tag_name', $decoded) || !\is_string($decoded['tag_name']) || '' === $decoded['tag_name']) {
+            throw SelfUpdateFailedException::forUnresolvableLatestVersion(self::LATEST_RELEASE_API_URL);
+        }
+
+        return $decoded['tag_name'];
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    private function replaceBinary(GitHubBinaryAsset $gitHubBinaryAsset): void
+    {
+        $binaryPath = $this->runningBinaryLocator->path();
+        if (!is_writable($binaryPath)) {
+            throw SelfUpdateFailedException::forUnwritableBinary($binaryPath);
+        }
+
+        $downloadPath = \sprintf('%s/.%s.download', \dirname($binaryPath), $gitHubBinaryAsset->name);
+        $this->releaseClient->download($gitHubBinaryAsset->downloadUrl, $downloadPath);
+        $this->assertChecksumMatches($gitHubBinaryAsset, $downloadPath);
+        $this->install($downloadPath, $binaryPath);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    private function assertChecksumMatches(GitHubBinaryAsset $gitHubBinaryAsset, string $downloadPath): void
+    {
+        $actual = hash_file('sha256', $downloadPath);
+        \assert(false !== $actual);
+
+        if (!hash_equals($this->expectedChecksum($gitHubBinaryAsset), $actual)) {
+            $this->filesystem->remove($downloadPath);
+
+            throw SelfUpdateFailedException::forChecksumMismatch($gitHubBinaryAsset->name);
+        }
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    private function expectedChecksum(GitHubBinaryAsset $gitHubBinaryAsset): string
+    {
+        return explode(' ', trim($this->releaseClient->get($gitHubBinaryAsset->checksumUrl)))[0];
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    private function install(string $downloadPath, string $binaryPath): void
+    {
+        try {
+            $this->filesystem->chmod($downloadPath, 0o755);
+            $this->filesystem->rename($downloadPath, $binaryPath, true);
+        } catch (IOException $ioException) {
+            $this->filesystem->remove($downloadPath);
+
+            throw SelfUpdateFailedException::forFailedReplacement($binaryPath, $ioException);
+        }
+    }
+}

--- a/src/Audit/Infrastructure/SelfUpdate/SelfUpdaterInterface.php
+++ b/src/Audit/Infrastructure/SelfUpdate/SelfUpdaterInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\UnsupportedSelfUpdatePlatformException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface SelfUpdaterInterface
+{
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function run(string $currentVersion, bool $checkOnly): SelfUpdateResult;
+}

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\UnsupportedSelfUpdatePlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateResult;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdaterInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateStatus;
+
+/** @internal not part of the BC promise — the command *name* (`self-update`) is public, but the PHP class itself is for internal use only. */
+#[AsCommand(name: self::NAME, description: self::DESCRIPTION)]
+final readonly class SelfUpdateCommand
+{
+    public const string NAME = 'self-update';
+
+    public const string DESCRIPTION = 'Update the standalone binary to the latest released version';
+
+    public function __construct(
+        private SelfUpdaterInterface $selfUpdater,
+        private string $currentVersion,
+    ) {}
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function __invoke(
+        SymfonyStyle $symfonyStyle,
+        #[Option(description: 'Only report whether a newer version is available; do not modify the binary.')]
+        bool $check = false,
+    ): int {
+        return $this->report($symfonyStyle, $this->selfUpdater->run($this->currentVersion, $check));
+    }
+
+    private function report(SymfonyStyle $symfonyStyle, SelfUpdateResult $selfUpdateResult): int
+    {
+        match ($selfUpdateResult->status) {
+            SelfUpdateStatus::AlreadyUpToDate => $symfonyStyle->success(\sprintf('Already up to date (%s).', $selfUpdateResult->currentVersion)),
+            SelfUpdateStatus::UpdateAvailable => $symfonyStyle->warning(\sprintf('A newer version is available: %s (currently %s). Run "self-update" without --check to install it.', $selfUpdateResult->latestVersion, $selfUpdateResult->currentVersion)),
+            SelfUpdateStatus::Updated => $symfonyStyle->success(\sprintf('Updated from %s to %s.', $selfUpdateResult->currentVersion, $selfUpdateResult->latestVersion)),
+        };
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -29,8 +29,13 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneP
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\YamlStandaloneConfigWriter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\GitHubBinaryAssetResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\ProcessReleaseClient;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\RunningBinaryLocator;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdater;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\InitCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\SelfUpdateCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Standalone\Exception\AmbiguousPlatformException;
 use VinceAmstoutz\SymfonySecurityAuditor\Standalone\Exception\MissingBundleExtensionException;
 use VinceAmstoutz\SymfonySecurityAuditor\Standalone\Exception\UnknownPlatformProviderException;
@@ -51,12 +56,13 @@ final readonly class StandaloneApplicationFactory
         private BridgeInstallerInterface $bridgeInstaller,
         private StandaloneContainerFactory $standaloneContainerFactory = new StandaloneContainerFactory(),
         private StandaloneConsoleCommandFactory $standaloneConsoleCommandFactory = new StandaloneConsoleCommandFactory(),
+        private string $runningBinaryPath = '',
     ) {}
 
     /**
      * @param array<string, string> $environment
      */
-    public static function fromEnvironment(array $environment): self
+    public static function fromEnvironment(array $environment, ?string $runningBinaryPath = null): self
     {
         $xdgConfigPathResolver = self::resolverFromEnvironment($environment);
 
@@ -68,6 +74,7 @@ final readonly class StandaloneApplicationFactory
             ),
             $xdgConfigPathResolver,
             new ComposerBridgeInstaller(ComposerBridgeInstaller::defaultProcessBuilder()),
+            runningBinaryPath: $runningBinaryPath ?? '',
         );
     }
 
@@ -99,6 +106,7 @@ final readonly class StandaloneApplicationFactory
     {
         $application = new Application(self::APPLICATION_NAME, (new ReportPackage())->version());
         $application->addCommand($this->initCommand());
+        $application->addCommand($this->selfUpdateCommand());
         $application->addCommand($this->lazyAuditCommand());
 
         return $application;
@@ -126,6 +134,18 @@ final readonly class StandaloneApplicationFactory
             new StandaloneConfigFactory(),
             new YamlStandaloneConfigWriter(),
             $this->bridgeInstaller,
+        );
+    }
+
+    private function selfUpdateCommand(): SelfUpdateCommand
+    {
+        return new SelfUpdateCommand(
+            new SelfUpdater(
+                new ProcessReleaseClient(ProcessReleaseClient::defaultProcessBuilder()),
+                new GitHubBinaryAssetResolver(\PHP_OS_FAMILY, php_uname('m')),
+                new RunningBinaryLocator('/proc/self/exe', $this->runningBinaryPath),
+            ),
+            (new ReportPackage())->version(),
         );
     }
 

--- a/tests/Phpunit/Integration/Command/Fixture/RecordingSelfUpdater.php
+++ b/tests/Phpunit/Integration/Command/Fixture/RecordingSelfUpdater.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Fixture;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateResult;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdaterInterface;
+
+final class RecordingSelfUpdater implements SelfUpdaterInterface
+{
+    public ?string $currentVersion = null;
+
+    public ?bool $checkOnly = null;
+
+    public function __construct(private readonly SelfUpdateResult $selfUpdateResult) {}
+
+    /**
+     * @throws void
+     */
+    #[Override]
+    public function run(string $currentVersion, bool $checkOnly): SelfUpdateResult
+    {
+        $this->currentVersion = $currentVersion;
+        $this->checkOnly = $checkOnly;
+
+        return $this->selfUpdateResult;
+    }
+}

--- a/tests/Phpunit/Integration/Command/SelfUpdateCommandTest.php
+++ b/tests/Phpunit/Integration/Command/SelfUpdateCommandTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateResult;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateStatus;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\SelfUpdateCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Fixture\RecordingSelfUpdater;
+
+final class SelfUpdateCommandTest extends TestCase
+{
+    public function test_it_reports_a_successful_update(): void
+    {
+        $commandTester = $this->commandTester(new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::Updated, '1.0.0', '2.0.0')));
+
+        $commandTester->execute([]);
+
+        self::assertStringContainsString('Updated from 1.0.0 to 2.0.0', $commandTester->getDisplay());
+    }
+
+    public function test_it_reports_when_already_up_to_date(): void
+    {
+        $commandTester = $this->commandTester(new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::AlreadyUpToDate, '2.0.0', '2.0.0')));
+
+        $commandTester->execute([]);
+
+        self::assertStringContainsString('Already up to date', $commandTester->getDisplay());
+    }
+
+    public function test_it_reports_an_available_update_in_check_mode(): void
+    {
+        $recordingSelfUpdater = new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::UpdateAvailable, '1.0.0', '2.0.0'));
+
+        $this->commandTester($recordingSelfUpdater)->execute(['--check' => true]);
+
+        self::assertTrue($recordingSelfUpdater->checkOnly);
+    }
+
+    public function test_it_runs_a_real_update_by_default(): void
+    {
+        $recordingSelfUpdater = new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::Updated, '3.1.4', '4.0.0'));
+
+        $this->commandTester($recordingSelfUpdater, '3.1.4')->execute([]);
+
+        self::assertFalse($recordingSelfUpdater->checkOnly);
+        self::assertSame('3.1.4', $recordingSelfUpdater->currentVersion);
+    }
+
+    public function test_it_reports_a_success_exit_code(): void
+    {
+        $commandTester = $this->commandTester(new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::Updated, '1.0.0', '2.0.0')));
+
+        self::assertSame(Command::SUCCESS, $commandTester->execute([]));
+    }
+
+    private function commandTester(RecordingSelfUpdater $recordingSelfUpdater, string $currentVersion = '1.0.0'): CommandTester
+    {
+        return new CommandTester(new SelfUpdateCommand($recordingSelfUpdater, $currentVersion));
+    }
+}

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/Fixture/FakeReleaseClient.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/Fixture/FakeReleaseClient.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Infrastructure\SelfUpdate\Fixture;
+
+use Override;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\ReleaseClientInterface;
+
+final class FakeReleaseClient implements ReleaseClientInterface
+{
+    /**
+     * @param array<string, string> $bodies keyed by URL
+     */
+    public function __construct(
+        private readonly array $bodies,
+        private readonly string $downloadPayload = '',
+    ) {}
+
+    #[Override]
+    public function get(string $url): string
+    {
+        return $this->bodies[$url] ?? throw SelfUpdateFailedException::forFailedDownload($url);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    #[Override]
+    public function download(string $url, string $destination): void
+    {
+        try {
+            (new Filesystem())->dumpFile($destination, $this->downloadPayload);
+        } catch (IOException $ioException) {
+            throw SelfUpdateFailedException::forFailedDownload($url, $ioException);
+        }
+    }
+}

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/ProcessReleaseClientTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/ProcessReleaseClientTest.php
@@ -50,6 +50,16 @@ final class ProcessReleaseClientTest extends TestCase
     /**
      * @throws SelfUpdateFailedException
      */
+    public function test_get_passes_the_requested_url_to_the_process(): void
+    {
+        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => Process::fromShellCommandline(\sprintf('printf %%s %s', escapeshellarg(implode(' ', $arguments)))));
+
+        self::assertSame('https://example.test/resource', $processReleaseClient->get('https://example.test/resource'));
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
     public function test_get_throws_when_the_process_reports_failure(): void
     {
         $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => new Process(['false']));

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/ProcessReleaseClientTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/ProcessReleaseClientTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Infrastructure\SelfUpdate;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\ProcessReleaseClient;
+
+final class ProcessReleaseClientTest extends TestCase
+{
+    private string $workingDirectory;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->workingDirectory = sys_get_temp_dir().'/ssa-release-'.bin2hex(random_bytes(6));
+        (new Filesystem())->mkdir($this->workingDirectory);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->workingDirectory);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_get_returns_the_process_output(): void
+    {
+        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => Process::fromShellCommandline('printf %s BODY'));
+
+        self::assertSame('BODY', $processReleaseClient->get('https://example.test/resource'));
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_get_throws_when_the_process_reports_failure(): void
+    {
+        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => new Process(['false']));
+
+        $this->expectException(SelfUpdateFailedException::class);
+
+        $processReleaseClient->get('https://example.test/resource');
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_download_writes_the_response_to_the_destination(): void
+    {
+        $destination = $this->workingDirectory.'/asset';
+        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => Process::fromShellCommandline(\sprintf('printf CONTENT > %s', escapeshellarg($arguments[1]))));
+
+        $processReleaseClient->download('https://example.test/asset', $destination);
+
+        self::assertStringEqualsFile($destination, 'CONTENT');
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_download_throws_when_the_process_reports_failure(): void
+    {
+        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => new Process(['false']));
+
+        $this->expectException(SelfUpdateFailedException::class);
+
+        $processReleaseClient->download('https://example.test/asset', $this->workingDirectory.'/asset');
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_throws_when_the_process_cannot_be_started(): void
+    {
+        $unlaunchableWorkingDirectory = $this->workingDirectory.'/missing-'.bin2hex(random_bytes(4));
+        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => new Process(['true'], $unlaunchableWorkingDirectory));
+
+        $this->expectException(SelfUpdateFailedException::class);
+
+        $processReleaseClient->get('https://example.test/resource');
+    }
+
+    public function test_default_process_builder_uses_authenticated_curl(): void
+    {
+        $process = (ProcessReleaseClient::defaultProcessBuilder())(['--output', '/tmp/asset', 'https://example.test/asset']);
+
+        $commandLine = $process->getCommandLine();
+        self::assertStringContainsString("'curl'", $commandLine);
+        self::assertStringContainsString("'-fsSL'", $commandLine);
+        self::assertStringContainsString("'User-Agent: symfony-security-auditor-self-update'", $commandLine);
+        self::assertStringContainsString("'https://example.test/asset'", $commandLine);
+        self::assertNull($process->getTimeout());
+    }
+}

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Infrastructure\SelfUpdate;
+
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\UnsupportedSelfUpdatePlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\GitHubBinaryAsset;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\GitHubBinaryAssetResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\ReleaseClientInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\RunningBinaryLocatorInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdater;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateStatus;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Infrastructure\SelfUpdate\Fixture\FakeReleaseClient;
+
+final class SelfUpdaterTest extends TestCase
+{
+    private const string LATEST_RELEASE_API_URL = 'https://api.github.com/repos/vinceAmstoutz/symfony-security-auditor/releases/latest';
+
+    private string $workingDirectory;
+
+    private string $binaryPath;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->workingDirectory = sys_get_temp_dir().'/ssa-updater-'.bin2hex(random_bytes(6));
+        (new Filesystem())->mkdir($this->workingDirectory);
+        $this->binaryPath = $this->workingDirectory.'/symfony-security-auditor';
+        (new Filesystem())->dumpFile($this->binaryPath, 'OLD-BINARY');
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->workingDirectory);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function test_it_downloads_verifies_and_replaces_the_binary_with_the_latest_release(): void
+    {
+        $payload = 'NEW-BINARY';
+        $selfUpdateResult = $this->selfUpdater($this->clientFor('9.9.9', $payload, hash('sha256', $payload)))->run('1.0.0', false);
+
+        self::assertSame(SelfUpdateStatus::Updated, $selfUpdateResult->status);
+        self::assertStringEqualsFile($this->binaryPath, $payload);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function test_it_reports_already_up_to_date_without_touching_the_binary(): void
+    {
+        $selfUpdateResult = $this->selfUpdater($this->clientFor('1.0.0', 'IGNORED', hash('sha256', 'IGNORED')))->run('1.0.0', false);
+
+        self::assertSame(SelfUpdateStatus::AlreadyUpToDate, $selfUpdateResult->status);
+        self::assertStringEqualsFile($this->binaryPath, 'OLD-BINARY');
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function test_check_only_reports_an_available_update_without_touching_the_binary(): void
+    {
+        $selfUpdateResult = $this->selfUpdater($this->clientFor('9.9.9', 'NEW', hash('sha256', 'NEW')))->run('1.0.0', true);
+
+        self::assertSame(SelfUpdateStatus::UpdateAvailable, $selfUpdateResult->status);
+        self::assertStringEqualsFile($this->binaryPath, 'OLD-BINARY');
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function test_it_rejects_a_download_whose_checksum_does_not_match(): void
+    {
+        $selfUpdater = $this->selfUpdater($this->clientFor('9.9.9', 'NEW', 'da39a3ee5e6b4b0d3255bfef95601890afd80709'));
+
+        try {
+            $this->expectException(SelfUpdateFailedException::class);
+
+            $selfUpdater->run('1.0.0', false);
+        } finally {
+            self::assertStringEqualsFile($this->binaryPath, 'OLD-BINARY');
+            self::assertFileDoesNotExist($this->workingDirectory.'/.symfony-security-auditor-linux-x86_64.download');
+        }
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function test_it_refuses_to_update_when_the_binary_is_not_writable(): void
+    {
+        $selfUpdater = $this->selfUpdater($this->clientFor('9.9.9', 'NEW', hash('sha256', 'NEW')), $this->workingDirectory.'/missing/symfony-security-auditor');
+
+        $this->expectException(SelfUpdateFailedException::class);
+        $this->expectExceptionMessage('not writable');
+
+        $selfUpdater->run('1.0.0', false);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    public function test_it_wraps_a_replacement_io_failure(): void
+    {
+        $filesystem = new class extends Filesystem {
+            #[Override]
+            public function rename(string $origin, string $target, bool $overwrite = false): void
+            {
+                throw new IOException('rename refused');
+            }
+        };
+        $payload = 'NEW';
+        $selfUpdater = $this->selfUpdater($this->clientFor('9.9.9', $payload, hash('sha256', $payload)), $this->binaryPath, $filesystem);
+
+        $this->expectException(SelfUpdateFailedException::class);
+
+        $selfUpdater->run('1.0.0', false);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    #[DataProvider('unresolvableLatestVersionPayloads')]
+    public function test_it_rejects_an_unresolvable_latest_version(string $apiBody): void
+    {
+        $selfUpdater = $this->selfUpdater(new FakeReleaseClient([self::LATEST_RELEASE_API_URL => $apiBody]));
+
+        $this->expectException(SelfUpdateFailedException::class);
+
+        $selfUpdater->run('1.0.0', false);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unresolvableLatestVersionPayloads(): iterable
+    {
+        yield 'not json' => ['this is not json'];
+        yield 'json scalar' => ['123'];
+        yield 'object without tag_name' => ['{"foo":"bar"}'];
+        yield 'non-string tag_name' => ['{"tag_name":123}'];
+        yield 'empty tag_name' => ['{"tag_name":""}'];
+    }
+
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    private function clientFor(string $tagName, string $payload, string $checksum): FakeReleaseClient
+    {
+        $asset = $this->asset($tagName);
+
+        return new FakeReleaseClient([
+            self::LATEST_RELEASE_API_URL => \sprintf('{"tag_name":"%s"}', $tagName),
+            $asset->checksumUrl => \sprintf('%s  %s', $checksum, $asset->name),
+        ], $payload);
+    }
+
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    private function asset(string $version): GitHubBinaryAsset
+    {
+        return (new GitHubBinaryAssetResolver('Linux', 'x86_64'))->resolve($version);
+    }
+
+    private function selfUpdater(ReleaseClientInterface $releaseClient, ?string $binaryPath = null, ?Filesystem $filesystem = null): SelfUpdater
+    {
+        $locator = self::createStub(RunningBinaryLocatorInterface::class);
+        $locator->method('path')->willReturn($binaryPath ?? $this->binaryPath);
+
+        return new SelfUpdater($releaseClient, new GitHubBinaryAssetResolver('Linux', 'x86_64'), $locator, $filesystem ?? new Filesystem());
+    }
+}

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
@@ -68,6 +68,18 @@ final class SelfUpdaterTest extends TestCase
      * @throws SelfUpdateFailedException
      * @throws UnsupportedSelfUpdatePlatformException
      */
+    public function test_it_marks_the_replaced_binary_as_executable(): void
+    {
+        $payload = 'NEW-BINARY';
+        $this->selfUpdater($this->clientFor('9.9.9', $payload, hash('sha256', $payload)))->run('1.0.0', false);
+
+        self::assertSame(0o755, fileperms($this->binaryPath) & 0o777);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
     public function test_it_reports_already_up_to_date_without_touching_the_binary(): void
     {
         $selfUpdateResult = $this->selfUpdater($this->clientFor('1.0.0', 'IGNORED', hash('sha256', 'IGNORED')))->run('1.0.0', false);
@@ -136,9 +148,13 @@ final class SelfUpdaterTest extends TestCase
         $payload = 'NEW';
         $selfUpdater = $this->selfUpdater($this->clientFor('9.9.9', $payload, hash('sha256', $payload)), $this->binaryPath, $filesystem);
 
-        $this->expectException(SelfUpdateFailedException::class);
+        try {
+            $this->expectException(SelfUpdateFailedException::class);
 
-        $selfUpdater->run('1.0.0', false);
+            $selfUpdater->run('1.0.0', false);
+        } finally {
+            self::assertFileDoesNotExist($this->workingDirectory.'/.symfony-security-auditor-linux-x86_64.download');
+        }
     }
 
     /**
@@ -176,7 +192,7 @@ final class SelfUpdaterTest extends TestCase
 
         return new FakeReleaseClient([
             self::LATEST_RELEASE_API_URL => \sprintf('{"tag_name":"%s"}', $tagName),
-            $asset->checksumUrl => \sprintf('%s  %s', $checksum, $asset->name),
+            $asset->checksumUrl => \sprintf("%s\n", $checksum),
         ], $payload);
     }
 

--- a/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
@@ -88,6 +88,16 @@ final class StandaloneApplicationFactoryTest extends TestCase
         self::assertTrue($application->has('init'));
     }
 
+    public function test_it_registers_the_self_update_command(): void
+    {
+        $application = StandaloneApplicationFactory::fromEnvironment([
+            'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
+            'XDG_CACHE_HOME' => $this->cacheHome,
+        ], '/usr/local/bin/symfony-security-auditor')->create();
+
+        self::assertTrue($application->has('self-update'));
+    }
+
     public function test_it_registers_the_audit_command_as_visible(): void
     {
         $application = StandaloneApplicationFactory::fromEnvironment([

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/GitHubBinaryAssetResolverTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/GitHubBinaryAssetResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\UnsupportedSelfUpdatePlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\GitHubBinaryAssetResolver;
+
+final class GitHubBinaryAssetResolverTest extends TestCase
+{
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    #[DataProvider('platformCases')]
+    public function test_it_resolves_the_release_asset_and_urls_for_the_platform(string $osFamily, string $machine, string $expectedAsset): void
+    {
+        $gitHubBinaryAsset = (new GitHubBinaryAssetResolver($osFamily, $machine))->resolve('1.2.3');
+
+        self::assertSame($expectedAsset, $gitHubBinaryAsset->name);
+        self::assertSame('https://github.com/vinceAmstoutz/symfony-security-auditor/releases/download/1.2.3/'.$expectedAsset, $gitHubBinaryAsset->downloadUrl);
+        self::assertSame($gitHubBinaryAsset->downloadUrl.'.sha256', $gitHubBinaryAsset->checksumUrl);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function platformCases(): iterable
+    {
+        yield 'linux x86_64' => ['Linux', 'x86_64', 'symfony-security-auditor-linux-x86_64'];
+        yield 'linux amd64' => ['Linux', 'amd64', 'symfony-security-auditor-linux-x86_64'];
+        yield 'linux aarch64' => ['Linux', 'aarch64', 'symfony-security-auditor-linux-aarch64'];
+        yield 'linux arm64' => ['Linux', 'arm64', 'symfony-security-auditor-linux-aarch64'];
+        yield 'macos x86_64' => ['Darwin', 'x86_64', 'symfony-security-auditor-macos-x86_64'];
+        yield 'macos arm64' => ['Darwin', 'arm64', 'symfony-security-auditor-macos-arm64'];
+        yield 'macos aarch64' => ['Darwin', 'aarch64', 'symfony-security-auditor-macos-arm64'];
+    }
+
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    #[DataProvider('unsupportedPlatformCases')]
+    public function test_it_rejects_an_unsupported_platform(string $osFamily, string $machine): void
+    {
+        $this->expectException(UnsupportedSelfUpdatePlatformException::class);
+
+        (new GitHubBinaryAssetResolver($osFamily, $machine))->resolve('1.2.3');
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function unsupportedPlatformCases(): iterable
+    {
+        yield 'unsupported operating system' => ['Windows', 'x86_64'];
+        yield 'unsupported bsd operating system' => ['BSD', 'x86_64'];
+        yield 'unsupported architecture' => ['Linux', 'riscv64'];
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate;
 
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
@@ -63,10 +64,20 @@ final class RunningBinaryLocatorTest extends TestCase
     /**
      * @throws SelfUpdateFailedException
      */
-    public function test_it_fails_when_neither_source_resolves_a_path(): void
+    #[DataProvider('unresolvableInvokedScriptCases')]
+    public function test_it_fails_when_neither_source_resolves_a_path(string $invokedScriptPath): void
     {
         $this->expectException(SelfUpdateFailedException::class);
 
-        (new RunningBinaryLocator($this->workingDirectory.'/missing', $this->workingDirectory.'/also-missing'))->path();
+        (new RunningBinaryLocator($this->workingDirectory.'/missing', $invokedScriptPath))->path();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unresolvableInvokedScriptCases(): iterable
+    {
+        yield 'no invoked script provided' => [''];
+        yield 'invoked script does not exist' => [sys_get_temp_dir().'/ssa-locator-also-missing'];
     }
 }

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
@@ -53,6 +53,21 @@ final class RunningBinaryLocatorTest extends TestCase
     /**
      * @throws SelfUpdateFailedException
      */
+    public function test_it_prefers_the_kernel_reported_executable_over_the_invoked_script(): void
+    {
+        $kernelTarget = $this->workingDirectory.'/kernel-binary';
+        (new Filesystem())->touch($kernelTarget);
+        $procSelfExe = $this->workingDirectory.'/proc-self-exe';
+        symlink($kernelTarget, $procSelfExe);
+        $invokedScript = $this->workingDirectory.'/invoked-binary';
+        (new Filesystem())->touch($invokedScript);
+
+        self::assertSame($kernelTarget, (new RunningBinaryLocator($procSelfExe, $invokedScript))->path());
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
     public function test_it_falls_back_to_the_resolved_invoked_script_when_proc_self_exe_is_absent(): void
     {
         $invokedScript = $this->workingDirectory.'/invoked-binary';

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\RunningBinaryLocator;
+
+final class RunningBinaryLocatorTest extends TestCase
+{
+    private string $workingDirectory;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->workingDirectory = sys_get_temp_dir().'/ssa-locator-'.bin2hex(random_bytes(6));
+        (new Filesystem())->mkdir($this->workingDirectory);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->workingDirectory);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_returns_the_kernel_reported_executable_when_proc_self_exe_is_a_link(): void
+    {
+        $target = $this->workingDirectory.'/actual-binary';
+        (new Filesystem())->touch($target);
+        $procSelfExe = $this->workingDirectory.'/proc-self-exe';
+        symlink($target, $procSelfExe);
+
+        self::assertSame($target, (new RunningBinaryLocator($procSelfExe, ''))->path());
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_falls_back_to_the_resolved_invoked_script_when_proc_self_exe_is_absent(): void
+    {
+        $invokedScript = $this->workingDirectory.'/invoked-binary';
+        (new Filesystem())->touch($invokedScript);
+
+        self::assertSame($invokedScript, (new RunningBinaryLocator($this->workingDirectory.'/missing', $invokedScript))->path());
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_fails_when_neither_source_resolves_a_path(): void
+    {
+        $this->expectException(SelfUpdateFailedException::class);
+
+        (new RunningBinaryLocator($this->workingDirectory.'/missing', $this->workingDirectory.'/also-missing'))->path();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **`self-update`** command to the standalone binary so users can upgrade in place instead of re-running the install script:

```bash
symfony-security-auditor self-update          # download + verify + replace, if newer
symfony-security-auditor self-update --check  # only report whether a newer version exists
```

It queries the GitHub releases API for the latest version and, when the running binary is older, downloads the asset for the current platform (mirroring `install.sh`'s OS/arch detection), **verifies its `.sha256` checksum before touching anything**, and atomically replaces the running executable. A non-writable binary (e.g. `/usr/local/bin` without write access) is refused with guidance to re-run with `sudo` or reinstall.

**Standalone-only** — it's wired in `StandaloneApplicationFactory`, not in the bundle (the Composer bundle updates via `composer update`).

### Design

- **No new dependency.** Downloads go through `curl` via Symfony `Process`, matching the project's subprocess-only convention and `ComposerBridgeInstaller`'s injected-process-builder pattern.
- Everything lives in `src/Audit/Infrastructure/SelfUpdate/` behind small ports — `ReleaseClientInterface` (`ProcessReleaseClient`), `RunningBinaryLocatorInterface` (`RunningBinaryLocator`), `SelfUpdaterInterface` (`SelfUpdater`) — plus a pure `GitHubBinaryAssetResolver` and value objects. The running-binary path is injected from `bin/` (`$_SERVER['SCRIPT_FILENAME']`, with `/proc/self/exe` preferred on Linux) so the replace logic is fully unit-tested against temp files.
- 100% line coverage + **100% MSI** on the new classes; PHPStan max, CS Fixer, Rector, and Deptrac all clean.

### ⚠️ One thing to verify before relying on it

Replacing the **running micro binary in place** can't be smoke-tested in CI (there's no real release binary in the test environment). The logic is unit-tested against temp files and correct by design, but please run one real `self-update` against a published release binary — especially on macOS, where there's no `/proc/self/exe` and it falls back to the invoked-script path — before announcing the feature. If that fallback proves unreliable on macOS, the fix is localized to `RunningBinaryLocator`.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)