### PR TITLE
ci: retry apt installs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,6 +111,14 @@ jobs:
           # unauthenticated 60-req/hour limit intermittently 403-ing the fix).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Preinstall doctor's Linux packages with apt retries and forced
+          # IPv4: doctor's own single-try 'apt-get install re2c autopoint'
+          # fails the job whenever the runner's mirror flakes (ports.ubuntu.com
+          # on arm64 times out intermittently and has no IPv6 route).
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update -o Acquire::Retries=3 -o Acquire::ForceIPv4=true
+            sudo apt-get install -y -o Acquire::Retries=3 -o Acquire::ForceIPv4=true re2c autopoint
+          fi
           # Must pass everywhere: on Unix it installs pkg-config/autoconf; on
           # Windows it installs php-sdk-binary-tools, whose 7za.exe spc's
           # source extraction silently depends on (exit codes are discarded).


### PR DESCRIPTION
## Summary

The `linux-aarch64` release leg fails intermittently: spc doctor's auto-fix runs a single-try `apt-get install re2c autopoint`, and `ports.ubuntu.com` (the arm64 mirror) times out over IPv4 while being unreachable over IPv6. The doctor step now preinstalls those two packages itself with `Acquire::Retries=3` and `Acquire::ForceIPv4=true`, so a mirror flake retries instead of failing the leg.

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint` (YAML validated; no PHP or Markdown touched)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)