### PR TITLE
ci: hide the macOS tap-trust warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,6 +119,13 @@ jobs:
             sudo apt-get update -o Acquire::Retries=3 -o Acquire::ForceIPv4=true
             sudo apt-get install -y -o Acquire::Retries=3 -o Acquire::ForceIPv4=true re2c autopoint
           fi
+          # The macOS runner image ships the aws/tap Homebrew tap, which
+          # Homebrew's tap-trust policy distrusts — every brew call doctor
+          # makes then emits a warning annotation. Nothing here uses that
+          # tap, so drop it (untap is Homebrew's own first recommendation).
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            brew untap aws/tap || true
+          fi
           # Must pass everywhere: on Unix it installs pkg-config/autoconf; on
           # Windows it installs php-sdk-binary-tools, whose 7za.exe spc's
           # source extraction silently depends on (exit codes are discarded).


### PR DESCRIPTION
## Summary

Every release run collects eight warning annotations from the macOS legs: the runner image ships the `aws/tap` Homebrew tap, and Homebrew's tap-trust policy warns "`The following taps are not trusted: aws/tap`" on each brew call `spc doctor` makes. Nothing in the build uses that tap, so the doctor step now untaps it first — Homebrew's own first recommendation, rather than the discouraged `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` escape hatch.

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass: `bin/castor lint` (YAML validated; no PHP or Markdown touched)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)