### PR TITLE
feat(scan): add an HTTP trust-boundary attacker skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   See
   [CLI Reference → `self-update`](docs/configuration.md#self-update--updating-the-standalone-binary).
 
+- **The attacker now hunts HTTP trust-boundary misconfigurations: wildcard
+  `trusted_proxies`, and Host-header injection / cache poisoning.** Two new
+  `AttackerSkillInterface` strategies — `TrustBoundaryAttackerSkill` (`CONFIG`)
+  and `ControllerTrustBoundaryAttackerSkill` (`CONTROLLER`) — teach the attacker
+  to flag `framework.trusted_proxies`/`TRUSTED_PROXIES` set to a wildcard CIDR
+  (`0.0.0.0/0`, `::/0`), which lets any client spoof `X-Forwarded-*` headers and
+  defeat IP allowlists and rate limiters, and to flag `Request::getHost()` /
+  `getSchemeAndHttpHost()` / `getHttpHost()` used to build links or cache
+  decisions without `trusted_hosts` configured. `RegexStaticPreScanner` gained
+  matching `trusted_proxies_wildcard` and `forwarded_host_usage` risk markers
+  (`CACHE_VERSION` bumped to 27). Two new `VulnerabilityType` cases —
+  `host_header_injection` (CWE-20) and `trusted_proxy_misconfiguration`
+  (CWE-290) — cover the new findings, both under OWASP A02:2025 - Security
+  Misconfiguration. Implementation lives in
+  `src/Audit/Infrastructure/Prompt/Skill/` and
+  `src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php`.
+
 ### Fixed
 
 - **The native Windows binary is published with releases again.**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,7 +253,7 @@ Fields: `id`, `type` (enum), `severity` (enum), `title`, `description`,
 
 ### `VulnerabilityType` — backed enum with OWASP and CWE references
 
-40 cases in six categories:
+42 cases in six categories:
 
 | Category              | Examples                                                                   |
 | --------------------- | -------------------------------------------------------------------------- |

--- a/src/Audit/Domain/Model/VulnerabilityType.php
+++ b/src/Audit/Domain/Model/VulnerabilityType.php
@@ -68,6 +68,8 @@ enum VulnerabilityType: string
     case MAILER_HEADER_INJECTION = 'mailer_header_injection';
     case WEBHOOK_REPLAY = 'webhook_replay';
     case AUTHENTICATOR_BYPASS = 'authenticator_bypass';
+    case HOST_HEADER_INJECTION = 'host_header_injection';
+    case TRUSTED_PROXY_MISCONFIGURATION = 'trusted_proxy_misconfiguration';
 
     public function category(): string
     {
@@ -103,6 +105,7 @@ enum VulnerabilityType: string
             self::MISCONFIGURED_FIREWALL,
             self::INSECURE_REDIRECT,
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
+            self::TRUSTED_PROXY_MISCONFIGURATION,
             self::MESSENGER_HANDLER_UNSAFE => 'Symfony-Specific',
 
             self::SENSITIVE_DATA_EXPOSURE,
@@ -111,6 +114,7 @@ enum VulnerabilityType: string
             self::SSRF,
             self::XXE,
             self::OPEN_REDIRECT,
+            self::HOST_HEADER_INJECTION,
             self::CACHE_POISONING => 'Data Exposure',
 
             self::WEAK_CRYPTOGRAPHY,
@@ -161,6 +165,8 @@ enum VulnerabilityType: string
             self::MISCONFIGURED_FIREWALL,
             self::XXE,
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
+            self::HOST_HEADER_INJECTION,
+            self::TRUSTED_PROXY_MISCONFIGURATION,
             self::CACHE_POISONING => 'OWASP A02:2025 - Security Misconfiguration',
 
             self::INSECURE_DESERIALIZATION,
@@ -213,6 +219,8 @@ enum VulnerabilityType: string
             self::MISCONFIGURED_FIREWALL,
             self::XXE,
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
+            self::HOST_HEADER_INJECTION,
+            self::TRUSTED_PROXY_MISCONFIGURATION,
             self::CACHE_POISONING => 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/',
 
             self::INSECURE_DESERIALIZATION,
@@ -253,9 +261,11 @@ enum VulnerabilityType: string
             self::MASS_ASSIGNMENT => CweReference::of(915),
             self::INSECURE_DESERIALIZATION,
             self::MESSENGER_HANDLER_UNSAFE => CweReference::of(502),
-            self::UNSAFE_PARAMETER_BINDING => CweReference::of(20),
+            self::UNSAFE_PARAMETER_BINDING,
+            self::HOST_HEADER_INJECTION => CweReference::of(20),
             self::EXPOSED_INTERNAL_SERVICE => CweReference::of(668),
             self::MISCONFIGURED_FIREWALL => CweReference::of(306),
+            self::TRUSTED_PROXY_MISCONFIGURATION => CweReference::of(290),
             self::INSECURE_REDIRECT,
             self::OPEN_REDIRECT => CweReference::of(601),
             self::OVER_PERMISSIVE_SERIALIZER_GROUP => CweReference::of(213),

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -210,7 +210,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             log_injection, path_traversal, ssrf, xxe, open_redirect, weak_cryptography, insecure_random,
             hardcoded_secret, missing_signature_verification, messenger_handler_unsafe, missing_rate_limiting,
             cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass,
-            over_permissive_serializer_group
+            over_permissive_serializer_group, host_header_injection, trusted_proxy_misconfiguration
 
             Severity rubric (calibrate every finding against this scale — do NOT inflate severity for emphasis):
             - critical: unauthenticated RCE, full authentication bypass, mass data exfiltration without auth, hardcoded production secret in a committed file.

--- a/src/Audit/Infrastructure/Prompt/Reviewer/ReviewerPromptSections.php
+++ b/src/Audit/Infrastructure/Prompt/Reviewer/ReviewerPromptSections.php
@@ -89,7 +89,7 @@ final readonly class ReviewerPromptSections implements ReviewerPromptSectionsInt
         log_injection, path_traversal, ssrf, xxe, open_redirect, weak_cryptography, insecure_random,
         hardcoded_secret, missing_signature_verification, messenger_handler_unsafe, missing_rate_limiting,
         cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass,
-        over_permissive_serializer_group
+        over_permissive_serializer_group, host_header_injection, trusted_proxy_misconfiguration
         SCHEMA;
 
     private const string DECISION_RULES = <<<'RULES'

--- a/src/Audit/Infrastructure/Prompt/Skill/AttackerSkillRegistry.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/AttackerSkillRegistry.php
@@ -65,6 +65,7 @@ final readonly class AttackerSkillRegistry
         return [
             new ControllerAttackerSkill(),
             new ControllerFileUploadAttackerSkill(),
+            new ControllerTrustBoundaryAttackerSkill(),
             new ApiResourceAttackerSkill(),
             new LiveComponentAttackerSkill(),
             new AuthenticatorAttackerSkill(),
@@ -82,6 +83,7 @@ final readonly class AttackerSkillRegistry
             new TemplateAttackerSkill(),
             new TwigExtensionAttackerSkill(),
             new ConfigAttackerSkill(),
+            new TrustBoundaryAttackerSkill(),
             new PhpAttackerSkill(),
         ];
     }

--- a/src/Audit/Infrastructure/Prompt/Skill/ControllerTrustBoundaryAttackerSkill.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/ControllerTrustBoundaryAttackerSkill.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class ControllerTrustBoundaryAttackerSkill implements AttackerSkillInterface
+{
+    #[Override]
+    public function fileType(): ProjectFileType
+    {
+        return ProjectFileType::CONTROLLER;
+    }
+
+    #[Override]
+    public function priority(): int
+    {
+        return 17;
+    }
+
+    #[Override]
+    public function block(): string
+    {
+        return <<<'SKILL'
+            <skills role="controller_trust_boundary">
+            Hunt (`Request::getHost()` / `getSchemeAndHttpHost()` / `getHttpHost()`):
+            - The Host derived from the request is used to build a password-reset, email-verification, or webhook-callback URL without a hardcoded or `%env(APP_URL)%`-sourced base — an attacker-controlled `Host` header ends up embedded in a link sent to another user (host header injection / password-reset poisoning).
+            - A cache key, cached response, or `Cache-Control` decision derived from the request's Host or forwarded headers — HTTP cache poisoning via header spoofing when `trusted_proxies`/`trusted_hosts` is not correctly scoped.
+            Do NOT flag:
+            - URL generation via the `router` service (`UrlGeneratorInterface::generate(..., UrlGeneratorInterface::ABSOLUTE_URL)`) — Symfony's router uses the configured request context, not a manually read `Host` header.
+            - `getHost()`/`getHttpHost()` calls used only for logging or display, not for building a link, cache key, or security decision.
+            </skills>
+            SKILL;
+    }
+}

--- a/src/Audit/Infrastructure/Prompt/Skill/TrustBoundaryAttackerSkill.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/TrustBoundaryAttackerSkill.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class TrustBoundaryAttackerSkill implements AttackerSkillInterface
+{
+    #[Override]
+    public function fileType(): ProjectFileType
+    {
+        return ProjectFileType::CONFIG;
+    }
+
+    #[Override]
+    public function priority(): int
+    {
+        return 155;
+    }
+
+    #[Override]
+    public function block(): string
+    {
+        return <<<'SKILL'
+            <skills role="trust_boundary">
+            Hunt (`framework.trusted_proxies` / `framework.trusted_headers` / `TRUSTED_PROXIES`):
+            - `trusted_proxies` set to a wildcard CIDR (`'0.0.0.0/0'`, `'::/0'`) — any client can spoof `X-Forwarded-For`/`X-Forwarded-Host`/`X-Forwarded-Proto`, defeating IP allowlists and rate limiters that trust `Request::getClientIp()`.
+            - `TRUSTED_PROXIES=0.0.0.0/0` (or an equivalent wildcard) in a committed `.env`/`.env.*` file — same risk, sourced from the environment instead of YAML.
+            - `framework.trusted_hosts` absent or empty while the app builds absolute URLs (password-reset links, email-verification links, webhook callback URLs) from the incoming request — an attacker-supplied `Host` header is trusted verbatim and can poison those links or an intermediary cache.
+            Do NOT flag:
+            - `trusted_proxies` scoped to a private/internal CIDR (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) or a specific load-balancer IP — that is the correct configuration for a reverse-proxy deployment.
+            - `trusted_hosts` populated with an explicit allow-list of hostnames or a regex.
+            </skills>
+            SKILL;
+    }
+}

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -34,7 +34,7 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      * alter scan output for existing chunk content. Folded into the attacker
      * cache key so stale entries are invalidated.
      */
-    public const int CACHE_VERSION = 26;
+    public const int CACHE_VERSION = 27;
 
     /**
      * Detects the `s` (DOTALL) flag among a PCRE pattern's trailing modifier
@@ -152,6 +152,10 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
             'request_mapping_attribute' => [
                 'regex' => '/#\[Map(?:RequestPayload|QueryString|QueryParameter)\b/',
                 'description' => '#[MapRequestPayload]/#[MapQueryString]/#[MapQueryParameter] — verify the bound DTO has validation constraints and no privileged setters (mass assignment / IDOR)',
+            ],
+            'forwarded_host_usage' => [
+                'regex' => '/->(?:getHost|getSchemeAndHttpHost|getHttpHost)\s*\(/',
+                'description' => 'Request::getHost()/getSchemeAndHttpHost() — verify trusted_proxies/trusted_hosts are configured before this value is used in a link or cache key (host header injection / cache poisoning)',
             ],
         ],
         ProjectFileType::VOTER->value => [
@@ -278,6 +282,10 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
             'scrubbed_secret' => [
                 'regex' => '/\*\*\*REDACTED:/',
                 'description' => 'A credential-shaped value was redacted here before analysis — a real secret is committed in this file',
+            ],
+            'trusted_proxies_wildcard' => [
+                'regex' => '/(?:trusted_proxies\s*:|TRUSTED_PROXIES\s*=)\s*[\'"]?(?:0\.0\.0\.0\/0|::\/0)/i',
+                'description' => 'trusted_proxies set to a wildcard CIDR (0.0.0.0/0, ::/0) — any client can spoof X-Forwarded-* headers, defeating IP allowlists and rate limiters',
             ],
         ],
         ProjectFileType::AUTHENTICATOR->value => [

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
@@ -63,6 +63,8 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::WEBHOOK_REPLAY, 'Logic Flaw'];
         yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'Broken Access Control'];
         yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'Symfony-Specific'];
+        yield [VulnerabilityType::HOST_HEADER_INJECTION, 'Data Exposure'];
+        yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'Symfony-Specific'];
     }
 
     public static function owaspProvider(): Iterator
@@ -96,6 +98,8 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::WEBHOOK_REPLAY, 'A06:2025'];
         yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'A07:2025'];
         yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'A02:2025'];
+        yield [VulnerabilityType::HOST_HEADER_INJECTION, 'A02:2025'];
+        yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'A02:2025'];
     }
 
     #[DataProvider('categoryProvider')]
@@ -148,6 +152,8 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::MISSING_SIGNATURE_VERIFICATION, 'https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/'];
         yield [VulnerabilityType::BUSINESS_LOGIC_FLAW, 'https://owasp.org/Top10/2025/A06_2025-Insecure_Design/'];
         yield [VulnerabilityType::MASS_ASSIGNMENT, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
+        yield [VulnerabilityType::HOST_HEADER_INJECTION, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
+        yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
         yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/'];
         yield [VulnerabilityType::SENSITIVE_DATA_EXPOSURE, 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/'];
         yield [VulnerabilityType::SSRF, 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/'];
@@ -189,8 +195,10 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'CWE-502'];
         yield [VulnerabilityType::MESSENGER_HANDLER_UNSAFE, 'CWE-502'];
         yield [VulnerabilityType::UNSAFE_PARAMETER_BINDING, 'CWE-20'];
+        yield [VulnerabilityType::HOST_HEADER_INJECTION, 'CWE-20'];
         yield [VulnerabilityType::EXPOSED_INTERNAL_SERVICE, 'CWE-668'];
         yield [VulnerabilityType::MISCONFIGURED_FIREWALL, 'CWE-306'];
+        yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'CWE-290'];
         yield [VulnerabilityType::INSECURE_REDIRECT, 'CWE-601'];
         yield [VulnerabilityType::OPEN_REDIRECT, 'CWE-601'];
         yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'CWE-213'];

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -1254,7 +1254,7 @@ final class AttackerPromptBuilderTest extends TestCase
 
         $prompt = $attackerPromptBuilder->buildSystemPrompt([$projectFile]);
 
-        self::assertSame(20, substr_count($prompt, '<skills role="'));
+        self::assertSame(22, substr_count($prompt, '<skills role="'));
     }
 
     /**
@@ -2049,6 +2049,8 @@ final class AttackerPromptBuilderTest extends TestCase
         self::assertStringContainsString('mailer_header_injection', $prompt);
         self::assertStringContainsString('webhook_replay', $prompt);
         self::assertStringContainsString('authenticator_bypass', $prompt);
+        self::assertStringContainsString('host_header_injection', $prompt);
+        self::assertStringContainsString('trusted_proxy_misconfiguration', $prompt);
     }
 
     public function test_base_prompt_references_modern_symfony_components_in_expertise(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
@@ -222,6 +222,8 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString('messenger_handler_unsafe', $prompt);
         self::assertStringContainsString('webhook_replay', $prompt);
         self::assertStringContainsString('authenticator_bypass', $prompt);
+        self::assertStringContainsString('host_header_injection', $prompt);
+        self::assertStringContainsString('trusted_proxy_misconfiguration', $prompt);
     }
 
     public function test_decision_rules_restrict_rejection_to_a_named_mitigating_control(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/Skill/AttackerSkillRegistryTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/Skill/AttackerSkillRegistryTest.php
@@ -24,6 +24,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\Authe
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\ConfigAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\ControllerAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\ControllerFileUploadAttackerSkill;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\ControllerTrustBoundaryAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\EntityAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\EntityFileUploadAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\EventSubscriberAttackerSkill;
@@ -36,6 +37,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\PhpAt
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\RepositoryAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\SchedulerAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\TemplateAttackerSkill;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\TrustBoundaryAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\TwigExtensionAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\VoterAttackerSkill;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Prompt\Skill\WebhookConsumerAttackerSkill;
@@ -64,6 +66,7 @@ final class AttackerSkillRegistryTest extends TestCase
     {
         yield 'controller' => [new ControllerAttackerSkill(), ProjectFileType::CONTROLLER, 10, 'controller'];
         yield 'file_upload_controller' => [new ControllerFileUploadAttackerSkill(), ProjectFileType::CONTROLLER, 15, 'file_upload_controller'];
+        yield 'controller_trust_boundary' => [new ControllerTrustBoundaryAttackerSkill(), ProjectFileType::CONTROLLER, 17, 'controller_trust_boundary'];
         yield 'api_resource' => [new ApiResourceAttackerSkill(), ProjectFileType::API_RESOURCE, 20, 'api_resource'];
         yield 'live_component' => [new LiveComponentAttackerSkill(), ProjectFileType::LIVE_COMPONENT, 30, 'live_component'];
         yield 'authenticator' => [new AuthenticatorAttackerSkill(), ProjectFileType::AUTHENTICATOR, 40, 'authenticator'];
@@ -81,6 +84,7 @@ final class AttackerSkillRegistryTest extends TestCase
         yield 'template' => [new TemplateAttackerSkill(), ProjectFileType::TEMPLATE, 140, 'template'];
         yield 'twig_extension' => [new TwigExtensionAttackerSkill(), ProjectFileType::TWIG_EXTENSION, 145, 'twig_extension'];
         yield 'config' => [new ConfigAttackerSkill(), ProjectFileType::CONFIG, 150, 'config'];
+        yield 'trust_boundary' => [new TrustBoundaryAttackerSkill(), ProjectFileType::CONFIG, 155, 'trust_boundary'];
         yield 'php' => [new PhpAttackerSkill(), ProjectFileType::PHP, 160, 'php'];
     }
 
@@ -101,7 +105,7 @@ final class AttackerSkillRegistryTest extends TestCase
 
         $output = $attackerSkillRegistry->render([], emitAll: true);
 
-        self::assertSame(20, substr_count($output, '<skills role="'));
+        self::assertSame(22, substr_count($output, '<skills role="'));
     }
 
     public function test_it_emits_blocks_in_attack_surface_priority_order(): void
@@ -115,6 +119,7 @@ final class AttackerSkillRegistryTest extends TestCase
         self::assertSame([
             'controller',
             'file_upload_controller',
+            'controller_trust_boundary',
             'api_resource',
             'live_component',
             'authenticator',
@@ -132,6 +137,7 @@ final class AttackerSkillRegistryTest extends TestCase
             'template',
             'twig_extension',
             'config',
+            'trust_boundary',
             'php',
         ], $matches[1]);
     }
@@ -157,7 +163,7 @@ final class AttackerSkillRegistryTest extends TestCase
      */
     public static function everyFileTypeWithASkill(): iterable
     {
-        yield 'controller' => [ProjectFileType::CONTROLLER, ['controller', 'file_upload_controller']];
+        yield 'controller' => [ProjectFileType::CONTROLLER, ['controller', 'file_upload_controller', 'controller_trust_boundary']];
         yield 'api_resource' => [ProjectFileType::API_RESOURCE, ['api_resource']];
         yield 'live_component' => [ProjectFileType::LIVE_COMPONENT, ['live_component']];
         yield 'authenticator' => [ProjectFileType::AUTHENTICATOR, ['authenticator']];
@@ -172,7 +178,7 @@ final class AttackerSkillRegistryTest extends TestCase
         yield 'entity' => [ProjectFileType::ENTITY, ['entity', 'file_upload_entity']];
         yield 'template' => [ProjectFileType::TEMPLATE, ['template']];
         yield 'twig_extension' => [ProjectFileType::TWIG_EXTENSION, ['twig_extension']];
-        yield 'config' => [ProjectFileType::CONFIG, ['config']];
+        yield 'config' => [ProjectFileType::CONFIG, ['config', 'trust_boundary']];
         yield 'php' => [ProjectFileType::PHP, ['php']];
     }
 

--- a/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
@@ -791,6 +791,92 @@ final class RegexStaticPreScannerTest extends TestCase
      * @throws InvalidProjectFileException
      * @throws InvalidRiskMarkerException
      */
+    #[DataProvider('forwardedHostUsageCases')]
+    public function test_it_flags_forwarded_host_usage_in_a_controller(string $call): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/PasswordResetController.php',
+            '/app/src/Controller/PasswordResetController.php',
+            "<?php\nclass PasswordResetController { public function reset(\$request) { return \$request->{$call}(); } }",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('forwarded_host_usage', $patterns);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function forwardedHostUsageCases(): iterable
+    {
+        yield 'getHost' => ['getHost'];
+        yield 'getSchemeAndHttpHost' => ['getSchemeAndHttpHost'];
+        yield 'getHttpHost' => ['getHttpHost'];
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_does_not_flag_an_unrelated_getter_call(): void
+    {
+        $projectFile = ProjectFile::create(
+            'src/Controller/ImportController.php',
+            '/app/src/Controller/ImportController.php',
+            "<?php\nclass ImportController { public function import(\$uri) { return \$uri->getPath(); } }",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertNotContains('forwarded_host_usage', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    #[DataProvider('trustedProxiesWildcardCases')]
+    public function test_it_flags_a_wildcard_trusted_proxies_configuration(string $fileName, string $content): void
+    {
+        $projectFile = ProjectFile::create($fileName, '/app/'.$fileName, $content);
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('trusted_proxies_wildcard', $patterns);
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function trustedProxiesWildcardCases(): iterable
+    {
+        yield 'YAML IPv4 wildcard' => ['config/packages/framework.yaml', "framework:\n    trusted_proxies: '0.0.0.0/0'"];
+        yield 'YAML IPv6 wildcard' => ['config/packages/framework.yaml', "framework:\n    trusted_proxies: '::/0'"];
+        yield 'dotenv wildcard' => ['.env', "TRUSTED_PROXIES=0.0.0.0/0\n"];
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_does_not_flag_trusted_proxies_scoped_to_a_private_cidr(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/framework.yaml',
+            '/app/config/packages/framework.yaml',
+            "framework:\n    trusted_proxies: '10.0.0.0/8'",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertNotContains('trusted_proxies_wildcard', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
     public function test_it_flags_form_submit_with_request_all_split_across_lines(): void
     {
         $projectFile = ProjectFile::create(


### PR DESCRIPTION
## Summary

This update introduces zero-coverage detection for Trusted-proxy and Host-header vulnerabilities by adding two new AttackerSkillInterface strategies (TrustBoundaryAttackerSkill and ControllerTrustBoundaryAttackerSkill), two new RegexStaticPreScanner risk markers (trusted_proxies_wildcard and forwarded_host_usage which bumps the CACHE_VERSION to 27), and two new VulnerabilityType cases (host_header_injection/CWE-20 and trusted_proxy_misconfiguration/CWE-290 under OWASP A02:2025), while updating JSON-mode schema validation lists in prompt builders; because these additions consist purely of additive Domain enum cases and internal skill classes with no public configuration or command surface changes, this qualifies as a MINOR version change.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass
- [x] 100% MSI maintained
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)