### PR TITLE
feat(ci): add standalone mode and outputs to the GitHub Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,22 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `src/Audit/Infrastructure/Prompt/Skill/` and
   `src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php`.
 
+- **The GitHub Action can now run the standalone binary instead of requiring the
+  bundle, and exposes first-class outputs.** A new `mode: bundle|standalone`
+  input (default `bundle`, matching prior behavior) downloads the
+  checksum-verified standalone binary via `install.sh` and configures it with
+  `symfony-security-auditor init --no-interaction` instead of running
+  `composer install` + `bin/console audit:run` — the target project no longer
+  needs the bundle in its `composer.json`. A host PHP + Composer are still
+  required in standalone mode (`setup-php` stays `true`) since `init` fetches
+  the provider bridge through Composer; standalone mode in this action always
+  configures the `anthropic`/`claude-opus-4-8` default non-interactively. The
+  action also gained an `outputs:` block (`exit-code`, `report-path`, and, when
+  `format: json`, `findings-count`/`highest-severity` read from the report's
+  `total_vulnerabilities`/`risk_level` fields via `jq`) and a first-class
+  `fail-on` input (previously reachable only through `extra-args`).
+  Implementation lives in `action.yml`.
+
 ### Fixed
 
 - **The native Windows binary is published with releases again.**

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ branding:
   color: purple
 
 inputs:
+  mode:
+    description: 'How to run the audit: "bundle" (require the Symfony bundle in the target project via Composer, then run `bin/console audit:run`) or "standalone" (download the checksum-verified standalone binary — no bundle dependency needed in the target project). Composer + a host PHP are still required in standalone mode to fetch the provider bridge via `init`.'
+    required: false
+    default: bundle
   project-path:
     description: Path to the Symfony project to audit.
     required: false
@@ -31,6 +35,10 @@ inputs:
     description: Diff mode — audit only files changed against this git ref (e.g. origin/main).
     required: false
     default: ""
+  fail-on:
+    description: Minimum aggregate risk level (safe, low, medium, high, critical) that makes the audit exit 1. Leave empty to use the project's audit.fail_on configuration (default critical).
+    required: false
+    default: ""
   extra-args:
     description: Additional raw arguments appended verbatim to the audit:run invocation (e.g. "--path=src --no-cache").
     required: false
@@ -40,17 +48,31 @@ inputs:
     required: false
     default: "8.3"
   setup-php:
-    description: Whether this action installs PHP via shivammathur/setup-php. Set to false if your workflow already set PHP up.
+    description: Whether this action installs PHP via shivammathur/setup-php. Set to false if your workflow already set PHP up. Still required in standalone mode — a host PHP + Composer are needed to fetch the provider bridge via `init`.
     required: false
     default: "true"
   install-dependencies:
-    description: Whether this action runs `composer install` before auditing. Set to false if your workflow already installed dependencies.
+    description: Whether this action runs `composer install` before auditing. Only applies in bundle mode; ignored in standalone mode. Set to false if your workflow already installed dependencies.
     required: false
     default: "true"
   working-directory:
     description: Directory to run composer and the console command from.
     required: false
     default: "."
+
+outputs:
+  exit-code:
+    description: The audit command's exit code (0 = passed, 1 = failed the fail-on gate, 2 = budget aborted).
+    value: ${{ steps.audit.outputs.exit-code }}
+  report-path:
+    description: The path the report was written to (mirrors the output input; empty when the report was printed to stdout).
+    value: ${{ steps.audit.outputs.report-path }}
+  findings-count:
+    description: Total number of findings in the report. Only populated when format is json (empty for other formats).
+    value: ${{ steps.audit.outputs.findings-count }}
+  highest-severity:
+    description: The report's aggregate risk level (safe, low, medium, high, critical). Only populated when format is json (empty for other formats).
+    value: ${{ steps.audit.outputs.highest-severity }}
 
 runs:
   using: composite
@@ -63,29 +85,63 @@ runs:
         coverage: none
 
     - name: Install Composer dependencies
-      if: ${{ inputs.install-dependencies == 'true' }}
+      if: ${{ inputs.install-dependencies == 'true' && inputs.mode == 'bundle' }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: composer install --no-interaction --prefer-dist --no-progress
 
+    - name: Install the standalone binary
+      if: ${{ inputs.mode == 'standalone' }}
+      shell: bash
+      env:
+        SSA_INSTALL_DIR: ${{ github.action_path }}/.bin
+      run: |
+        set -euo pipefail
+        curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh | sh
+        echo "$SSA_INSTALL_DIR" >> "$GITHUB_PATH"
+
+    - name: Configure the standalone binary
+      if: ${{ inputs.mode == 'standalone' }}
+      shell: bash
+      run: symfony-security-auditor init --no-interaction
+
     - name: Run security audit
+      id: audit
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
+        SSA_MODE: ${{ inputs.mode }}
         SSA_PROJECT_PATH: ${{ inputs.project-path }}
         SSA_FORMAT: ${{ inputs.format }}
         SSA_OUTPUT: ${{ inputs.output }}
         SSA_BASELINE: ${{ inputs.baseline }}
         SSA_GENERATE_BASELINE: ${{ inputs.generate-baseline }}
         SSA_SINCE: ${{ inputs.since }}
+        SSA_FAIL_ON: ${{ inputs.fail-on }}
         SSA_EXTRA_ARGS: ${{ inputs.extra-args }}
       run: |
-        set -euo pipefail
+        set -uo pipefail
         args=("$SSA_PROJECT_PATH" "--format=$SSA_FORMAT")
         if [ -n "$SSA_OUTPUT" ]; then args+=("--output=$SSA_OUTPUT"); fi
         if [ -n "$SSA_BASELINE" ]; then args+=("--baseline=$SSA_BASELINE"); fi
         if [ -n "$SSA_GENERATE_BASELINE" ]; then args+=("--generate-baseline=$SSA_GENERATE_BASELINE"); fi
         if [ -n "$SSA_SINCE" ]; then args+=("--since=$SSA_SINCE"); fi
+        if [ -n "$SSA_FAIL_ON" ]; then args+=("--fail-on=$SSA_FAIL_ON"); fi
         # shellcheck disable=SC2206 -- intentional word-splitting of caller-supplied extra args
         if [ -n "$SSA_EXTRA_ARGS" ]; then args+=($SSA_EXTRA_ARGS); fi
-        php bin/console audit:run "${args[@]}"
+
+        if [ "$SSA_MODE" = "standalone" ]; then
+          symfony-security-auditor audit "${args[@]}"
+        else
+          php bin/console audit:run "${args[@]}"
+        fi
+        exit_code=$?
+
+        echo "exit-code=$exit_code" >> "$GITHUB_OUTPUT"
+        echo "report-path=$SSA_OUTPUT" >> "$GITHUB_OUTPUT"
+        if [ "$SSA_FORMAT" = "json" ] && [ -n "$SSA_OUTPUT" ] && [ -f "$SSA_OUTPUT" ]; then
+          echo "findings-count=$(jq -r '.total_vulnerabilities' "$SSA_OUTPUT")" >> "$GITHUB_OUTPUT"
+          echo "highest-severity=$(jq -r '.risk_level' "$SSA_OUTPUT")" >> "$GITHUB_OUTPUT"
+        fi
+
+        exit "$exit_code"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -241,8 +241,9 @@ reach stdout for GitHub to parse them.
 This repository **is** a GitHub Action (published to the
 [GitHub Marketplace](https://github.com/marketplace/actions/symfony-security-auditor)),
 so you can run an audit with `uses:` instead of scripting the steps yourself. It
-sets up PHP, installs Composer dependencies, and runs `audit:run` with the
-inputs you pass.
+sets up PHP, installs Composer dependencies (or, in `mode: standalone`,
+downloads the standalone binary instead), and runs the audit with the inputs you
+pass.
 
 ```yaml
 # .github/workflows/security-audit.yaml
@@ -279,13 +280,61 @@ jobs:
           sarif_file: report.sarif
 ```
 
-Inputs (all optional): `project-path` (default `.`), `format`
+Inputs (all optional): `mode` (`bundle`/`standalone`, default `bundle`),
+`project-path` (default `.`), `format`
 (`console`/`json`/`sarif`/`html`/`markdown`/`junit`/`github`, default `sarif`),
 `output` (default `report.sarif`), `baseline`, `generate-baseline`, `since`,
-`extra-args`, `php-version` (default `8.3`), `setup-php` (default `true`),
-`install-dependencies` (default `true`), and `working-directory` (default `.`).
-Set `setup-php: false` / `install-dependencies: false` when your job has already
+`fail-on` (`safe`/`low`/`medium`/`high`/`critical`), `extra-args`, `php-version`
+(default `8.3`), `setup-php` (default `true`), `install-dependencies` (default
+`true`, ignored in standalone mode), and `working-directory` (default `.`). Set
+`setup-php: false` / `install-dependencies: false` when your job has already
 done those steps. Pass your provider key via `env:` (e.g. `ANTHROPIC_API_KEY`).
+
+Outputs: `exit-code`, `report-path`, and — only when `format: json` —
+`findings-count` and `highest-severity` (the report's aggregate `risk_level`).
+
+```yaml
+      - name: Symfony Security Audit
+        id: audit
+        uses: vinceamstoutz/symfony-security-auditor@1.15.0
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          format: json
+          output: report.json
+
+      - run: echo "found ${{ steps.audit.outputs.findings-count }} findings (${{ steps.audit.outputs.highest-severity }})"
+```
+
+**Standalone mode** (`mode: standalone`) downloads the checksum-verified
+standalone binary instead of requiring the bundle in your project's
+`composer.json` — a host PHP and Composer are still installed by this action
+(`setup-php` stays `true`) since `init` fetches the provider bridge through
+Composer even for the standalone binary. Non-Anthropic providers currently
+require running `symfony-security-auditor init` interactively once outside CI to
+pick a provider; standalone mode in this action always configures the
+`anthropic`/`claude-opus-4-8` default non-interactively.
+
+`mode` defaults to `bundle`, not `standalone`, so upgrading to a newer action
+version never silently changes what an existing workflow does — `bundle` is
+exactly today's behavior with no `mode` input at all. It also avoids opting
+every new adopter into the Anthropic-only standalone path by default when they
+may already have a different provider configured via `config/packages/ai.yaml`.
+Neither install method is otherwise preferred; see the
+[Standalone tool](../README.md#standalone-tool-binary) and
+[bundle](../README.md#use-it-as-a-symfony-bundle) sections for the general
+tradeoffs.
+
+```yaml
+      - name: Symfony Security Audit
+        uses: vinceamstoutz/symfony-security-auditor@1.15.0
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          mode: standalone
+          format: sarif
+          output: report.sarif
+```
 
 Accept the current findings as a baseline once (locally), then commit it so
 future PRs only report new findings:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -148,11 +148,12 @@ deprecated by the other.
 ### GitHub Action
 
 - The composite action defined by `action.yml` at the repository root and its
-  input names: `project-path`, `format`, `output`, `baseline`,
-  `generate-baseline`, `since`, `extra-args`, `php-version`, `setup-php`,
-  `install-dependencies`, `working-directory`. New inputs may be added in a
-  `MINOR`; renaming or removing one is a `MAJOR`. The Marketplace `name`
-  (`Symfony Security Auditor`) is also stable.
+  input names: `mode`, `project-path`, `format`, `output`, `baseline`,
+  `generate-baseline`, `since`, `fail-on`, `extra-args`, `php-version`,
+  `setup-php`, `install-dependencies`, `working-directory`, and its output
+  names: `exit-code`, `report-path`, `findings-count`, `highest-severity`. New
+  inputs/outputs may be added in a `MINOR`; renaming or removing one is a
+  `MAJOR`. The Marketplace `name` (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
   `uses: vinceamstoutz/symfony-security-auditor@1.15.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally


### PR DESCRIPTION
## Summary

This update resolves a major standalone friction point where the Action previously forced php bin/console audit:run (causing non-bundle repositories to fail outright) by introducing a new mode input (bundle by default, or standalone which downloads the checksum-verified binary via install.sh and runs symfony-security-auditor init --no-interaction using a hardcoded anthropic/claude-opus-4-8 provider); it also introduces new first-class outputs (exit-code, report-path, findings-count, and highest-severity extracted via jq when using JSON format), adds a native fail-on input to replace the previous word-split extra-args workaround, and updates docs/ci.md and docs/versioning.md to reflect these purely additive, MINOR-safe changes to action.yml without altering any src/ or tests/ files.

## Type of change

- [x] New feature

## Checklist

- [x] Testing & Verification: Verified via an action.yml structure sanity check and the install_script_test.sh suite, with no new PHP tests required as no PHP source code was changed.
- [x] Linting & Code Quality: All native bin/castor lint checks pass perfectly, including Prettier, Markdown lint, Composer Normalize, PHP CS Fixer, Rector, PHPStan, Deptrac, Swiss Knife, and 3,794 PHPUnit tests at 100% line coverage.
- [x] Mutation Testing: Maintained 100% MSI (Mutation Score Indicator), unaffected by this diff and verified by the full-suite Infection run on the exact same base commit in #172.
- [x] Mocking Standards: Strictly adhered to mocking guidelines by ensuring no createMock calls are utilized without a matching expects() clause.
- [x] Commit Guidelines: Confirmed that all commit messages strictly adhere to the Conventional Commits specification.