### PR TITLE
feat(scan): add five security misconfiguration audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,28 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `fail-on` input (previously reachable only through `extra-args`).
   Implementation lives in `action.yml`.
 
+- **The attacker now hunts weak password hashing and permissive CORS
+  configuration.** Two new `VulnerabilityType` cases — `weak_password_hashing`
+  (CWE-916, OWASP A04:2025 - Cryptographic Failures) and
+  `permissive_cors_origin` (CWE-942, OWASP A02:2025 - Security
+  Misconfiguration). `RegexStaticPreScanner` gained three matching `CONFIG` risk
+  markers (`CACHE_VERSION` bumped to 28): `weak_password_hasher_algorithm` flags
+  `security.password_hashers.*.algorithm` set to `plaintext`, `md5`, or `sha1`
+  instead of `auto`; `remember_me_secure_false` flags a `remember_me` firewall
+  cookie configured with `secure: false`; `unanchored_cors_origin_regex` flags
+  NelmioCors `origin_regex: true`, prompting a check that every `allow_origin`
+  pattern is anchored with `^...$` (an unanchored regex matches as a substring
+  and can allow unintended origins). `ConfigAttackerSkill` gained matching hunt
+  bullets, and `AuthenticatorAttackerSkill`'s blanket "do not flag
+  `RememberMeBadge`" carve-out was narrowed to only exempt
+  conditionally-attached badges — a `RememberMeBadge` attached unconditionally
+  (not gated on a user-submitted "remember me" flag) is now flagged, since it
+  issues a long-lived authentication cookie for every login regardless of
+  consent. Implementation lives in
+  `src/Audit/Domain/Model/VulnerabilityType.php`,
+  `src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php`, and
+  `src/Audit/Infrastructure/Prompt/Skill/`.
+
 ### Fixed
 
 - **The native Windows binary is published with releases again.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,25 +58,30 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `fail-on` input (previously reachable only through `extra-args`).
   Implementation lives in `action.yml`.
 
-- **The attacker now hunts weak password hashing and permissive CORS
-  configuration.** Two new `VulnerabilityType` cases — `weak_password_hashing`
-  (CWE-916, OWASP A04:2025 - Cryptographic Failures) and
-  `permissive_cors_origin` (CWE-942, OWASP A02:2025 - Security
-  Misconfiguration). `RegexStaticPreScanner` gained three matching `CONFIG` risk
-  markers (`CACHE_VERSION` bumped to 28): `weak_password_hasher_algorithm` flags
-  `security.password_hashers.*.algorithm` set to `plaintext`, `md5`, or `sha1`
-  instead of `auto`; `remember_me_secure_false` flags a `remember_me` firewall
-  cookie configured with `secure: false`; `unanchored_cors_origin_regex` flags
-  NelmioCors `origin_regex: true`, prompting a check that every `allow_origin`
-  pattern is anchored with `^...$` (an unanchored regex matches as a substring
-  and can allow unintended origins). `ConfigAttackerSkill` gained matching hunt
-  bullets, and `AuthenticatorAttackerSkill`'s blanket "do not flag
-  `RememberMeBadge`" carve-out was narrowed to only exempt
-  conditionally-attached badges — a `RememberMeBadge` attached unconditionally
-  (not gated on a user-submitted "remember me" flag) is now flagged, since it
-  issues a long-lived authentication cookie for every login regardless of
-  consent. Implementation lives in
-  `src/Audit/Domain/Model/VulnerabilityType.php`,
+- **The attacker now hunts weak password hashing, permissive CORS, weak CSP,
+  missing HSTS, and debug mode left enabled.** Five new `VulnerabilityType`
+  cases — `weak_password_hashing` (CWE-916), `permissive_cors_origin` (CWE-942),
+  `weak_content_security_policy` (CWE-693), `missing_transport_security`
+  (CWE-319), and `debug_mode_enabled` (CWE-489), all under OWASP A02:2025 -
+  Security Misconfiguration except `weak_password_hashing` (OWASP A04:2025 -
+  Cryptographic Failures). `RegexStaticPreScanner` gained six matching `CONFIG`
+  risk markers (`CACHE_VERSION` bumped to 29): `weak_password_hasher_algorithm`
+  flags `security.password_hashers.*.algorithm` set to `plaintext`, `md5`, or
+  `sha1` instead of `auto`; `remember_me_secure_false` flags a `remember_me`
+  firewall cookie configured with `secure: false`;
+  `unanchored_cors_origin_regex` flags NelmioCors `origin_regex: true`,
+  prompting a check that every `allow_origin` pattern is anchored with `^...$`
+  (an unanchored regex matches as a substring and can allow unintended origins);
+  `csp_unsafe_inline_or_eval` flags a Content-Security-Policy directive allowing
+  `'unsafe-inline'` or `'unsafe-eval'`; `hsts_disabled` flags NelmioSecurity
+  `forced_ssl.enabled: false`; `app_debug_enabled` flags `APP_DEBUG=1`/`=true`
+  in a dotenv file. `ConfigAttackerSkill` gained matching hunt bullets, and
+  `AuthenticatorAttackerSkill`'s blanket "do not flag `RememberMeBadge`"
+  carve-out was narrowed to only exempt conditionally-attached badges — a
+  `RememberMeBadge` attached unconditionally (not gated on a user-submitted
+  "remember me" flag) is now flagged, since it issues a long-lived
+  authentication cookie for every login regardless of consent. Implementation
+  lives in `src/Audit/Domain/Model/VulnerabilityType.php`,
   `src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php`, and
   `src/Audit/Infrastructure/Prompt/Skill/`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,7 +253,7 @@ Fields: `id`, `type` (enum), `severity` (enum), `title`, `description`,
 
 ### `VulnerabilityType` — backed enum with OWASP and CWE references
 
-44 cases in six categories:
+47 cases in six categories:
 
 | Category              | Examples                                                                   |
 | --------------------- | -------------------------------------------------------------------------- |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,7 +253,7 @@ Fields: `id`, `type` (enum), `severity` (enum), `title`, `description`,
 
 ### `VulnerabilityType` — backed enum with OWASP and CWE references
 
-42 cases in six categories:
+44 cases in six categories:
 
 | Category              | Examples                                                                   |
 | --------------------- | -------------------------------------------------------------------------- |

--- a/src/Audit/Domain/Model/VulnerabilityType.php
+++ b/src/Audit/Domain/Model/VulnerabilityType.php
@@ -72,6 +72,9 @@ enum VulnerabilityType: string
     case TRUSTED_PROXY_MISCONFIGURATION = 'trusted_proxy_misconfiguration';
     case WEAK_PASSWORD_HASHING = 'weak_password_hashing';
     case PERMISSIVE_CORS_ORIGIN = 'permissive_cors_origin';
+    case WEAK_CONTENT_SECURITY_POLICY = 'weak_content_security_policy';
+    case MISSING_TRANSPORT_SECURITY = 'missing_transport_security';
+    case DEBUG_MODE_ENABLED = 'debug_mode_enabled';
 
     public function category(): string
     {
@@ -109,6 +112,9 @@ enum VulnerabilityType: string
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
             self::TRUSTED_PROXY_MISCONFIGURATION,
             self::PERMISSIVE_CORS_ORIGIN,
+            self::WEAK_CONTENT_SECURITY_POLICY,
+            self::MISSING_TRANSPORT_SECURITY,
+            self::DEBUG_MODE_ENABLED,
             self::MESSENGER_HANDLER_UNSAFE => 'Symfony-Specific',
 
             self::SENSITIVE_DATA_EXPOSURE,
@@ -172,6 +178,9 @@ enum VulnerabilityType: string
             self::HOST_HEADER_INJECTION,
             self::TRUSTED_PROXY_MISCONFIGURATION,
             self::PERMISSIVE_CORS_ORIGIN,
+            self::WEAK_CONTENT_SECURITY_POLICY,
+            self::MISSING_TRANSPORT_SECURITY,
+            self::DEBUG_MODE_ENABLED,
             self::CACHE_POISONING => 'OWASP A02:2025 - Security Misconfiguration',
 
             self::INSECURE_DESERIALIZATION,
@@ -228,6 +237,9 @@ enum VulnerabilityType: string
             self::HOST_HEADER_INJECTION,
             self::TRUSTED_PROXY_MISCONFIGURATION,
             self::PERMISSIVE_CORS_ORIGIN,
+            self::WEAK_CONTENT_SECURITY_POLICY,
+            self::MISSING_TRANSPORT_SECURITY,
+            self::DEBUG_MODE_ENABLED,
             self::CACHE_POISONING => 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/',
 
             self::INSECURE_DESERIALIZATION,
@@ -275,6 +287,9 @@ enum VulnerabilityType: string
             self::MISCONFIGURED_FIREWALL => CweReference::of(306),
             self::TRUSTED_PROXY_MISCONFIGURATION => CweReference::of(290),
             self::PERMISSIVE_CORS_ORIGIN => CweReference::of(942),
+            self::WEAK_CONTENT_SECURITY_POLICY => CweReference::of(693),
+            self::MISSING_TRANSPORT_SECURITY => CweReference::of(319),
+            self::DEBUG_MODE_ENABLED => CweReference::of(489),
             self::INSECURE_REDIRECT,
             self::OPEN_REDIRECT => CweReference::of(601),
             self::OVER_PERMISSIVE_SERIALIZER_GROUP => CweReference::of(213),

--- a/src/Audit/Domain/Model/VulnerabilityType.php
+++ b/src/Audit/Domain/Model/VulnerabilityType.php
@@ -70,6 +70,8 @@ enum VulnerabilityType: string
     case AUTHENTICATOR_BYPASS = 'authenticator_bypass';
     case HOST_HEADER_INJECTION = 'host_header_injection';
     case TRUSTED_PROXY_MISCONFIGURATION = 'trusted_proxy_misconfiguration';
+    case WEAK_PASSWORD_HASHING = 'weak_password_hashing';
+    case PERMISSIVE_CORS_ORIGIN = 'permissive_cors_origin';
 
     public function category(): string
     {
@@ -106,6 +108,7 @@ enum VulnerabilityType: string
             self::INSECURE_REDIRECT,
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
             self::TRUSTED_PROXY_MISCONFIGURATION,
+            self::PERMISSIVE_CORS_ORIGIN,
             self::MESSENGER_HANDLER_UNSAFE => 'Symfony-Specific',
 
             self::SENSITIVE_DATA_EXPOSURE,
@@ -120,6 +123,7 @@ enum VulnerabilityType: string
             self::WEAK_CRYPTOGRAPHY,
             self::INSECURE_RANDOM,
             self::HARDCODED_SECRET,
+            self::WEAK_PASSWORD_HASHING,
             self::MISSING_SIGNATURE_VERIFICATION => 'Cryptographic',
         };
     }
@@ -167,6 +171,7 @@ enum VulnerabilityType: string
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
             self::HOST_HEADER_INJECTION,
             self::TRUSTED_PROXY_MISCONFIGURATION,
+            self::PERMISSIVE_CORS_ORIGIN,
             self::CACHE_POISONING => 'OWASP A02:2025 - Security Misconfiguration',
 
             self::INSECURE_DESERIALIZATION,
@@ -176,7 +181,8 @@ enum VulnerabilityType: string
             self::SENSITIVE_DATA_EXPOSURE,
             self::WEAK_CRYPTOGRAPHY,
             self::INSECURE_RANDOM,
-            self::HARDCODED_SECRET => 'OWASP A04:2025 - Cryptographic Failures',
+            self::HARDCODED_SECRET,
+            self::WEAK_PASSWORD_HASHING => 'OWASP A04:2025 - Cryptographic Failures',
         };
     }
 
@@ -221,6 +227,7 @@ enum VulnerabilityType: string
             self::OVER_PERMISSIVE_SERIALIZER_GROUP,
             self::HOST_HEADER_INJECTION,
             self::TRUSTED_PROXY_MISCONFIGURATION,
+            self::PERMISSIVE_CORS_ORIGIN,
             self::CACHE_POISONING => 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/',
 
             self::INSECURE_DESERIALIZATION,
@@ -230,7 +237,8 @@ enum VulnerabilityType: string
             self::SENSITIVE_DATA_EXPOSURE,
             self::WEAK_CRYPTOGRAPHY,
             self::INSECURE_RANDOM,
-            self::HARDCODED_SECRET => 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/',
+            self::HARDCODED_SECRET,
+            self::WEAK_PASSWORD_HASHING => 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/',
         };
     }
 
@@ -266,6 +274,7 @@ enum VulnerabilityType: string
             self::EXPOSED_INTERNAL_SERVICE => CweReference::of(668),
             self::MISCONFIGURED_FIREWALL => CweReference::of(306),
             self::TRUSTED_PROXY_MISCONFIGURATION => CweReference::of(290),
+            self::PERMISSIVE_CORS_ORIGIN => CweReference::of(942),
             self::INSECURE_REDIRECT,
             self::OPEN_REDIRECT => CweReference::of(601),
             self::OVER_PERMISSIVE_SERIALIZER_GROUP => CweReference::of(213),
@@ -279,6 +288,7 @@ enum VulnerabilityType: string
             self::WEAK_CRYPTOGRAPHY => CweReference::of(327),
             self::INSECURE_RANDOM => CweReference::of(338),
             self::HARDCODED_SECRET => CweReference::of(798),
+            self::WEAK_PASSWORD_HASHING => CweReference::of(916),
 
             self::MISSING_SIGNATURE_VERIFICATION => CweReference::of(347),
             self::MISSING_RATE_LIMITING => CweReference::of(799),

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -210,7 +210,8 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             log_injection, path_traversal, ssrf, xxe, open_redirect, weak_cryptography, insecure_random,
             hardcoded_secret, missing_signature_verification, messenger_handler_unsafe, missing_rate_limiting,
             cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass,
-            over_permissive_serializer_group, host_header_injection, trusted_proxy_misconfiguration
+            over_permissive_serializer_group, host_header_injection, trusted_proxy_misconfiguration,
+            weak_password_hashing, permissive_cors_origin
 
             Severity rubric (calibrate every finding against this scale — do NOT inflate severity for emphasis):
             - critical: unauthenticated RCE, full authentication bypass, mass data exfiltration without auth, hardcoded production secret in a committed file.

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -211,7 +211,8 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             hardcoded_secret, missing_signature_verification, messenger_handler_unsafe, missing_rate_limiting,
             cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass,
             over_permissive_serializer_group, host_header_injection, trusted_proxy_misconfiguration,
-            weak_password_hashing, permissive_cors_origin
+            weak_password_hashing, permissive_cors_origin, weak_content_security_policy,
+            missing_transport_security, debug_mode_enabled
 
             Severity rubric (calibrate every finding against this scale — do NOT inflate severity for emphasis):
             - critical: unauthenticated RCE, full authentication bypass, mass data exfiltration without auth, hardcoded production secret in a committed file.

--- a/src/Audit/Infrastructure/Prompt/Reviewer/ReviewerPromptSections.php
+++ b/src/Audit/Infrastructure/Prompt/Reviewer/ReviewerPromptSections.php
@@ -90,7 +90,8 @@ final readonly class ReviewerPromptSections implements ReviewerPromptSectionsInt
         hardcoded_secret, missing_signature_verification, messenger_handler_unsafe, missing_rate_limiting,
         cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass,
         over_permissive_serializer_group, host_header_injection, trusted_proxy_misconfiguration,
-        weak_password_hashing, permissive_cors_origin
+        weak_password_hashing, permissive_cors_origin, weak_content_security_policy,
+        missing_transport_security, debug_mode_enabled
         SCHEMA;
 
     private const string DECISION_RULES = <<<'RULES'

--- a/src/Audit/Infrastructure/Prompt/Reviewer/ReviewerPromptSections.php
+++ b/src/Audit/Infrastructure/Prompt/Reviewer/ReviewerPromptSections.php
@@ -89,7 +89,8 @@ final readonly class ReviewerPromptSections implements ReviewerPromptSectionsInt
         log_injection, path_traversal, ssrf, xxe, open_redirect, weak_cryptography, insecure_random,
         hardcoded_secret, missing_signature_verification, messenger_handler_unsafe, missing_rate_limiting,
         cache_poisoning, mailer_header_injection, webhook_replay, authenticator_bypass,
-        over_permissive_serializer_group, host_header_injection, trusted_proxy_misconfiguration
+        over_permissive_serializer_group, host_header_injection, trusted_proxy_misconfiguration,
+        weak_password_hashing, permissive_cors_origin
         SCHEMA;
 
     private const string DECISION_RULES = <<<'RULES'

--- a/src/Audit/Infrastructure/Prompt/Skill/AuthenticatorAttackerSkill.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/AuthenticatorAttackerSkill.php
@@ -45,9 +45,10 @@ final readonly class AuthenticatorAttackerSkill implements AttackerSkillInterfac
             - Missing `CsrfTokenBadge` on form-based login authenticators where CSRF was previously enforced.
             - OAuth/OIDC handlers omitting `state` parameter verification (CSRF on auth callback) or PKCE for public clients.
             - `UserBadge::setUserLoader()` query running with a user-controlled `identifier` without normalization (`User WHERE email = :id` accepting wildcards/case-insensitive variants).
+            - `RememberMeBadge` attached unconditionally — not gated on a user-submitted "remember me" request parameter — issuing a long-lived authentication cookie for every login regardless of consent.
             Do NOT flag:
             - Authenticators that explicitly throw `AuthenticationException` on missing credentials.
-            - `RememberMeBadge` on long-lived auth — that is the documented opt-in pattern.
+            - `RememberMeBadge` conditionally attached based on a user-submitted "remember me" flag — that is the documented opt-in pattern.
             </skills>
             SKILL;
     }

--- a/src/Audit/Infrastructure/Prompt/Skill/ConfigAttackerSkill.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/ConfigAttackerSkill.php
@@ -53,6 +53,9 @@ final readonly class ConfigAttackerSkill implements AttackerSkillInterface
             - `security.password_hashers.*.algorithm` set to `plaintext`, `md5`, or `sha1` instead of `auto` (bcrypt/argon2id) — fast, unsalted or reversible hashing.
             - `remember_me` cookie configured with `secure: false` — a long-lived authentication cookie sent over plain HTTP.
             - NelmioCors `origin_regex: true` paired with an `allow_origin` pattern that is not anchored with `^...$` — an unanchored regex matches as a substring and can allow unintended origins.
+            - A Content-Security-Policy directive allowing `'unsafe-inline'` or `'unsafe-eval'` — defeats CSP's main protection against injected/inline script execution.
+            - NelmioSecurity `forced_ssl.enabled: false` — HSTS not enforced, leaving the first plaintext request open to SSL-stripping.
+            - `APP_DEBUG=1` (or `=true`) in a committed base `.env` file with no environment-specific override visible — if it reaches production, the Symfony error page leaks stack traces, source paths, and environment variables.
             Do NOT flag:
             - Environment-variable references like `%env(DATABASE_URL)%` — those are externalized, not hardcoded.
             - `_profiler` / `_wdt` declarations gated by `when@dev` / `when@test`.

--- a/src/Audit/Infrastructure/Prompt/Skill/ConfigAttackerSkill.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/ConfigAttackerSkill.php
@@ -50,6 +50,9 @@ final readonly class ConfigAttackerSkill implements AttackerSkillInterface
             - `framework.html_sanitizer` sanitizers with `allow_static_elements: true` plus a broad `allow_elements`/`allow_attributes` list — XSS via "sanitized" output.
             - `framework.http_client.scoped_clients.*.verify_peer: false` / `verify_host: false` — MITM exposure.
             - `messenger.routing` directing privileged commands to a transport with `failure_transport: null` — silent loss of audit trail.
+            - `security.password_hashers.*.algorithm` set to `plaintext`, `md5`, or `sha1` instead of `auto` (bcrypt/argon2id) — fast, unsalted or reversible hashing.
+            - `remember_me` cookie configured with `secure: false` — a long-lived authentication cookie sent over plain HTTP.
+            - NelmioCors `origin_regex: true` paired with an `allow_origin` pattern that is not anchored with `^...$` — an unanchored regex matches as a substring and can allow unintended origins.
             Do NOT flag:
             - Environment-variable references like `%env(DATABASE_URL)%` — those are externalized, not hardcoded.
             - `_profiler` / `_wdt` declarations gated by `when@dev` / `when@test`.

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -34,7 +34,7 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      * alter scan output for existing chunk content. Folded into the attacker
      * cache key so stale entries are invalidated.
      */
-    public const int CACHE_VERSION = 27;
+    public const int CACHE_VERSION = 28;
 
     /**
      * Detects the `s` (DOTALL) flag among a PCRE pattern's trailing modifier
@@ -286,6 +286,18 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
             'trusted_proxies_wildcard' => [
                 'regex' => '/(?:trusted_proxies\s*:|TRUSTED_PROXIES\s*=)\s*[\'"]?(?:0\.0\.0\.0\/0|::\/0)/i',
                 'description' => 'trusted_proxies set to a wildcard CIDR (0.0.0.0/0, ::/0) — any client can spoof X-Forwarded-* headers, defeating IP allowlists and rate limiters',
+            ],
+            'weak_password_hasher_algorithm' => [
+                'regex' => '/password_hashers\b[\s\S]{0,300}?algorithm\s*:\s*[\'"]?(?:plaintext|md5|sha1)[\'"]?/si',
+                'description' => 'password_hashers using a weak algorithm (plaintext/md5/sha1) — use auto (bcrypt/argon2id) instead',
+            ],
+            'remember_me_secure_false' => [
+                'regex' => '/remember_me\b[\s\S]{0,300}?secure\s*:\s*false/s',
+                'description' => 'remember_me cookie secure: false — long-lived authentication cookie sent over plain HTTP',
+            ],
+            'unanchored_cors_origin_regex' => [
+                'regex' => '/origin_regex\s*:\s*true/',
+                'description' => 'NelmioCors origin_regex: true — verify every allow_origin pattern is anchored (^...$); an unanchored regex matches as a substring and can allow unintended origins',
             ],
         ],
         ProjectFileType::AUTHENTICATOR->value => [

--- a/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
+++ b/src/Audit/Infrastructure/Scan/RegexStaticPreScanner.php
@@ -34,7 +34,7 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
      * alter scan output for existing chunk content. Folded into the attacker
      * cache key so stale entries are invalidated.
      */
-    public const int CACHE_VERSION = 28;
+    public const int CACHE_VERSION = 29;
 
     /**
      * Detects the `s` (DOTALL) flag among a PCRE pattern's trailing modifier
@@ -298,6 +298,18 @@ final readonly class RegexStaticPreScanner implements StaticPreScannerInterface
             'unanchored_cors_origin_regex' => [
                 'regex' => '/origin_regex\s*:\s*true/',
                 'description' => 'NelmioCors origin_regex: true — verify every allow_origin pattern is anchored (^...$); an unanchored regex matches as a substring and can allow unintended origins',
+            ],
+            'csp_unsafe_inline_or_eval' => [
+                'regex' => '/[\'"]unsafe-(?:inline|eval)[\'"]/',
+                'description' => "Content-Security-Policy directive allows 'unsafe-inline'/'unsafe-eval' — defeats CSP's main protection against script injection",
+            ],
+            'hsts_disabled' => [
+                'regex' => '/forced_ssl\b[\s\S]{0,100}?enabled\s*:\s*false/s',
+                'description' => 'NelmioSecurity forced_ssl.enabled: false — HSTS not enforced, leaving the app open to SSL-stripping on the first plaintext request',
+            ],
+            'app_debug_enabled' => [
+                'regex' => '/^APP_DEBUG\s*=\s*(?:1|true)\s*$/i',
+                'description' => 'APP_DEBUG enabled — verify this is not a committed base .env (debug mode in production leaks stack traces, source, and container internals)',
             ],
         ],
         ProjectFileType::AUTHENTICATOR->value => [

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
@@ -67,6 +67,9 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'Symfony-Specific'];
         yield [VulnerabilityType::WEAK_PASSWORD_HASHING, 'Cryptographic'];
         yield [VulnerabilityType::PERMISSIVE_CORS_ORIGIN, 'Symfony-Specific'];
+        yield [VulnerabilityType::WEAK_CONTENT_SECURITY_POLICY, 'Symfony-Specific'];
+        yield [VulnerabilityType::MISSING_TRANSPORT_SECURITY, 'Symfony-Specific'];
+        yield [VulnerabilityType::DEBUG_MODE_ENABLED, 'Symfony-Specific'];
     }
 
     public static function owaspProvider(): Iterator
@@ -104,6 +107,9 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'A02:2025'];
         yield [VulnerabilityType::WEAK_PASSWORD_HASHING, 'A04:2025'];
         yield [VulnerabilityType::PERMISSIVE_CORS_ORIGIN, 'A02:2025'];
+        yield [VulnerabilityType::WEAK_CONTENT_SECURITY_POLICY, 'A02:2025'];
+        yield [VulnerabilityType::MISSING_TRANSPORT_SECURITY, 'A02:2025'];
+        yield [VulnerabilityType::DEBUG_MODE_ENABLED, 'A02:2025'];
     }
 
     #[DataProvider('categoryProvider')]
@@ -159,6 +165,9 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::HOST_HEADER_INJECTION, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
         yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
         yield [VulnerabilityType::PERMISSIVE_CORS_ORIGIN, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
+        yield [VulnerabilityType::WEAK_CONTENT_SECURITY_POLICY, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
+        yield [VulnerabilityType::MISSING_TRANSPORT_SECURITY, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
+        yield [VulnerabilityType::DEBUG_MODE_ENABLED, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
         yield [VulnerabilityType::WEAK_PASSWORD_HASHING, 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/'];
         yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/'];
         yield [VulnerabilityType::SENSITIVE_DATA_EXPOSURE, 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/'];
@@ -223,6 +232,9 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'CWE-287'];
         yield [VulnerabilityType::PERMISSIVE_CORS_ORIGIN, 'CWE-942'];
         yield [VulnerabilityType::WEAK_PASSWORD_HASHING, 'CWE-916'];
+        yield [VulnerabilityType::WEAK_CONTENT_SECURITY_POLICY, 'CWE-693'];
+        yield [VulnerabilityType::MISSING_TRANSPORT_SECURITY, 'CWE-319'];
+        yield [VulnerabilityType::DEBUG_MODE_ENABLED, 'CWE-489'];
     }
 
     #[DataProvider('cweProvider')]

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
@@ -65,6 +65,8 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'Symfony-Specific'];
         yield [VulnerabilityType::HOST_HEADER_INJECTION, 'Data Exposure'];
         yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'Symfony-Specific'];
+        yield [VulnerabilityType::WEAK_PASSWORD_HASHING, 'Cryptographic'];
+        yield [VulnerabilityType::PERMISSIVE_CORS_ORIGIN, 'Symfony-Specific'];
     }
 
     public static function owaspProvider(): Iterator
@@ -100,6 +102,8 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::OVER_PERMISSIVE_SERIALIZER_GROUP, 'A02:2025'];
         yield [VulnerabilityType::HOST_HEADER_INJECTION, 'A02:2025'];
         yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'A02:2025'];
+        yield [VulnerabilityType::WEAK_PASSWORD_HASHING, 'A04:2025'];
+        yield [VulnerabilityType::PERMISSIVE_CORS_ORIGIN, 'A02:2025'];
     }
 
     #[DataProvider('categoryProvider')]
@@ -154,6 +158,8 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::MASS_ASSIGNMENT, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
         yield [VulnerabilityType::HOST_HEADER_INJECTION, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
         yield [VulnerabilityType::TRUSTED_PROXY_MISCONFIGURATION, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
+        yield [VulnerabilityType::PERMISSIVE_CORS_ORIGIN, 'https://owasp.org/Top10/2025/A02_2025-Security_Misconfiguration/'];
+        yield [VulnerabilityType::WEAK_PASSWORD_HASHING, 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/'];
         yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/'];
         yield [VulnerabilityType::SENSITIVE_DATA_EXPOSURE, 'https://owasp.org/Top10/2025/A04_2025-Cryptographic_Failures/'];
         yield [VulnerabilityType::SSRF, 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/'];
@@ -215,6 +221,8 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::CACHE_POISONING, 'CWE-349'];
         yield [VulnerabilityType::WEBHOOK_REPLAY, 'CWE-294'];
         yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'CWE-287'];
+        yield [VulnerabilityType::PERMISSIVE_CORS_ORIGIN, 'CWE-942'];
+        yield [VulnerabilityType::WEAK_PASSWORD_HASHING, 'CWE-916'];
     }
 
     #[DataProvider('cweProvider')]

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -2051,6 +2051,8 @@ final class AttackerPromptBuilderTest extends TestCase
         self::assertStringContainsString('authenticator_bypass', $prompt);
         self::assertStringContainsString('host_header_injection', $prompt);
         self::assertStringContainsString('trusted_proxy_misconfiguration', $prompt);
+        self::assertStringContainsString('weak_password_hashing', $prompt);
+        self::assertStringContainsString('permissive_cors_origin', $prompt);
     }
 
     public function test_base_prompt_references_modern_symfony_components_in_expertise(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/AttackerPromptBuilderTest.php
@@ -2053,6 +2053,9 @@ final class AttackerPromptBuilderTest extends TestCase
         self::assertStringContainsString('trusted_proxy_misconfiguration', $prompt);
         self::assertStringContainsString('weak_password_hashing', $prompt);
         self::assertStringContainsString('permissive_cors_origin', $prompt);
+        self::assertStringContainsString('weak_content_security_policy', $prompt);
+        self::assertStringContainsString('missing_transport_security', $prompt);
+        self::assertStringContainsString('debug_mode_enabled', $prompt);
     }
 
     public function test_base_prompt_references_modern_symfony_components_in_expertise(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
@@ -224,6 +224,8 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString('authenticator_bypass', $prompt);
         self::assertStringContainsString('host_header_injection', $prompt);
         self::assertStringContainsString('trusted_proxy_misconfiguration', $prompt);
+        self::assertStringContainsString('weak_password_hashing', $prompt);
+        self::assertStringContainsString('permissive_cors_origin', $prompt);
     }
 
     public function test_decision_rules_restrict_rejection_to_a_named_mitigating_control(): void

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/ReviewerPromptBuilderTest.php
@@ -226,6 +226,9 @@ final class ReviewerPromptBuilderTest extends TestCase
         self::assertStringContainsString('trusted_proxy_misconfiguration', $prompt);
         self::assertStringContainsString('weak_password_hashing', $prompt);
         self::assertStringContainsString('permissive_cors_origin', $prompt);
+        self::assertStringContainsString('weak_content_security_policy', $prompt);
+        self::assertStringContainsString('missing_transport_security', $prompt);
+        self::assertStringContainsString('debug_mode_enabled', $prompt);
     }
 
     public function test_decision_rules_restrict_rejection_to_a_named_mitigating_control(): void

--- a/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
@@ -877,6 +877,123 @@ final class RegexStaticPreScannerTest extends TestCase
      * @throws InvalidProjectFileException
      * @throws InvalidRiskMarkerException
      */
+    #[DataProvider('weakPasswordHasherAlgorithmCases')]
+    public function test_it_flags_a_weak_password_hasher_algorithm(string $algorithm): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/security.yaml',
+            '/app/config/packages/security.yaml',
+            \sprintf("security:\n    password_hashers:\n        App\\Entity\\User:\n            algorithm: %s", $algorithm),
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('weak_password_hasher_algorithm', $patterns);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function weakPasswordHasherAlgorithmCases(): iterable
+    {
+        yield 'plaintext' => ['plaintext'];
+        yield 'md5' => ['md5'];
+        yield 'sha1' => ['sha1'];
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_does_not_flag_the_default_password_hasher_algorithm(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/security.yaml',
+            '/app/config/packages/security.yaml',
+            "security:\n    password_hashers:\n        App\\Entity\\User:\n            algorithm: auto",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertNotContains('weak_password_hasher_algorithm', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_flags_a_remember_me_cookie_without_secure(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/security.yaml',
+            '/app/config/packages/security.yaml',
+            "security:\n    firewalls:\n        main:\n            remember_me:\n                secret: '%kernel.secret%'\n                secure: false",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('remember_me_secure_false', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_does_not_flag_a_remember_me_cookie_marked_secure(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/security.yaml',
+            '/app/config/packages/security.yaml',
+            "security:\n    firewalls:\n        main:\n            remember_me:\n                secret: '%kernel.secret%'\n                secure: true",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertNotContains('remember_me_secure_false', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_flags_an_unanchored_cors_origin_regex(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/nelmio_cors.yaml',
+            '/app/config/packages/nelmio_cors.yaml',
+            "nelmio_cors:\n    paths:\n        '^/api/':\n            allow_origin: ['^https://.*\\.example\\.com']\n            origin_regex: true",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('unanchored_cors_origin_regex', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_does_not_flag_cors_config_without_a_regex_origin(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/nelmio_cors.yaml',
+            '/app/config/packages/nelmio_cors.yaml',
+            "nelmio_cors:\n    paths:\n        '^/api/':\n            allow_origin: ['https://example.com']",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertNotContains('unanchored_cors_origin_regex', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
     public function test_it_flags_form_submit_with_request_all_split_across_lines(): void
     {
         $projectFile = ProjectFile::create(

--- a/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Scan/RegexStaticPreScannerTest.php
@@ -413,7 +413,7 @@ final class RegexStaticPreScannerTest extends TestCase
         $projectFile = ProjectFile::create(
             '.env',
             '/app/.env',
-            "APP_ENV=dev\nAPP_SECRET=\nAPP_DEBUG=1\n",
+            "APP_ENV=dev\nAPP_SECRET=\nAPP_DEBUG=0\n",
         );
 
         self::assertSame([], $this->regexStaticPreScanner->scan([$projectFile]));
@@ -988,6 +988,122 @@ final class RegexStaticPreScannerTest extends TestCase
 
         $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
         self::assertNotContains('unanchored_cors_origin_regex', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    #[DataProvider('cspUnsafeDirectiveCases')]
+    public function test_it_flags_a_csp_directive_allowing_unsafe_inline_or_eval(string $directive): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/nelmio_security.yaml',
+            '/app/config/packages/nelmio_security.yaml',
+            "nelmio_security:\n    csp:\n        default:\n            script-src:\n                - '{$directive}'",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('csp_unsafe_inline_or_eval', $patterns);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function cspUnsafeDirectiveCases(): iterable
+    {
+        yield 'unsafe-inline' => ['unsafe-inline'];
+        yield 'unsafe-eval' => ['unsafe-eval'];
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_does_not_flag_a_csp_directive_without_unsafe_keywords(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/nelmio_security.yaml',
+            '/app/config/packages/nelmio_security.yaml',
+            "nelmio_security:\n    csp:\n        default:\n            script-src:\n                - 'self'",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertNotContains('csp_unsafe_inline_or_eval', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_flags_hsts_disabled_via_forced_ssl(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/nelmio_security.yaml',
+            '/app/config/packages/nelmio_security.yaml',
+            "nelmio_security:\n    forced_ssl:\n        enabled: false",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('hsts_disabled', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_does_not_flag_hsts_enabled_via_forced_ssl(): void
+    {
+        $projectFile = ProjectFile::create(
+            'config/packages/nelmio_security.yaml',
+            '/app/config/packages/nelmio_security.yaml',
+            "nelmio_security:\n    forced_ssl:\n        enabled: true",
+        );
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertNotContains('hsts_disabled', $patterns);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    #[DataProvider('appDebugEnabledCases')]
+    public function test_it_flags_app_debug_enabled_in_a_dotenv_file(string $value): void
+    {
+        $projectFile = ProjectFile::create('.env', '/app/.env', "APP_ENV=prod\n{$value}\n");
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertContains('app_debug_enabled', $patterns);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function appDebugEnabledCases(): iterable
+    {
+        yield 'numeric 1' => ['APP_DEBUG=1'];
+        yield 'literal true' => ['APP_DEBUG=true'];
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     * @throws InvalidRiskMarkerException
+     */
+    public function test_it_does_not_flag_app_debug_disabled_in_a_dotenv_file(): void
+    {
+        $projectFile = ProjectFile::create('.env', '/app/.env', "APP_ENV=prod\nAPP_DEBUG=0\n");
+
+        $markers = $this->regexStaticPreScanner->scan([$projectFile]);
+
+        $patterns = array_map(static fn (RiskMarker $riskMarker): string => $riskMarker->pattern(), $markers);
+        self::assertNotContains('app_debug_enabled', $patterns);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds five new `VulnerabilityType` security scan checks (`weak_password_hashing`, `permissive_cors_origin`, `weak_content_security_policy`, `missing_transport_security`, and `debug_mode_enabled`) mapping to OWASP and CWE standards. 

* **Static Analysis:** Implements six new `RegexStaticPreScanner` configuration risk markers to track down weak crypto algorithms, unanchored CORS rules, unsafe CSP policies, disabled HSTS headers, and exposed debug flags, bumping the `CACHE_VERSION` from 27 to 29.
* **Refinement:** Narrows down the `AuthenticatorAttackerSkill` `RememberMeBadge` exception to catch unconsented, long-lived authentication cookies. 
* **Scope:** This is a `MINOR` release as all additions are internal domain enums and scanner behaviors without breaking public API changes.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass
- [x] 100% MSI maintained
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)