### PR TITLE
docs(ci): add a sticky PR-comment recipe for the summary

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,8 +9,8 @@ GitHub Code Scanning or the GitLab Security Dashboard.
 - [Managing LLM Costs](#managing-llm-costs)
 - [Report Visibility on Public Repositories](#report-visibility-on-public-repositories)
 - [GitHub Actions](#github-actions)
-  - [Sticky PR comment with the audit summary](#sticky-pr-comment-with-the-audit-summary)
   - [Reusable GitHub Action](#reusable-github-action)
+  - [Sticky PR comment with the audit summary](#sticky-pr-comment-with-the-audit-summary)
 - [GitLab CI](#gitlab-ci)
 - [Output Formats Reference](#output-formats-reference)
 
@@ -145,6 +145,117 @@ Add your LLM provider key as a repository secret
 (`Settings → Secrets → Actions`). Example for Anthropic: `ANTHROPIC_API_KEY`.
 
 See [supported platforms](../README.md#supported-platforms) for other providers.
+
+### Reusable GitHub Action
+
+This repository **is** a GitHub Action (published to the
+[GitHub Marketplace](https://github.com/marketplace/actions/symfony-security-auditor)),
+so you can run an audit with `uses:` instead of scripting the steps yourself. It
+sets up PHP, installs Composer dependencies (or, in `mode: standalone`,
+downloads the standalone binary instead), and runs the audit with the inputs you
+pass.
+
+```yaml
+# .github/workflows/security-audit.yaml
+name: Security Audit
+
+on:
+  pull_request: ~
+
+permissions:
+  contents: read
+  security-events: write # required for the Code Scanning upload
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so `since` can diff against the base branch
+
+      - name: Symfony Security Audit
+        uses: vinceamstoutz/symfony-security-auditor@1.15.0
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          since: origin/${{ github.base_ref }}
+          baseline: .security-baseline.json
+          format: sarif
+          output: report.sarif
+
+      - uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: report.sarif
+```
+
+Inputs (all optional): `mode` (`bundle`/`standalone`, default `bundle`),
+`project-path` (default `.`), `format`
+(`console`/`json`/`sarif`/`html`/`markdown`/`junit`/`github`, default `sarif`),
+`output` (default `report.sarif`), `baseline`, `generate-baseline`, `since`,
+`fail-on` (`safe`/`low`/`medium`/`high`/`critical`), `extra-args`, `php-version`
+(default `8.3`), `setup-php` (default `true`), `install-dependencies` (default
+`true`, ignored in standalone mode), and `working-directory` (default `.`). Set
+`setup-php: false` / `install-dependencies: false` when your job has already
+done those steps. Pass your provider key via `env:` (e.g. `ANTHROPIC_API_KEY`).
+
+Outputs: `exit-code`, `report-path`, and — only when `format: json` —
+`findings-count` and `highest-severity` (the report's aggregate `risk_level`).
+
+```yaml
+      - name: Symfony Security Audit
+        id: audit
+        uses: vinceamstoutz/symfony-security-auditor@1.15.0
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          format: json
+          output: report.json
+
+      - run: echo "found ${{ steps.audit.outputs.findings-count }} findings (${{ steps.audit.outputs.highest-severity }})"
+```
+
+**Standalone mode** (`mode: standalone`) downloads the checksum-verified
+standalone binary instead of requiring the bundle in your project's
+`composer.json` — a host PHP and Composer are still installed by this action
+(`setup-php` stays `true`) since `init` fetches the provider bridge through
+Composer even for the standalone binary. Non-Anthropic providers currently
+require running `symfony-security-auditor init` interactively once outside CI to
+pick a provider; standalone mode in this action always configures the
+`anthropic`/`claude-opus-4-8` default non-interactively.
+
+`mode` defaults to `bundle`, not `standalone`, so upgrading to a newer action
+version never silently changes what an existing workflow does — `bundle` is
+exactly today's behavior with no `mode` input at all. It also avoids opting
+every new adopter into the Anthropic-only standalone path by default when they
+may already have a different provider configured via `config/packages/ai.yaml`.
+Neither install method is otherwise preferred; see the
+[Standalone tool](../README.md#standalone-tool-binary) and
+[bundle](../README.md#use-it-as-a-symfony-bundle) sections for the general
+tradeoffs.
+
+```yaml
+      - name: Symfony Security Audit
+        uses: vinceamstoutz/symfony-security-auditor@1.15.0
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          mode: standalone
+          format: sarif
+          output: report.sarif
+```
+
+Accept the current findings as a baseline once (locally), then commit it so
+future PRs only report new findings:
+
+```bash
+php bin/console audit:run --generate-baseline=.security-baseline.json
+git add .security-baseline.json
+```
+
+Baselined findings are dropped from the report and do **not** affect the exit
+code, so a green PR check means "no new findings since the baseline".
 
 ### Nightly SARIF upload to GitHub Code Scanning
 
@@ -297,117 +408,6 @@ regardless, while the job itself still fails on the `audit:run` step so
 action to its own comment; give a second sticky-comment step in the same
 workflow (e.g. one posting coverage) a different `header` so the two never
 overwrite each other.
-
-### Reusable GitHub Action
-
-This repository **is** a GitHub Action (published to the
-[GitHub Marketplace](https://github.com/marketplace/actions/symfony-security-auditor)),
-so you can run an audit with `uses:` instead of scripting the steps yourself. It
-sets up PHP, installs Composer dependencies (or, in `mode: standalone`,
-downloads the standalone binary instead), and runs the audit with the inputs you
-pass.
-
-```yaml
-# .github/workflows/security-audit.yaml
-name: Security Audit
-
-on:
-  pull_request: ~
-
-permissions:
-  contents: read
-  security-events: write # required for the Code Scanning upload
-
-jobs:
-  audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # full history so `since` can diff against the base branch
-
-      - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.15.0
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        with:
-          since: origin/${{ github.base_ref }}
-          baseline: .security-baseline.json
-          format: sarif
-          output: report.sarif
-
-      - uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: report.sarif
-```
-
-Inputs (all optional): `mode` (`bundle`/`standalone`, default `bundle`),
-`project-path` (default `.`), `format`
-(`console`/`json`/`sarif`/`html`/`markdown`/`junit`/`github`, default `sarif`),
-`output` (default `report.sarif`), `baseline`, `generate-baseline`, `since`,
-`fail-on` (`safe`/`low`/`medium`/`high`/`critical`), `extra-args`, `php-version`
-(default `8.3`), `setup-php` (default `true`), `install-dependencies` (default
-`true`, ignored in standalone mode), and `working-directory` (default `.`). Set
-`setup-php: false` / `install-dependencies: false` when your job has already
-done those steps. Pass your provider key via `env:` (e.g. `ANTHROPIC_API_KEY`).
-
-Outputs: `exit-code`, `report-path`, and — only when `format: json` —
-`findings-count` and `highest-severity` (the report's aggregate `risk_level`).
-
-```yaml
-      - name: Symfony Security Audit
-        id: audit
-        uses: vinceamstoutz/symfony-security-auditor@1.15.0
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        with:
-          format: json
-          output: report.json
-
-      - run: echo "found ${{ steps.audit.outputs.findings-count }} findings (${{ steps.audit.outputs.highest-severity }})"
-```
-
-**Standalone mode** (`mode: standalone`) downloads the checksum-verified
-standalone binary instead of requiring the bundle in your project's
-`composer.json` — a host PHP and Composer are still installed by this action
-(`setup-php` stays `true`) since `init` fetches the provider bridge through
-Composer even for the standalone binary. Non-Anthropic providers currently
-require running `symfony-security-auditor init` interactively once outside CI to
-pick a provider; standalone mode in this action always configures the
-`anthropic`/`claude-opus-4-8` default non-interactively.
-
-`mode` defaults to `bundle`, not `standalone`, so upgrading to a newer action
-version never silently changes what an existing workflow does — `bundle` is
-exactly today's behavior with no `mode` input at all. It also avoids opting
-every new adopter into the Anthropic-only standalone path by default when they
-may already have a different provider configured via `config/packages/ai.yaml`.
-Neither install method is otherwise preferred; see the
-[Standalone tool](../README.md#standalone-tool-binary) and
-[bundle](../README.md#use-it-as-a-symfony-bundle) sections for the general
-tradeoffs.
-
-```yaml
-      - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.15.0
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        with:
-          mode: standalone
-          format: sarif
-          output: report.sarif
-```
-
-Accept the current findings as a baseline once (locally), then commit it so
-future PRs only report new findings:
-
-```bash
-php bin/console audit:run --generate-baseline=.security-baseline.json
-git add .security-baseline.json
-```
-
-Baselined findings are dropped from the report and do **not** affect the exit
-code, so a green PR check means "no new findings since the baseline".
 
 ### JSON report as artifact
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,6 +9,7 @@ GitHub Code Scanning or the GitLab Security Dashboard.
 - [Managing LLM Costs](#managing-llm-costs)
 - [Report Visibility on Public Repositories](#report-visibility-on-public-repositories)
 - [GitHub Actions](#github-actions)
+  - [Sticky PR comment with the audit summary](#sticky-pr-comment-with-the-audit-summary)
   - [Reusable GitHub Action](#reusable-github-action)
 - [GitLab CI](#gitlab-ci)
 - [Output Formats Reference](#output-formats-reference)
@@ -235,6 +236,67 @@ Critical and high-severity findings become `::error`, medium becomes
 how GitHub displays the finding, not the job's exit code; combine with
 `--fail-on` to also fail the check run. Don't pass `--output` — annotations must
 reach stdout for GitHub to parse them.
+
+### Sticky PR comment with the audit summary
+
+Inline annotations are easy to miss once a PR has more than a couple of review
+comments, and a fresh top-level comment on every push spams the thread.
+[`marocchino/sticky-pull-request-comment`](https://github.com/marketplace/actions/sticky-pull-request-comment)
+solves both: it finds its own previous comment (matched by the `header` input)
+and edits it in place, so the PR always shows exactly one up-to-date audit
+comment regardless of how many times the workflow reruns. Pair it with
+`--format markdown` so the comment renders as native GitHub markdown — headings,
+a findings table — rather than a log dump.
+
+```yaml
+# .github/workflows/security-audit.yaml
+name: Security Audit
+
+on:
+  pull_request: ~
+
+permissions:
+  contents: read
+  pull-requests: write # required to post/update the sticky comment
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so `since` can diff against the base branch
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3' # Or 8.4 or 8.5
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run security audit
+        id: audit
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          php bin/console audit:run --since origin/${{ github.base_ref }} --format markdown --output report.md --fail-on high
+
+      - name: Post sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        if: always() # post the summary even when audit:run exits non-zero on --fail-on
+        with:
+          header: security-audit
+          path: report.md
+```
+
+The report file is written before the exit code is computed, so it exists even
+on a failing run — `if: always()` on the comment step is what lets it post
+regardless, while the job itself still fails on the `audit:run` step so
+`--fail-on` still gates the check run. `header: security-audit` scopes this
+action to its own comment; give a second sticky-comment step in the same
+workflow (e.g. one posting coverage) a different `header` so the two never
+overwrite each other.
 
 ### Reusable GitHub Action
 


### PR DESCRIPTION
## Summary

Adds a new `docs/ci.md` recipe pairing `--format markdown` with [`marocchino/sticky-pull-request-comment`](https://github.com/marketplace/actions/sticky-pull-request-comment) so a PR's audit summary is posted as a single comment that gets edited in place on every rerun, instead of either being buried in inline annotations once a PR has a few review comments, or spamming the thread with a fresh top-level comment on every push. Docs-only change — no code, no config keys, no CHANGELOG entry per the docs-only exemption in `.claude/rules/changelog.md`.

## Type of change

- [x] Documentation

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — N/A, docs-only
- [x] All checks pass
- [x] 100% MSI maintained — N/A, docs-only
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)