### PR TITLE
fix(llm): pass a plain string to ToolCallMessage for ai-bundle 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **Every attacker/reviewer tool call was broken by the `symfony/ai-bundle` 0.11
+  upgrade.** `SequentialToolLoop` and `ToolConversationWavefront` both wrapped a
+  tool's string result in a `Content\Text` object before handing it to
+  `new ToolCallMessage($toolCall, ...)`, but 0.11 tightened that constructor's
+  second parameter to a plain `string` — every tool invocation (`read_file`,
+  `grep`, `list_files`, `lookup_advisory`) threw a `TypeError` (argument
+  `$content` must be `string`, `Content\Text` given) instead of feeding the
+  result back to the model. Both call sites now pass the result string directly.
+  Implementation lives in `src/Audit/Infrastructure/LLM/SequentialToolLoop.php`
+  and `src/Audit/Infrastructure/LLM/ToolConversationWavefront.php`.
+
 - **The native Windows binary is published with releases again.**
   `windows-latest` lost VS 2022 in GitHub's June 2026 image migration, so
   `static-php-cli` 2.8.5's doctor aborted before installing the `7za.exe` its

--- a/src/Audit/Infrastructure/LLM/SequentialToolLoop.php
+++ b/src/Audit/Infrastructure/LLM/SequentialToolLoop.php
@@ -15,7 +15,6 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM;
 
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\Message\AssistantMessage;
-use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\ToolCallMessage;
@@ -139,7 +138,7 @@ final readonly class SequentialToolLoop
             $toolResults = [];
             foreach ($toolCalls as $toolCall) {
                 $result = $toolRegistry->execute($toolCall->getName(), $toolCall->getArguments());
-                $messageBag->add(new ToolCallMessage($toolCall, new Text($result)));
+                $messageBag->add(new ToolCallMessage($toolCall, $result));
                 $toolResults[] = $result;
                 $this->logger->debug('Tool invoked', [
                     'tool' => $toolCall->getName(),

--- a/src/Audit/Infrastructure/LLM/ToolConversationWavefront.php
+++ b/src/Audit/Infrastructure/LLM/ToolConversationWavefront.php
@@ -15,7 +15,6 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM;
 
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\Message\AssistantMessage;
-use Symfony\AI\Platform\Message\Content\Text;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\ToolCallMessage;
@@ -330,7 +329,7 @@ final readonly class ToolConversationWavefront
         $toolResults = [];
         foreach ($toolCalls as $toolCall) {
             $result = $request['tools']->execute($toolCall->getName(), $toolCall->getArguments());
-            $state['bag']->add(new ToolCallMessage($toolCall, new Text($result)));
+            $state['bag']->add(new ToolCallMessage($toolCall, $result));
             $toolResults[] = $result;
         }
 


### PR DESCRIPTION
## Summary

- `symfony/ai-bundle` 0.11 (merged in #179) tightened `ToolCallMessage::__construct()`'s second parameter to a plain `string`. `SequentialToolLoop` and `ToolConversationWavefront` both still wrapped a tool's result in a `Content\Text` object, so every attacker/reviewer tool invocation (`read_file`, `grep`, `list_files`, `lookup_advisory`) threw a `TypeError` instead of feeding the result back to the model.
- Both call sites now pass the result string directly.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)