### PR TITLE
feat(llm): expose finish reasons and retry 5xx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
+- **Truncated and content-filtered LLM responses are now called out
+  explicitly.** `symfony/ai` 0.11 exposes a normalized `finish_reason` on every
+  platform result; `PlatformResultExtractor` now reads it, so `LLMResponse`
+  carries the real provider stop reason (e.g. `max_tokens`) instead of a
+  hard-coded `end_turn`, and the auditor logs an actionable
+  `LLM response was truncated by the output token limit` warning (pointing at
+  `max_output_tokens`) when a response was truncated, or a
+  `suppressed by the provider content filter` warning when the provider filtered
+  it out — both previously surfaced only as silent finding loss or empty-chunk
+  noise. `TransientFailureClassifier` additionally recognizes symfony/ai's typed
+  `ServerException` (HTTP 5xx) as transient, so server-side hiccups are retried
+  even when the provider's error wording matches no known heuristic.
+
 - **MiniMax is now a first-class provider.** `symfony/ai-bundle` 0.11 ships a
   `minimax` platform configuration backed by the new
   `symfony/ai-mini-max-platform` bridge, so the auditor can run on

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -615,9 +615,10 @@ above), `SequentialToolLoop` (the autonomous tool-using conversation behind
 `completeWithTools()`), `BatchWindowResolver` and `ToolConversationWavefront`
 (the `completeBatch()` / `completeBatchWithTools()` concurrency windows, falling
 back to the sequential paths on failure), `PlatformResultExtractor` (token
-usage, tool calls, text), `PlatformOptionsFactory` (temperature +
-Anthropic-dialect options), and `PlatformToolsMapper` (Domain `ToolDefinition` →
-platform `Tool` schema mapping).
+usage, tool calls, text, and the provider finish reason — warning when a
+response was truncated or content-filtered), `PlatformOptionsFactory`
+(temperature + Anthropic-dialect options), and `PlatformToolsMapper` (Domain
+`ToolDefinition` → platform `Tool` schema mapping).
 
 ### `LLMResponse`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -176,6 +176,12 @@ When raising the cap, raise `audit.rate_limit.output_tokens_per_minute`
 proportionally — otherwise the output-tokens bucket becomes the binding
 throttle.
 
+When the provider reports why generation stopped (`symfony/ai` ≥ 0.11 exposes a
+normalized finish reason), the auditor logs an explicit
+`LLM response was truncated by the output token limit` warning — no output-token
+forensics needed. A `LLM response was suppressed by the provider content filter`
+warning likewise flags responses the provider filtered out.
+
 ### `Ollama: model not found`
 
 Pull the model first:

--- a/src/Audit/Infrastructure/LLM/BatchWindowResolver.php
+++ b/src/Audit/Infrastructure/LLM/BatchWindowResolver.php
@@ -112,7 +112,7 @@ final readonly class BatchWindowResolver
             $llmResponse = LLMResponse::of(
                 $content,
                 $this->model,
-                'end_turn',
+                $this->platformResultExtractor->extractStopReason($deferredResult) ?? 'end_turn',
                 TokenUsageSnapshot::of($inputTokens, $outputTokens, $cacheReadTokens, $cacheCreationTokens),
             );
             $this->budgetTracker?->recordCall($llmResponse);

--- a/src/Audit/Infrastructure/LLM/PlatformResultExtractor.php
+++ b/src/Audit/Infrastructure/LLM/PlatformResultExtractor.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\MultiPartResult;
 use Symfony\AI\Platform\Result\ResultInterface;
@@ -24,8 +28,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\NegativeTok
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Telemetry\TokenUsageRecorder;
 
 /**
- * Extracts token usage, tool calls, and text from symfony/ai platform
- * results, recording usage on the optional telemetry recorder.
+ * Extracts token usage, tool calls, text, and the provider finish reason from
+ * symfony/ai platform results, recording usage on the optional telemetry
+ * recorder and warning when a response was truncated or content-filtered.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -33,6 +38,7 @@ final readonly class PlatformResultExtractor
 {
     public function __construct(
         private ?TokenUsageRecorder $tokenUsageRecorder,
+        private LoggerInterface $logger = new NullLogger(),
     ) {}
 
     /** @return array{0: int, 1: int, 2: int, 3: int}
@@ -54,6 +60,31 @@ final readonly class PlatformResultExtractor
         $this->tokenUsageRecorder?->record($inputTokens, $outputTokens, $cacheReadTokens, $cacheCreationTokens);
 
         return [$inputTokens, $outputTokens, $cacheReadTokens, $cacheCreationTokens];
+    }
+
+    public function extractStopReason(DeferredResult $deferredResult): ?string
+    {
+        $finishReason = $deferredResult->getMetadata()->all()['finish_reason'] ?? null;
+        if (!$finishReason instanceof FinishReason) {
+            return null;
+        }
+
+        $this->warnWhenDegraded($finishReason);
+
+        return $finishReason->getRaw();
+    }
+
+    private function warnWhenDegraded(FinishReason $finishReason): void
+    {
+        $warning = match (true) {
+            $finishReason->is(FinishReasonCase::LENGTH) => 'LLM response was truncated by the output token limit — findings may be lost; raise max_output_tokens (or the per-agent attacker/reviewer variants)',
+            $finishReason->is(FinishReasonCase::CONTENT_FILTER) => 'LLM response was suppressed by the provider content filter — findings may be lost',
+            default => null,
+        };
+
+        if (null !== $warning) {
+            $this->logger->warning($warning, ['finish_reason' => $finishReason->getRaw()]);
+        }
     }
 
     /**

--- a/src/Audit/Infrastructure/LLM/SequentialToolLoop.php
+++ b/src/Audit/Infrastructure/LLM/SequentialToolLoop.php
@@ -129,7 +129,7 @@ final readonly class SequentialToolLoop
                 return LLMResponse::of(
                     $content,
                     $this->model,
-                    'end_turn',
+                    $this->platformResultExtractor->extractStopReason($deferredResult) ?? 'end_turn',
                     TokenUsageSnapshot::of($totalInputTokens, $totalOutputTokens, $totalCacheReadTokens, $totalCacheCreationTokens),
                 );
             }

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -88,7 +88,7 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         $this->budgetTracker = $platformAccountingConfig->budgetTracker;
         $this->rateLimiter = $platformResilienceConfig->rateLimiter;
         $this->promptTokenEstimator = new PromptTokenEstimator($platformRequestConfig->tokenEstimator, $platformBinding->model);
-        $this->platformResultExtractor = new PlatformResultExtractor($platformAccountingConfig->tokenUsageRecorder);
+        $this->platformResultExtractor = new PlatformResultExtractor($platformAccountingConfig->tokenUsageRecorder, $platformBinding->logger);
         $platformOptionsFactory = new PlatformOptionsFactory($platformBinding->model, $platformRequestConfig->temperature, $platformRequestConfig->providerJsonMode, $platformBinding->maxOutputTokens);
         $this->platformOptionsFactory = $platformOptionsFactory;
 
@@ -195,7 +195,7 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         $llmResponse = LLMResponse::of(
             $content,
             $this->model,
-            'end_turn',
+            $this->platformResultExtractor->extractStopReason($deferredResult) ?? 'end_turn',
             TokenUsageSnapshot::of($inputTokens, $outputTokens, $cacheReadTokens, $cacheCreationTokens),
         );
         $this->budgetTracker?->recordCall($llmResponse);

--- a/src/Audit/Infrastructure/LLM/ToolConversationWavefront.php
+++ b/src/Audit/Infrastructure/LLM/ToolConversationWavefront.php
@@ -266,7 +266,7 @@ final readonly class ToolConversationWavefront
         $state['response'] = LLMResponse::of(
             $this->platformResultExtractor->extractText($platformResult),
             $this->model,
-            'end_turn',
+            $this->platformResultExtractor->extractStopReason($deferredResult) ?? 'end_turn',
             TokenUsageSnapshot::of($state['input'], $state['output'], $state['cacheRead'], $state['cacheCreation']),
         );
 

--- a/src/Audit/Infrastructure/LLM/TransientFailureClassifier.php
+++ b/src/Audit/Infrastructure/LLM/TransientFailureClassifier.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM;
 
+use Symfony\AI\Platform\Exception\ServerException;
 use Throwable;
 
 use function Symfony\Component\String\u;
@@ -74,6 +75,10 @@ final readonly class TransientFailureClassifier
 
     public function isTransient(Throwable $throwable): bool
     {
+        if ($throwable instanceof ServerException) {
+            return true;
+        }
+
         $joined = $this->joinMessages($throwable);
 
         if (u($joined)->containsAny(self::NON_TRANSIENT_HINTS) || $this->containsStatusCode($joined, self::NON_TRANSIENT_STATUS_CODES)) {

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -22,6 +22,8 @@ use Psr\Log\NullLogger;
 use RuntimeException;
 use Symfony\AI\Platform\Exception\RateLimitExceededException;
 use Symfony\AI\Platform\Exception\UnexpectedResultTypeException;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\Message\ToolCallMessage;
@@ -102,6 +104,93 @@ final class SymfonyAiLLMClientTest extends TestCase
         self::assertSame('end_turn', $llmResponse->stopReason());
         self::assertSame(0, $llmResponse->inputTokens());
         self::assertSame(0, $llmResponse->outputTokens());
+    }
+
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     * @throws InvalidTokenUsageException
+     * @throws NegativeTokenCountException
+     * @throws InvalidRetryConfigurationException
+     */
+    public function test_complete_surfaces_the_provider_finish_reason_as_stop_reason(): void
+    {
+        $textResult = new TextResult('truncated output');
+        $textResult->getMetadata()->add('finish_reason', new FinishReason(FinishReasonCase::LENGTH, 'max_tokens'));
+        $platform = $this->scriptedPlatform([$textResult]);
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding($platform, 'test-model', new NullLogger()));
+
+        $llmResponse = $symfonyAiLLMClient->complete('sys', 'usr');
+
+        self::assertSame('max_tokens', $llmResponse->stopReason());
+    }
+
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     * @throws InvalidTokenUsageException
+     * @throws NegativeTokenCountException
+     * @throws InvalidRetryConfigurationException
+     * @throws InvalidToolRegistryException
+     */
+    public function test_complete_with_tools_surfaces_the_provider_finish_reason_as_stop_reason(): void
+    {
+        $textResult = new TextResult('truncated output');
+        $textResult->getMetadata()->add('finish_reason', new FinishReason(FinishReasonCase::LENGTH, 'max_tokens'));
+        $platform = $this->scriptedPlatform([$textResult]);
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding($platform, 'test-model', new NullLogger()));
+
+        $llmResponse = $symfonyAiLLMClient->completeWithTools(
+            'sys',
+            'usr',
+            new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger()),
+            3,
+        );
+
+        self::assertSame('max_tokens', $llmResponse->stopReason());
+    }
+
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws NonTransientLLMFailureException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_complete_batch_surfaces_the_provider_finish_reason_as_stop_reason(): void
+    {
+        $textResult = new TextResult('truncated output');
+        $textResult->getMetadata()->add('finish_reason', new FinishReason(FinishReasonCase::LENGTH, 'max_tokens'));
+        $platform = $this->scriptedPlatform([$textResult]);
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding($platform, 'test-model', new NullLogger()));
+
+        $responses = $symfonyAiLLMClient->completeBatch([['system' => 's', 'user' => 'u']], 4);
+
+        self::assertSame('max_tokens', $responses[0]->stopReason());
+    }
+
+    /**
+     * @throws BudgetExceededException
+     * @throws MissingAiPlatformException
+     * @throws NonTransientLLMFailureException
+     * @throws InvalidTokenUsageException
+     * @throws InvalidToolRegistryException
+     */
+    public function test_complete_batch_with_tools_surfaces_the_provider_finish_reason_as_stop_reason(): void
+    {
+        $textResult = new TextResult('truncated output');
+        $textResult->getMetadata()->add('finish_reason', new FinishReason(FinishReasonCase::LENGTH, 'max_tokens'));
+        $platform = $this->scriptedPlatform([$textResult]);
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding($platform, 'test-model', new NullLogger()));
+
+        $responses = $symfonyAiLLMClient->completeBatchWithTools([
+            ['system' => 's', 'user' => 'u', 'tools' => new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger())],
+        ], 4, 3);
+
+        self::assertSame('max_tokens', $responses[0]->stopReason());
     }
 
     /**

--- a/tests/Phpunit/Unit/Infrastructure/LLM/PlatformResultExtractorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/PlatformResultExtractorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\LLM;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\AI\Platform\FinishReason\FinishReason;
+use Symfony\AI\Platform\FinishReason\FinishReasonCase;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\TextResult;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\PlatformResultExtractor;
+
+final class PlatformResultExtractorTest extends TestCase
+{
+    public function test_it_extracts_the_raw_provider_stop_reason(): void
+    {
+        $platformResultExtractor = new PlatformResultExtractor(null);
+
+        $stopReason = $platformResultExtractor->extractStopReason(
+            $this->deferredResultWithFinishReason(new FinishReason(FinishReasonCase::STOP, 'end_turn')),
+        );
+
+        self::assertSame('end_turn', $stopReason);
+    }
+
+    public function test_it_returns_null_when_the_result_carries_no_finish_reason(): void
+    {
+        $platformResultExtractor = new PlatformResultExtractor(null);
+
+        self::assertNull($platformResultExtractor->extractStopReason($this->deferredResult()));
+    }
+
+    public function test_it_warns_when_the_response_was_truncated_by_the_output_token_limit(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('truncated'),
+                ['finish_reason' => 'max_tokens'],
+            );
+
+        $platformResultExtractor = new PlatformResultExtractor(null, $logger);
+
+        $stopReason = $platformResultExtractor->extractStopReason(
+            $this->deferredResultWithFinishReason(new FinishReason(FinishReasonCase::LENGTH, 'max_tokens')),
+        );
+
+        self::assertSame('max_tokens', $stopReason);
+    }
+
+    public function test_it_warns_when_the_response_was_suppressed_by_the_content_filter(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('content filter'),
+                ['finish_reason' => 'content_filtered'],
+            );
+
+        $platformResultExtractor = new PlatformResultExtractor(null, $logger);
+
+        $stopReason = $platformResultExtractor->extractStopReason(
+            $this->deferredResultWithFinishReason(new FinishReason(FinishReasonCase::CONTENT_FILTER, 'content_filtered')),
+        );
+
+        self::assertSame('content_filtered', $stopReason);
+    }
+
+    public function test_it_does_not_warn_on_a_normal_stop(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+
+        $platformResultExtractor = new PlatformResultExtractor(null, $logger);
+
+        $stopReason = $platformResultExtractor->extractStopReason(
+            $this->deferredResultWithFinishReason(new FinishReason(FinishReasonCase::TOOL_CALL, 'tool_use')),
+        );
+
+        self::assertSame('tool_use', $stopReason);
+    }
+
+    private function deferredResultWithFinishReason(FinishReason $finishReason): DeferredResult
+    {
+        $deferredResult = $this->deferredResult();
+        $deferredResult->getMetadata()->add('finish_reason', $finishReason);
+
+        return $deferredResult;
+    }
+
+    private function deferredResult(): DeferredResult
+    {
+        return new DeferredResult(
+            new PlainConverter(new TextResult('ok')),
+            new InMemoryRawResult([], [], (object) []),
+        );
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/LLM/TransientFailureClassifierTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/TransientFailureClassifierTest.php
@@ -16,6 +16,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\LLM;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Symfony\AI\Platform\Exception\ServerException;
 use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\TransientFailureClassifier;
 
@@ -30,6 +31,7 @@ final class TransientFailureClassifierTest extends TestCase
     /** @return iterable<string, array{Throwable}> */
     public static function transientCases(): iterable
     {
+        yield 'typed_server_exception_without_transient_hints' => [new ServerException(null, 'provider hiccup')];
         yield 'http_429' => [new RuntimeException('HTTP 429 Too Many Requests')];
         yield 'http_500' => [new RuntimeException('Server returned HTTP 500')];
         yield 'http_502' => [new RuntimeException('Bad Gateway 502')];


### PR DESCRIPTION
## Summary

`symfony/ai` 0.11 exposes a normalized `finish_reason` on every platform result. `PlatformResultExtractor` now reads it, so `LLMResponse` carries the real provider stop reason (e.g. `max_tokens`) instead of a hard-coded `end_turn` across all four completion paths (`complete`, `completeWithTools`, `completeBatch`, `completeBatchWithTools`), and the auditor logs an actionable warning when a response was truncated by the output token limit (pointing at `max_output_tokens`) or suppressed by the provider content filter — both previously surfaced only as silent finding loss or empty-chunk noise. `TransientFailureClassifier` additionally recognizes symfony/ai's typed `ServerException` (HTTP 5xx) as transient, so server-side hiccups retry even when the provider's error wording matches no string heuristic.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)