### PR TITLE
chore: release 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.16.0] — 2026-07-18 — Perimeter
+
+A release about the security perimeter. The attacker gains a wave of
+misconfiguration hunts — HTTP trust boundaries (wildcard `trusted_proxies`,
+Host-header injection / cache poisoning), permissive CORS, weak CSP, missing
+HSTS, weak password hashing, debug mode left on, permissive Mercure topics, plus
+LDAP and admin-panel surfaces — and the reviewer learns across runs through
+opt-in triage memory. The standalone binary can now update itself in place with
+`self-update`, MiniMax joins as a first-class provider, and truncated /
+content-filtered LLM responses are finally surfaced instead of lost. A large
+batch of fixes hardens triage memory (per-project isolation, stable cache keys,
+bounded prompt injection surface) and wires the new attacker skills that were
+built but never registered.
+
 ### Added
 
 - **`Vulnerability::of()` accepts an optional `detectedAt` timestamp.** The
@@ -2529,6 +2543,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.16.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.16.0
 [1.15.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.15.0
 [1.14.0]:

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ bin/console audit:run --dry-run
   report and exit code so only new findings fail CI.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.15.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.16.0`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **DDD architecture** — strict layering and a sole `LLMClientInterface` seam

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.15.0
+        uses: vinceamstoutz/symfony-security-auditor@1.16.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -206,7 +206,7 @@ Outputs: `exit-code`, `report-path`, and — only when `format: json` —
 ```yaml
       - name: Symfony Security Audit
         id: audit
-        uses: vinceamstoutz/symfony-security-auditor@1.15.0
+        uses: vinceamstoutz/symfony-security-auditor@1.16.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -237,7 +237,7 @@ tradeoffs.
 
 ```yaml
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.15.0
+        uses: vinceamstoutz/symfony-security-auditor@1.16.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -156,7 +156,7 @@ deprecated by the other.
   inputs/outputs may be added in a `MINOR`; renaming or removing one is a
   `MAJOR`. The Marketplace `name` (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.15.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.16.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.15.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.16.0/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",


### PR DESCRIPTION
## Summary

Cuts the **1.16.0 "Perimeter"** release. 

## Type of change

- [x] Chore

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — N/A, changelog/version-pin only
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise) — N/A
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)