### PR TITLE
feat(standalone): one liner installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Added
+
+- **One command installs _and_ configures the standalone binary via
+  `SSA_INIT`.** `install.sh` now honors an `SSA_INIT` environment variable: with
+  `SSA_INIT=1`, after the binary is downloaded and its SHA-256 checksum
+  verified, the installer runs `<binary> init` — so
+  `curl -fsSL …/install.sh | SSA_INIT=1 sh` installs and configures the tool in
+  a single command instead of the previous two (`install.sh`, then `init`). When
+  a controlling terminal is reachable (the installer test-opens `/dev/tty`)
+  `init` runs interactively, so the provider/model prompts still work through a
+  `curl | sh` pipe; in a pipe or CI with no terminal it falls back to
+  `init --no-interaction` (Anthropic defaults). The installer invokes the binary
+  by its absolute install path, so `init` runs even when the target directory is
+  not yet on `PATH`. A failed `init` (e.g. `composer` unavailable) is non-fatal
+  — the installed binary is kept and a note points the user to run `init`
+  themselves. Documented in `README.md` and the `install.sh` header, and covered
+  by `tests/Shell/install_script_test.sh`.
+
 ### Fixed
 
 - **`install.sh` no longer fails silently when the `wget` fallback hits an HTTP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   themselves. Documented in `README.md` and the `install.sh` header, and covered
   by `tests/Shell/install_script_test.sh`.
 
+### Changed
+
+- **The standalone install docs now lead with the cross-platform `curl … | sh`
+  one-liner**, with the PowerShell `irm … | iex` command demoted to the
+  native-Windows fallback — the single `curl` command covers Linux, macOS, and
+  Windows under WSL or Git Bash.
+- **`install.sh` now points Windows POSIX-shell users (Git Bash / MSYS / Cygwin)
+  at the PowerShell installer.** It previously failed there with a generic
+  "download the `.exe`" message; it now detects a `MINGW*`/`MSYS*`/`CYGWIN*`
+  `uname` and prints the exact `irm …/install.ps1 | iex` command to run instead.
+  (A bare PowerShell session can't execute `install.sh` at all — there is no
+  `sh` to pipe into — so this guidance targets the POSIX shells on Windows that
+  can.)
+
 ### Fixed
 
 - **`install.sh` no longer fails silently when the `wget` fallback hits an HTTP

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-audi
 irm https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.ps1 | iex
 ```
 
+> [!TIP]
+>
+> **One command, installed _and_ configured.** Set `SSA_INIT=1` and the
+> installer runs the guided [`init`](#2-configure--the-guided-init) for you
+> right after downloading — so you skip step 2. It prompts for your provider
+> when a terminal is attached, and falls back to the Anthropic defaults
+> non-interactively in a pipe or CI. `init` fetches the provider bridge with
+> `composer`, so composer must be available for this combined step.
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh | SSA_INIT=1 sh
+> ```
+
 Or download the binary for your platform straight from the
 [latest release](https://github.com/vinceAmstoutz/symfony-security-auditor/releases/latest):
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,19 @@ Linux, macOS, and Windows.
 
 ### 1. Install
 
+**One command — Linux, macOS, and Windows (under WSL or Git Bash):**
+
 ```bash
-# Linux / macOS — detects your OS + architecture, downloads and verifies the binary
 curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh | sh
 ```
 
+`install.sh` detects your OS and CPU architecture, downloads the matching
+binary, and verifies its SHA-256 checksum before installing — anywhere you have
+a POSIX shell.
+
+**Native Windows (PowerShell)** — when you are not using WSL or Git Bash:
+
 ```powershell
-# Windows (PowerShell)
 irm https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.ps1 | iex
 ```
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -123,8 +123,8 @@ following surface is BC-protected:
   (`symfony-security-auditor-{linux-x86_64,linux-aarch64,macos-x86_64,macos-arm64}`
   and `symfony-security-auditor-windows-x86_64.exe`), each accompanied by a
   `.sha256` checksum, plus the `install.sh` (Linux/macOS) and `install.ps1`
-  (Windows) installer contracts and their `SSA_VERSION` / `SSA_INSTALL_DIR`
-  environment variables.
+  (Windows) installer contracts and their `SSA_VERSION` / `SSA_INSTALL_DIR` /
+  `SSA_INIT` environment variables.
 - The `init` command name. The standalone exposes the **identical** `audit:run`
   command (and its `audit` alias), arguments, options, and exit-code surface
   listed above.

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,9 @@ detect_asset() {
   case "$os" in
     Linux) os_slug="linux" ;;
     Darwin) os_slug="macos" ;;
+    MINGW* | MSYS* | CYGWIN*)
+      fail "this is a Windows POSIX shell (Git Bash / MSYS / Cygwin); install the native Windows binary from PowerShell instead:
+  irm https://raw.githubusercontent.com/${REPO}/main/install.ps1 | iex" ;;
     *) fail "unsupported OS '$os' — on Windows download symfony-security-auditor-windows-x86_64.exe from the releases page" ;;
   esac
 

--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,17 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh | sh
 #
+# One command to install *and* configure (installs the binary, then runs its
+# guided `init`):
+#   curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh | SSA_INIT=1 sh
+#
 # Environment variables:
 #   SSA_VERSION      release tag to install (default: latest)
 #   SSA_INSTALL_DIR  target directory (default: /usr/local/bin, else ~/.local/bin)
+#   SSA_INIT         when "1", run "<binary> init" after installing so a single
+#                    command installs and configures the tool; prompts read from
+#                    /dev/tty when a terminal is attached, else fall back to
+#                    "init --no-interaction" (needs composer, like init itself)
 #
 # The SHA-256 checksum is always verified; the install aborts if no checksum
 # tool is available.
@@ -82,6 +90,26 @@ resolve_install_dir() {
   fi
 }
 
+init_can_prompt() {
+  { : </dev/tty; } 2>/dev/null
+}
+
+run_init() {
+  [ "${SSA_INIT:-0}" = "1" ] || return 0
+
+  binary="$1"
+  echo "Configuring ${BINARY_NAME} (running 'init')…"
+  if init_can_prompt; then
+    "$binary" init </dev/tty || warn_init_incomplete
+  else
+    "$binary" init --no-interaction || warn_init_incomplete
+  fi
+}
+
+warn_init_incomplete() {
+  echo "note: '${BINARY_NAME} init' did not complete — run it yourself to finish configuration." >&2
+}
+
 main() {
   need uname
 
@@ -106,6 +134,9 @@ main() {
   mv "${tmp}/${asset}" "${install_dir}/${BINARY_NAME}"
 
   echo "Installed ${BINARY_NAME} to ${install_dir}/${BINARY_NAME}"
+
+  run_init "${install_dir}/${BINARY_NAME}"
+
   case ":${PATH}:" in
     *":${install_dir}:"*) ;;
     *) echo "note: ${install_dir} is not on your PATH — add it to run '${BINARY_NAME}' directly" ;;

--- a/tests/Shell/install_script_test.sh
+++ b/tests/Shell/install_script_test.sh
@@ -62,6 +62,17 @@ expect_failure "detect_asset rejects an unsupported OS" detect_asset
 FAKE_OS=Linux FAKE_ARCH=riscv64
 expect_failure "detect_asset rejects an unsupported architecture" detect_asset
 
+FAKE_OS=MINGW64_NT-10.0-19045 FAKE_ARCH=x86_64
+if windows_shell_message=$(detect_asset 2>&1); then
+  echo "NOT OK - detect_asset should fail in a Windows POSIX shell (Git Bash/MSYS)"
+  failures=$((failures + 1))
+elif printf '%s' "$windows_shell_message" | grep -q 'install.ps1'; then
+  echo "ok - detect_asset points a Windows POSIX shell to the PowerShell installer"
+else
+  echo "NOT OK - detect_asset failed without pointing to the PowerShell installer: [$windows_shell_message]"
+  failures=$((failures + 1))
+fi
+
 SSA_INSTALL_DIR=/opt/tools/bin
 expect_equals "resolve_install_dir honours SSA_INSTALL_DIR" /opt/tools/bin "$(resolve_install_dir)"
 unset SSA_INSTALL_DIR

--- a/tests/Shell/install_script_test.sh
+++ b/tests/Shell/install_script_test.sh
@@ -102,6 +102,32 @@ else
   echo "ok - verify_checksum fails closed when no digest tool is available"
 fi
 
+init_stub_dir=$(mktemp -d)
+trap 'rm -rf "$checksum_dir" "$init_stub_dir"' EXIT
+init_log="$init_stub_dir/args"
+cat >"$init_stub_dir/bin" <<STUB
+#!/bin/sh
+printf '%s' "\$*" >"$init_log"
+STUB
+chmod +x "$init_stub_dir/bin"
+
+unset SSA_INIT 2>/dev/null || true
+rm -f "$init_log"
+run_init "$init_stub_dir/bin" >/dev/null 2>&1
+if [ -f "$init_log" ]; then
+  echo "NOT OK - run_init invoked init without SSA_INIT=1"
+  failures=$((failures + 1))
+else
+  echo "ok - run_init is a no-op unless SSA_INIT=1"
+fi
+
+SSA_INIT=1
+init_can_prompt() { return 1; }
+rm -f "$init_log"
+run_init "$init_stub_dir/bin" >/dev/null 2>&1
+expect_equals "run_init passes --no-interaction when no terminal is attached" "init --no-interaction" "$(cat "$init_log")"
+unset SSA_INIT
+
 if [ "$failures" -eq 0 ]; then
   echo "All install.sh tests passed."
   exit 0


### PR DESCRIPTION
## Summary

Collapses the standalone tool's two-step setup (`curl … | sh`, then
`symfony-security-auditor init`) into a single command via a new `SSA_INIT`
environment variable:

```bash
curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh | SSA_INIT=1 sh
```

After the binary is downloaded and its SHA-256 checksum verified, the installer
runs `init` via the binary's **absolute install path** (so it works even when
the target directory is not yet on `PATH`). Prompts are read from `/dev/tty`
when a controlling terminal is reachable — **test-opened** rather than checked
with `[ -r ]`, which false-positives in containers/cron where the device node
exists but has no controlling terminal — so provider/model prompts still work
through a `curl | sh` pipe on a real terminal. Otherwise it falls back to
`init --no-interaction`. A failed `init` (e.g. `composer` unavailable) is
non-fatal: the binary stays installed and a note points the user to run `init`.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (two new cases in `tests/Shell/install_script_test.sh`)
- [x] All checks pass on CI (all matrix jobs green); verified locally: `sh -n`, the shell test suite, `prettier@3.6.2 --check`, and `markdownlint-cli2` all pass (the full `bin/castor lint` needs composer deps unavailable in the authoring environment)
- [x] No `createMock` without a matching `expects()` — n/a
- [x] Commit messages follow Conventional Commits