### PR TITLE
fix(standalone): windows download errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Fixed
+
+- **`install.sh` no longer fails silently when the `wget` fallback hits an HTTP
+  error.** The `wget` download path in `download()` used `-q`, which suppresses
+  wget's error output, so a failed request (e.g. a 404 for a missing release
+  asset) aborted the installer under `set -eu` with no diagnostic — unlike the
+  `curl` path (`curl -fSL`), which prints the HTTP error. Dropping `-q` restores
+  a visible failure reason on the `wget` path.
+- **`install.ps1` now shows its "no Windows binary for this release" guidance on
+  PowerShell 7, not only Windows PowerShell 5.1.** The friendly 404 handler
+  caught `[System.Net.WebException]`, which only Windows PowerShell 5.1 throws;
+  PowerShell 7+ (the common `irm | iex` host, built on .NET Core) throws
+  `Microsoft.PowerShell.Commands.HttpResponseException`, so the typed `catch`
+  never matched and users saw a raw transport error instead of the Composer/WSL
+  fallback instructions. A new `Get-ResponseStatusCode` helper reads the status
+  from the error record's shared `Response` property regardless of the thrown
+  exception type, so the guidance appears on both PowerShell editions.
+
 ## [1.16.0] — 2026-07-18 — Perimeter
 
 A release about the security perimeter. The attacker gains a wave of

--- a/install.ps1
+++ b/install.ps1
@@ -35,6 +35,18 @@ function Get-Asset([string]$Url, [string]$OutFile) {
     Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
 }
 
+function Get-ResponseStatusCode {
+    param([System.Management.Automation.ErrorRecord]$ErrorRecord)
+
+    # 5.1 throws WebException, 7+ throws HttpResponseException — read the shared Response property instead of a version-specific catch type.
+    $responseProperty = $ErrorRecord.Exception.PSObject.Properties['Response']
+    if ($responseProperty -and $responseProperty.Value) {
+        return [int]$responseProperty.Value.StatusCode
+    }
+
+    return 0
+}
+
 function Test-Checksum([string]$File, [string]$ChecksumFile) {
     $expected = ((Get-Content -Raw $ChecksumFile).Trim() -split '\s+')[0]
     $actual = (Get-FileHash -Path $File -Algorithm SHA256).Hash
@@ -64,9 +76,8 @@ function Install-Binary {
         try {
             Get-Asset "$base/$asset" "$tmp\$asset"
         }
-        catch [System.Net.WebException] {
-            $status = [int]$_.Exception.Response.StatusCode
-            if ($status -eq 404) {
+        catch {
+            if ((Get-ResponseStatusCode $_) -eq 404) {
                 throw @"
 No Windows binary is published for release '$Version'.
 

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ download() {
   if command -v curl >/dev/null 2>&1; then
     curl -fSL "$1" -o "$2"
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO "$2" "$1"
+    wget -O "$2" "$1"
   else
     fail "need either 'curl' or 'wget'"
   fi


### PR DESCRIPTION
## Summary

Two installer error-reporting fixes so a failed download surfaces a reason
instead of a silent or raw error:

- **`install.sh`** — the `wget` fallback in `download()` used `-q`, hiding
  wget's error output, so a failed request (e.g. a 404 for a missing release
  asset) aborted the installer under `set -eu` with no diagnostic, unlike the
  `curl -fSL` path. Dropped `-q`.
- **`install.ps1`** — the friendly "no Windows binary for this release" 404
  handler caught `[System.Net.WebException]`, which only Windows PowerShell 5.1
  throws. PowerShell 7+ (the common `irm | iex` host) throws
  `HttpResponseException`, so the guidance never showed and users saw a raw
  transport error. A new `Get-ResponseStatusCode` helper reads the status from
  the error record's shared `Response` property regardless of exception type.

## Type of change

- [x] Bug fix

## Checklist

- [x] All checks pass on CI (Lint, shell install-script tests, all matrix jobs green); locally `sh -n` + shell test suite + prettier + markdownlint pass
- [x] No `createMock` without a matching `expects()` — n/a
- [x] Commit messages follow Conventional Commits