### PR TITLE
feat(command): add scriptable options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   — the installed binary is kept and a note points the user to run `init`
   themselves. Documented in `README.md` and the `install.sh` header, and covered
   by `tests/Shell/install_script_test.sh`.
+- **`init` is now scriptable via `--provider`, `--model`, and `--env-var`
+  options.** Previously `symfony-security-auditor init` only asked interactively
+  and, under `--no-interaction`, always wrote the Anthropic defaults — so a
+  non-interactive install could not target a different provider. Each option now
+  skips its matching prompt; any option left out still falls back to its prompt
+  (or, non-interactively, to its default: `anthropic`, `claude-opus-4-8`, and a
+  `<PROVIDER>_API_KEY` variable derived from the resolved provider). This lets a
+  single command configure any provider — e.g.
+  `init --provider=openai --model=gpt-5.4 --no-interaction` — which the
+  standalone installer's `SSA_INIT` flow and the GitHub Action use to set up
+  non-interactively. Documented in
+  [`docs/configuration.md`](docs/configuration.md#standalone-configuration).
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -466,6 +466,17 @@ model: claude-opus-4-8
 # scan:, audit:, cache: are all accepted here too, unwrapped.
 ```
 
+`init` is also scriptable: pass `--provider`, `--model`, and `--env-var` to skip
+the matching prompt. Any option left out falls back to its interactive prompt
+(or, under `--no-interaction`, to its default — `anthropic`, `claude-opus-4-8`,
+and `<PROVIDER>_API_KEY` respectively). This is what the `SSA_INIT` installer
+flag and the GitHub Action rely on to configure non-interactively:
+
+```bash
+symfony-security-auditor init --provider=openai --model=gpt-5.4 --no-interaction
+# --env-var omitted → derived as OPENAI_API_KEY
+```
+
 ### Per-project overrides
 
 A `.symfony-security-auditor.yaml` in the working directory (`$PWD`) is layered

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
@@ -46,8 +47,15 @@ final readonly class InitCommand
      * @throws UnresolvableConfigPathException
      * @throws BridgeInstallationFailedException
      */
-    public function __invoke(SymfonyStyle $symfonyStyle): int
-    {
+    public function __invoke(
+        SymfonyStyle $symfonyStyle,
+        #[Option(description: 'AI provider to configure (any symfony/ai platform — e.g. anthropic, openai, gemini); skips the prompt when set')]
+        ?string $provider = null,
+        #[Option(description: 'Model the auditor should use; skips the prompt when set')]
+        ?string $model = null,
+        #[Option(description: 'Environment variable holding the API key; defaults to <PROVIDER>_API_KEY')]
+        ?string $envVar = null,
+    ): int {
         $configFile = $this->xdgConfigPathResolver->configFile();
 
         if ($this->isOverwriteDeclined($symfonyStyle, $configFile)) {
@@ -56,14 +64,14 @@ final readonly class InitCommand
             return Command::SUCCESS;
         }
 
-        $provider = $this->ask($symfonyStyle, 'Which AI provider do you want to use? (any symfony/ai platform — e.g. anthropic, openai, gemini, mistral, ollama)', 'anthropic');
-        $model = $this->ask($symfonyStyle, 'Which model should the auditor use?', 'claude-opus-4-8');
-        $environmentVariable = $this->ask($symfonyStyle, 'Which environment variable holds the API key?', $this->defaultApiKeyVariable($provider));
+        $provider ??= $this->ask($symfonyStyle, 'Which AI provider do you want to use? (any symfony/ai platform — e.g. anthropic, openai, gemini, mistral, ollama)', 'anthropic');
+        $model ??= $this->ask($symfonyStyle, 'Which model should the auditor use?', 'claude-opus-4-8');
+        $envVar ??= $this->ask($symfonyStyle, 'Which environment variable holds the API key?', $this->defaultApiKeyVariable($provider));
 
-        $this->standaloneConfigWriter->write($configFile, $this->standaloneConfigFactory->create($provider, $model, $environmentVariable));
+        $this->standaloneConfigWriter->write($configFile, $this->standaloneConfigFactory->create($provider, $model, $envVar));
         $this->bridgeInstaller->install($provider, $this->xdgConfigPathResolver->dataDir());
 
-        $symfonyStyle->success(\sprintf('Configuration written to %s. Export %s, then run "audit <path>".', $configFile, $environmentVariable));
+        $symfonyStyle->success(\sprintf('Configuration written to %s. Export %s, then run "audit <path>".', $configFile, $envVar));
 
         return Command::SUCCESS;
     }

--- a/tests/Phpunit/Integration/Command/InitCommandTest.php
+++ b/tests/Phpunit/Integration/Command/InitCommandTest.php
@@ -97,6 +97,48 @@ final class InitCommandTest extends TestCase
         );
     }
 
+    public function test_it_uses_the_provider_model_and_env_var_options_without_prompting(): void
+    {
+        $commandTester = $this->commandTester();
+
+        $commandTester->execute(
+            ['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => 'MY_CUSTOM_KEY'],
+            ['interactive' => false],
+        );
+
+        self::assertSame(
+            ['provider' => 'openai', 'platform' => ['openai' => ['api_key' => '%env(MY_CUSTOM_KEY)%']], 'model' => 'gpt-5.4'],
+            Yaml::parseFile($this->configFile()),
+        );
+    }
+
+    public function test_it_derives_the_api_key_variable_from_the_provider_option_when_env_var_is_omitted(): void
+    {
+        $commandTester = $this->commandTester();
+
+        $commandTester->execute(
+            ['--provider' => 'openai', '--model' => 'gpt-5.4'],
+            ['interactive' => false],
+        );
+
+        self::assertSame(
+            ['provider' => 'openai', 'platform' => ['openai' => ['api_key' => '%env(OPENAI_API_KEY)%']], 'model' => 'gpt-5.4'],
+            Yaml::parseFile($this->configFile()),
+        );
+    }
+
+    public function test_it_installs_the_bridge_for_the_provider_option(): void
+    {
+        $commandTester = $this->commandTester();
+
+        $commandTester->execute(
+            ['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => 'MY_CUSTOM_KEY'],
+            ['interactive' => false],
+        );
+
+        self::assertSame([['openai', $this->dataHome.'/symfony-security-auditor']], $this->recordingBridgeInstaller->installations);
+    }
+
     public function test_it_leaves_an_existing_configuration_untouched_when_the_overwrite_is_declined(): void
     {
         (new Filesystem())->dumpFile($this->configFile(), "model: keep-me\n");


### PR DESCRIPTION
## Summary

Makes `symfony-security-auditor init` scriptable with `--provider`, `--model`,
and `--env-var` options. Previously it only asked interactively and, under
`--no-interaction`, always wrote the default-provider config — so a scripted or
piped install (the `SSA_INIT` flow, the GitHub Action's standalone mode) could
not target a different provider.

Each option, when set, skips its matching prompt; any option left out still
falls back to its interactive prompt, or non-interactively to its default
(the same provider/model defaults as before, plus a `PROVIDER_API_KEY` variable
derived from the resolved provider). Additive and backward compatible — with no
options the interactive flow is unchanged. Follows `SelfUpdateCommand`'s
existing `#[Option]` invokable-command pattern.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated (three new cases in `InitCommandTest`: options provided with distinct values, env-var derived from the provider option, bridge install for the provider option)
- [x] All checks pass on CI (PHPStan max, PHPUnit 100% coverage, Infection 100% MSI — all matrix jobs green); locally only `php -l` was possible (composer deps unavailable in the authoring environment)
- [x] 100% MSI maintained — verified green on CI
- [x] No `createMock` without a matching `expects()` (no mocks added; uses the existing `RecordingBridgeInstaller` fixture)
- [x] Commit messages follow Conventional Commits