### PR TITLE
fix(standalone): resolve self-update binary path on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   fallback instructions. A new `Get-ResponseStatusCode` helper reads the status
   from the error record's shared `Response` property regardless of the thrown
   exception type, so the guidance appears on both PowerShell editions.
+- **`self-update` now resolves the running binary on macOS when it was launched
+  by a bare name found on `PATH`.** `RunningBinaryLocator` located the
+  executable via `/proc/self/exe` (Linux-only) and, failing that, `realpath()`
+  of the invoked entry path. macOS has no `/proc/self/exe`, and a binary started
+  as a bare command name (e.g. `symfony-security-auditor self-update` resolved
+  through `PATH`) has an entry path that `realpath()` cannot resolve against the
+  working directory, so `self-update` aborted with "could not determine the path
+  of the running binary". The locator now adds a final fallback that looks the
+  bare name up across the `PATH` directories (the same way the shell found it),
+  threaded in from the process environment via `StandaloneApplicationFactory`.
+  Linux behavior (kernel-reported `/proc/self/exe`) is unchanged.
 
 ## [1.16.0] — 2026-07-18 — Perimeter
 

--- a/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocator.php
+++ b/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocator.php
@@ -22,7 +22,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Excepti
  * interpreter `/proc/self/exe` resolves to the interpreter itself, so resolving
  * a path there and renaming a downloaded binary over it would destroy the
  * interpreter. When running as `micro`, the kernel exposes the binary at
- * `/proc/self/exe` (Linux); elsewhere it falls back to the resolved entry path.
+ * `/proc/self/exe` (Linux); elsewhere (notably macOS, which has no
+ * `/proc/self/exe`) it falls back to the resolved entry path, and — when the
+ * binary was invoked by a bare name found on `PATH` so the entry path is not a
+ * resolvable file — to a `PATH` lookup of that name.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -34,6 +37,7 @@ final readonly class RunningBinaryLocator implements RunningBinaryLocatorInterfa
         private string $procSelfExePath = '/proc/self/exe',
         private string $invokedScriptPath = '',
         private string $sapi = \PHP_SAPI,
+        private string $pathEnvironment = '',
     ) {}
 
     /**
@@ -47,7 +51,7 @@ final readonly class RunningBinaryLocator implements RunningBinaryLocatorInterfa
         }
 
         return $this->kernelReportedPath()
-            ?? $this->resolvedInvokedScriptPath()
+            ?? $this->resolvedEntryPath()
             ?? throw SelfUpdateFailedException::forUndeterminedBinaryPath();
     }
 
@@ -62,14 +66,33 @@ final readonly class RunningBinaryLocator implements RunningBinaryLocatorInterfa
         return \is_string($resolved) ? $resolved : null;
     }
 
-    private function resolvedInvokedScriptPath(): ?string
+    private function resolvedEntryPath(): ?string
     {
         if ('' === $this->invokedScriptPath) {
             return null;
         }
 
         $resolved = realpath($this->invokedScriptPath);
+        if (false !== $resolved) {
+            return $resolved;
+        }
 
-        return false !== $resolved ? $resolved : null;
+        return $this->resolvedFromPathEnvironment();
+    }
+
+    private function resolvedFromPathEnvironment(): ?string
+    {
+        foreach (explode(\PATH_SEPARATOR, $this->pathEnvironment) as $directory) {
+            if ('' === $directory) {
+                continue;
+            }
+
+            $candidate = realpath($directory.\DIRECTORY_SEPARATOR.$this->invokedScriptPath);
+            if (false !== $candidate) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -57,6 +57,7 @@ final readonly class StandaloneApplicationFactory
         private StandaloneContainerFactory $standaloneContainerFactory = new StandaloneContainerFactory(),
         private StandaloneConsoleCommandFactory $standaloneConsoleCommandFactory = new StandaloneConsoleCommandFactory(),
         private string $runningBinaryPath = '',
+        private string $pathEnvironment = '',
     ) {}
 
     /**
@@ -75,6 +76,7 @@ final readonly class StandaloneApplicationFactory
             $xdgConfigPathResolver,
             new ComposerBridgeInstaller(ComposerBridgeInstaller::defaultProcessBuilder()),
             runningBinaryPath: $runningBinaryPath ?? '',
+            pathEnvironment: $environment['PATH'] ?? '',
         );
     }
 
@@ -143,7 +145,7 @@ final readonly class StandaloneApplicationFactory
             new SelfUpdater(
                 new ProcessReleaseClient(ProcessReleaseClient::defaultProcessBuilder()),
                 new GitHubBinaryAssetResolver(\PHP_OS_FAMILY, php_uname('m')),
-                new RunningBinaryLocator('/proc/self/exe', $this->runningBinaryPath),
+                new RunningBinaryLocator('/proc/self/exe', $this->runningBinaryPath, pathEnvironment: $this->pathEnvironment),
             ),
             (new ReportPackage())->version(),
         );

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
@@ -79,6 +79,59 @@ final class RunningBinaryLocatorTest extends TestCase
     /**
      * @throws SelfUpdateFailedException
      */
+    public function test_it_resolves_a_bare_invoked_name_via_the_path_environment(): void
+    {
+        $binDirectory = $this->workingDirectory.'/real-bin';
+        $decoyDirectory = $this->workingDirectory.'/decoy-bin';
+        (new Filesystem())->mkdir([$decoyDirectory, $binDirectory]);
+        (new Filesystem())->touch($binDirectory.'/symfony-security-auditor');
+        $pathEnvironment = $decoyDirectory.\PATH_SEPARATOR.$binDirectory;
+
+        self::assertSame(
+            $binDirectory.'/symfony-security-auditor',
+            (new RunningBinaryLocator($this->workingDirectory.'/missing', 'symfony-security-auditor', 'micro', $pathEnvironment))->path(),
+        );
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_skips_empty_path_entries_and_keeps_searching(): void
+    {
+        $binDirectory = $this->workingDirectory.'/real-bin';
+        (new Filesystem())->mkdir($binDirectory);
+        (new Filesystem())->touch($binDirectory.'/symfony-security-auditor');
+        $pathEnvironment = \PATH_SEPARATOR.$binDirectory;
+
+        self::assertSame(
+            $binDirectory.'/symfony-security-auditor',
+            (new RunningBinaryLocator($this->workingDirectory.'/missing', 'symfony-security-auditor', 'micro', $pathEnvironment))->path(),
+        );
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_fails_when_a_bare_invoked_name_is_not_found_on_the_path(): void
+    {
+        $this->expectException(SelfUpdateFailedException::class);
+
+        (new RunningBinaryLocator($this->workingDirectory.'/missing', 'symfony-security-auditor', 'micro', $this->workingDirectory.'/empty-bin'))->path();
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_does_not_mistake_a_path_directory_for_the_binary_when_the_invoked_name_is_empty(): void
+    {
+        $this->expectException(SelfUpdateFailedException::class);
+
+        (new RunningBinaryLocator($this->workingDirectory.'/missing', '', 'micro', $this->workingDirectory))->path();
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
     #[DataProvider('unresolvableInvokedScriptCases')]
     public function test_it_fails_when_neither_source_resolves_a_path(string $invokedScriptPath): void
     {


### PR DESCRIPTION
## Summary

Fixes `self-update` on macOS when the binary was launched by a bare name found
on `PATH`. `RunningBinaryLocator` located the running executable via
`/proc/self/exe` (Linux-only) then `realpath()` of the invoked entry path.
macOS has no `/proc/self/exe`, and a binary started as a bare command name
(e.g. `symfony-security-auditor self-update`, resolved through `PATH`) has an
entry path `realpath()` can't resolve against the working directory — so
`self-update` aborted with "could not determine the path of the running binary".

Adds a final fallback that looks the bare name up across the `PATH` directories
(mirroring how the shell resolved it), with `PATH` threaded in from the process
environment through `StandaloneApplicationFactory`. The kernel-reported
`/proc/self/exe` path still wins when present, so Linux behavior is unchanged.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (four `RunningBinaryLocator` cases: bare name found across a multi-directory `PATH`, empty `PATH` entries skipped, bare name absent from `PATH`, and the empty-name guard)
- [x] All checks pass on CI (PHPStan max, PHPUnit 100% coverage, Infection 100% MSI — all matrix jobs green); locally only `php -l` was possible (composer deps unavailable in the authoring environment)
- [x] 100% MSI maintained — verified green on CI
- [x] No `createMock` without a matching `expects()` — n/a (no mocks; real filesystem fixtures)
- [x] Commit messages follow Conventional Commits