### PR TITLE
test: relax fork/boot slow-test bound

### DIFF
--- a/tests/Phpunit/EndToEnd/StandaloneAuditEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/StandaloneAuditEndToEndTest.php
@@ -75,7 +75,7 @@ final class StandaloneAuditEndToEndTest extends TestCase
      * @throws UnresolvableAuditCommandException
      */
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_the_standalone_application_audits_a_project_end_to_end_in_dry_run(): void
     {
         $application = StandaloneApplicationFactory::fromEnvironment([

--- a/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
+++ b/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
@@ -95,7 +95,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     private ?Kernel $bootedKernel = null;
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_boots_with_minimal_config_and_registers_audit_command(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -104,7 +104,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_dependency_expansion_stage_between_mapping_and_audit(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -125,7 +125,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_registers_every_built_in_attacker_skill(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -137,7 +137,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_boots_without_an_ai_platform_service(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o'], registerPlatform: false);
@@ -355,7 +355,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_escalating_attacker_agent_when_escalation_enabled(): void
     {
         $kernel = $this->boot([
@@ -491,7 +491,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_configured_scan_included_paths_scope_the_show_scanned_listing_end_to_end(): void
     {
         mkdir($this->tmpDir.'/src/Controller/Admin', 0o777, true);
@@ -518,7 +518,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_unlimited_audit_budget_when_both_caps_omitted(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -529,7 +529,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_token_only_audit_budget(): void
     {
         $kernel = $this->boot([
@@ -544,7 +544,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_cost_only_audit_budget(): void
     {
         $kernel = $this->boot([
@@ -559,7 +559,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_both_caps_audit_budget(): void
     {
         $kernel = $this->boot([
@@ -642,7 +642,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_accepts_deprecated_prompt_caching_key_and_still_exposes_its_value(): void
     {
         $this->expectUserDeprecationMessageMatches('/The "prompt_caching" option is deprecated and no longer has any effect/');
@@ -658,7 +658,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_filesystem_attacker_cache_when_cache_enabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'cache' => ['enabled' => true]]);
@@ -667,7 +667,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_null_attacker_cache_when_cache_disabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'cache' => ['enabled' => false]]);
@@ -676,7 +676,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_filesystem_reviewer_cache_when_cache_enabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'cache' => ['enabled' => true]]);
@@ -685,7 +685,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_null_reviewer_cache_when_cache_disabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'cache' => ['enabled' => false]]);
@@ -694,7 +694,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_null_triage_memory_recorder_when_triage_memory_disabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -704,7 +704,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_filesystem_triage_memory_store_when_triage_memory_enabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'audit' => ['triage_memory' => true]]);
@@ -715,7 +715,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_the_ttl_bounded_advisory_cache_when_cache_enabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'cache' => ['enabled' => true]]);
@@ -724,7 +724,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_bypasses_the_advisory_cache_when_cache_disabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'cache' => ['enabled' => false]]);
@@ -817,7 +817,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_regex_secret_scrubber_by_default(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -826,7 +826,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_null_secret_scrubber_when_scrubbing_disabled(): void
     {
         $kernel = $this->boot([
@@ -838,7 +838,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_regex_static_pre_scanner_by_default(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -847,7 +847,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_null_static_pre_scanner_when_disabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'audit' => ['static_prescan' => ['enabled' => false]]]);
@@ -856,7 +856,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_the_sarif_importer_around_the_pre_scanner_when_import_sarif_is_configured(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'scan' => ['import_sarif' => ['psalm.sarif']]]);
@@ -865,7 +865,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_the_sarif_importer_even_when_the_regex_pre_scan_is_disabled(): void
     {
         $kernel = $this->boot([
@@ -878,7 +878,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_regex_code_slicer_when_enabled(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o', 'audit' => ['code_slicing' => ['enabled' => true]]]);
@@ -887,7 +887,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_null_code_slicer_by_default(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -896,7 +896,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_composer_audit_advisory_database_as_default_implementation(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -905,7 +905,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_llm_client_alias_to_attacker_client(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -914,7 +914,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_null_rate_limiter_when_no_rate_limit_dimension_configured(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -923,7 +923,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_token_bucket_rate_limiter_when_any_dimension_configured(): void
     {
         $kernel = $this->boot([
@@ -939,7 +939,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_attacker_agent(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -948,7 +948,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_reviewer_agent(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -957,7 +957,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_wires_run_audit_use_case(): void
     {
         $kernel = $this->boot(['model' => 'gpt-4o']);
@@ -1053,7 +1053,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
      */
     #[DataProvider('rateLimitDimensionMinimumCases')]
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_accepts_each_rate_limit_dimension_at_its_minimum(array $config): void
     {
         $kernel = $this->boot($config);
@@ -1230,7 +1230,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_registers_a_tagged_attacker_skill_per_custom_skill_entry(): void
     {
         $kernel = $this->boot([
@@ -1244,7 +1244,7 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_bundle_defaults_an_omitted_custom_skill_priority_to_500(): void
     {
         $kernel = $this->boot([

--- a/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
@@ -151,7 +151,7 @@ final class StandaloneApplicationFactoryTest extends TestCase
     }
 
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_the_registered_audit_command_keeps_the_full_cli_option_surface(): void
     {
         $application = StandaloneApplicationFactory::fromEnvironment([

--- a/tests/Phpunit/Integration/Standalone/StandaloneConsoleCommandFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneConsoleCommandFactoryTest.php
@@ -53,7 +53,7 @@ final class StandaloneConsoleCommandFactoryTest extends TestCase
      * @throws UnresolvableAuditCommandException
      */
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_it_wraps_the_invokable_audit_command_under_its_name_and_alias(): void
     {
         $containerBuilder = (new StandaloneContainerFactory())->create(

--- a/tests/Phpunit/Integration/Standalone/StandaloneContainerFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneContainerFactoryTest.php
@@ -50,7 +50,7 @@ final class StandaloneContainerFactoryTest extends TestCase
      * @throws UnknownPlatformProviderException
      */
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_it_builds_a_container_exposing_a_fully_wired_audit_command(): void
     {
         $containerBuilder = (new StandaloneContainerFactory())->create(
@@ -67,7 +67,7 @@ final class StandaloneContainerFactoryTest extends TestCase
      * @throws UnknownPlatformProviderException
      */
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_it_configures_a_non_debug_kernel_with_a_public_event_dispatcher(): void
     {
         $containerBuilder = (new StandaloneContainerFactory())->create(
@@ -86,7 +86,7 @@ final class StandaloneContainerFactoryTest extends TestCase
      * @throws UnknownPlatformProviderException
      */
     #[RunInSeparateProcess]
-    #[MaximumDuration(2500)]
+    #[MaximumDuration(4000)]
     public function test_it_aliases_the_selected_provider_when_several_are_configured(): void
     {
         $containerBuilder = (new StandaloneContainerFactory())->create(


### PR DESCRIPTION
## Summary

Fixes an intermittent CI flake in the `ergebnis` slow-test guard that has failed
several unrelated PRs.

The `RunInSeparateProcess` bundle-boot, standalone-factory, and end-to-end tests
each fork a PHP process and boot the full container/kernel. That legitimately
takes ~2.5–2.8s and varies with CI load, but the per-test `MaximumDuration(2500)`
bound sat right at/below that real cost — so the guard randomly tripped (observed
on `test_bundle_boots_with_minimal_config…` and
`test_configured_scan_included_paths…`, both ~2.7–2.8s vs the 2.5s limit) even on
changes that never touched PHP.

This raises every such bound to `4000` ms across the affected fork/boot tests
(`SymfonySecurityAuditorBundleTest`, `StandaloneApplicationFactoryTest`,
`StandaloneContainerFactoryTest`, `StandaloneConsoleCommandFactoryTest`,
`StandaloneAuditEndToEndTest`). That leaves ~1.2–1.5s of headroom over the real
cost for CI variance while still catching a genuine regression (a boot ballooning
past 4s).

## Type of change

- [x] Tests only

## Checklist

- [x] Tests added or updated (timing bounds relaxed on the fork/boot tests)
- [x] Test-timing only — no library behaviour change, so no CHANGELOG entry (per the changelog rule's docs/CI/tooling exemption)
- [x] No `createMock` without a matching `expects()` — n/a
- [x] Commit messages follow Conventional Commits