### PR TITLE
feat(command): add a doctor preflight command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   standalone installer's `SSA_INIT` flow and the GitHub Action use to set up
   non-interactively. Documented in
   [`docs/configuration.md`](docs/configuration.md#standalone-configuration).
+- **New `doctor` command preflights the standalone environment before an
+  audit.** `symfony-security-auditor doctor` runs three checks and prints one
+  line each: **Configuration** (`config.yaml` resolves, a `platform:` block is
+  present, and any `%env(...)%` API-key variable it references is set),
+  **Provider bridge** (the `symfony/ai-*` bridge autoloader is installed under
+  the data directory), and **Composer** (a runnable `composer` is reachable). A
+  missing `composer` is a warning — auditing still works — while a
+  missing/invalid configuration or an uninstalled bridge is a failure. The
+  command exits `0` when every check passes or only warns and `1` when any check
+  fails, so it drops into a CI preflight step
+  (`symfony-security-auditor doctor && symfony-security-auditor audit`). The
+  command exists only in the standalone binary. Implemented by `DoctorCommand`
+  delegating to `EnvironmentDoctor` (`src/Command/`), wired into the standalone
+  application by `StandaloneApplicationFactory`.
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ bundle registration, bundle-level configuration, platform wiring via
   - [`audit:baseline`](#auditbaseline--maintaining-the-accepted-finding-baseline)
   - [`mcp:serve`](#mcpserve--model-context-protocol-server)
   - [`self-update`](#self-update--updating-the-standalone-binary)
+  - [`doctor`](#doctor--preflight-environment-check)
 
 > See also: [Architecture](architecture.md) · [Extending](extending.md) ·
 > [CI](ci.md) · [FAQ](faq.md) · [Troubleshooting](troubleshooting.md)
@@ -755,3 +756,31 @@ so it must be on the host (as it already is for the install script).
 If the binary is not writable (e.g. installed in `/usr/local/bin` without write
 access), the command refuses to update and tells you to re-run with the
 necessary permissions (`sudo`) or reinstall with the install script.
+
+### `doctor` — preflight environment check
+
+Verifies that the [standalone binary](#standalone-configuration) is ready to run
+an audit before you start one. Like `self-update` and `init`, this command
+exists **only in the standalone binary** — the Composer bundle relies on your
+application's own container and Composer autoloader.
+
+```bash
+symfony-security-auditor doctor
+```
+
+It runs three checks and prints one line for each:
+
+| Check           | What it verifies                                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Configuration   | `config.yaml` resolves, a `platform:` block is present, and any `%env(...)%` API-key variable it references is set |
+| Provider bridge | the `symfony/ai-*` bridge autoloader is installed under the data directory (`init` downloads it)                   |
+| Composer        | a runnable `composer` is reachable — needed only to run `init` or switch providers, not to audit                   |
+
+A missing `composer` is reported as a **warning** (auditing still works); a
+missing/invalid configuration or an uninstalled bridge is a **failure**. The
+command exits `0` when every check passes or only warns, and `1` when any check
+fails, so it drops into a CI preflight step:
+
+```bash
+symfony-security-auditor doctor && symfony-security-auditor audit path/to/app
+```

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -130,6 +130,9 @@ following surface is BC-protected:
   listed above.
 - The `self-update` command name and its `--check` option (see
   [CLI Reference → `self-update`](configuration.md#self-update--updating-the-standalone-binary)).
+- The `doctor` command name and its exit-code contract (`0` when every check
+  passes or only warns, `1` when any check fails — see
+  [CLI Reference → `doctor`](configuration.md#doctor--preflight-environment-check)).
 - The configuration path contract. On Linux/macOS the XDG Base Directory spec:
   the config file `$XDG_CONFIG_HOME/symfony-security-auditor/config.yaml`
   (falling back to `~/.config/…`), the cache directory

--- a/src/Command/ComposerAvailabilityCheckerInterface.php
+++ b/src/Command/ComposerAvailabilityCheckerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface ComposerAvailabilityCheckerInterface
+{
+    public function isAvailable(): bool;
+}

--- a/src/Command/DoctorCheckResult.php
+++ b/src/Command/DoctorCheckResult.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class DoctorCheckResult
+{
+    public function __construct(
+        public string $label,
+        public DoctorCheckStatus $status,
+        public string $detail,
+    ) {}
+}

--- a/src/Command/DoctorCheckStatus.php
+++ b/src/Command/DoctorCheckStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+/** @internal not part of the BC promise — the command *name* (`doctor`) is public, but this enum is for internal use only. */
+enum DoctorCheckStatus
+{
+    case Ok;
+
+    case Warning;
+
+    case Failure;
+}

--- a/src/Command/DoctorCommand.php
+++ b/src/Command/DoctorCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/** @internal not part of the BC promise — the command *name* (`doctor`) is public, but the PHP class itself is for internal use only. */
+#[AsCommand(name: self::NAME, description: self::DESCRIPTION)]
+final readonly class DoctorCommand
+{
+    public const string NAME = 'doctor';
+
+    public const string DESCRIPTION = 'Check that the environment is ready to run an audit';
+
+    public function __construct(
+        private EnvironmentDoctorInterface $environmentDoctor,
+    ) {}
+
+    public function __invoke(SymfonyStyle $symfonyStyle): int
+    {
+        $results = $this->environmentDoctor->diagnose();
+
+        foreach ($results as $result) {
+            $this->render($symfonyStyle, $result);
+        }
+
+        return $this->containsFailure($results) ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function render(SymfonyStyle $symfonyStyle, DoctorCheckResult $doctorCheckResult): void
+    {
+        $line = \sprintf('%s: %s', $doctorCheckResult->label, $doctorCheckResult->detail);
+
+        match ($doctorCheckResult->status) {
+            DoctorCheckStatus::Ok => $symfonyStyle->writeln(\sprintf('<info>[OK]</info> %s', $line)),
+            DoctorCheckStatus::Warning => $symfonyStyle->warning($line),
+            DoctorCheckStatus::Failure => $symfonyStyle->error($line),
+        };
+    }
+
+    /**
+     * @param list<DoctorCheckResult> $results
+     */
+    private function containsFailure(array $results): bool
+    {
+        return [] !== array_filter(
+            $results,
+            static fn (DoctorCheckResult $doctorCheckResult): bool => DoctorCheckStatus::Failure === $doctorCheckResult->status,
+        );
+    }
+}

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MalformedProjectConfigException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingPlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+
+/**
+ * Preflight for the standalone binary: confirms the configuration resolves
+ * (file present, valid, provider selected, API-key variable set), the provider
+ * bridge is installed, and `composer` is reachable — the prerequisites for a
+ * successful audit run.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
+{
+    private const string BRIDGE_AUTOLOAD_RELATIVE_PATH = 'vendor/autoload.php';
+
+    public function __construct(
+        private StandaloneConfigLoader $standaloneConfigLoader,
+        private XdgConfigPathResolver $xdgConfigPathResolver,
+        private ComposerAvailabilityCheckerInterface $composerAvailabilityChecker,
+    ) {}
+
+    /**
+     * @return list<DoctorCheckResult>
+     */
+    #[Override]
+    public function diagnose(): array
+    {
+        return [
+            $this->configurationCheck(),
+            $this->bridgeCheck(),
+            $this->composerCheck(),
+        ];
+    }
+
+    private function configurationCheck(): DoctorCheckResult
+    {
+        try {
+            $this->standaloneConfigLoader->load();
+        } catch (MissingPlatformException) {
+            return new DoctorCheckResult('Configuration', DoctorCheckStatus::Failure, 'No provider is configured — run "init".');
+        } catch (MissingEnvironmentVariableException $missingEnvironmentVariableException) {
+            return new DoctorCheckResult('API key', DoctorCheckStatus::Failure, $missingEnvironmentVariableException->getMessage());
+        } catch (MalformedProjectConfigException $malformedProjectConfigException) {
+            return new DoctorCheckResult('Configuration', DoctorCheckStatus::Failure, $malformedProjectConfigException->getMessage());
+        } catch (UnresolvableConfigPathException $unresolvableConfigPathException) {
+            return new DoctorCheckResult('Configuration', DoctorCheckStatus::Failure, $unresolvableConfigPathException->getMessage());
+        }
+
+        return new DoctorCheckResult('Configuration', DoctorCheckStatus::Ok, 'Config resolves and the API-key variable is set.');
+    }
+
+    private function bridgeCheck(): DoctorCheckResult
+    {
+        try {
+            $bridgeAutoloadFile = \sprintf('%s/%s', $this->xdgConfigPathResolver->dataDir(), self::BRIDGE_AUTOLOAD_RELATIVE_PATH);
+        } catch (UnresolvableConfigPathException $unresolvableConfigPathException) {
+            return new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, $unresolvableConfigPathException->getMessage());
+        }
+
+        return is_file($bridgeAutoloadFile)
+            ? new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed.')
+            : new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, 'Not installed — run "init" to download it.');
+    }
+
+    private function composerCheck(): DoctorCheckResult
+    {
+        return $this->composerAvailabilityChecker->isAvailable()
+            ? new DoctorCheckResult('Composer', DoctorCheckStatus::Ok, 'Available.')
+            : new DoctorCheckResult('Composer', DoctorCheckStatus::Warning, 'Not found — needed only to run "init" or switch providers, not to audit.');
+    }
+}

--- a/src/Command/EnvironmentDoctorInterface.php
+++ b/src/Command/EnvironmentDoctorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface EnvironmentDoctorInterface
+{
+    /**
+     * @return list<DoctorCheckResult>
+     */
+    public function diagnose(): array;
+}

--- a/src/Command/ProcessComposerAvailabilityChecker.php
+++ b/src/Command/ProcessComposerAvailabilityChecker.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+use Closure;
+use Override;
+use Symfony\Component\Process\Exception\ExceptionInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Probes for a runnable `composer` by executing `composer --version` through
+ * Symfony `Process` — the same subprocess-only convention the rest of the tool
+ * uses (no raw shell, no argument-interpolation surface).
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class ProcessComposerAvailabilityChecker implements ComposerAvailabilityCheckerInterface
+{
+    private const float PROCESS_TIMEOUT_SECONDS = 30.0;
+
+    /**
+     * @param Closure(): Process $processBuilder the composer probe builder (use self::defaultProcessBuilder() in production); tests inject a stub
+     */
+    public function __construct(
+        private Closure $processBuilder,
+    ) {}
+
+    /**
+     * @return Closure(): Process
+     */
+    public static function defaultProcessBuilder(): Closure
+    {
+        return static function (): Process {
+            $process = new Process(['composer', '--version']);
+            $process->setTimeout(self::PROCESS_TIMEOUT_SECONDS);
+
+            return $process;
+        };
+    }
+
+    #[Override]
+    public function isAvailable(): bool
+    {
+        $process = ($this->processBuilder)();
+
+        try {
+            $process->run();
+        } catch (ExceptionInterface) {
+            return false;
+        }
+
+        return $process->isSuccessful();
+    }
+}

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -34,7 +34,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Process
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\RunningBinaryLocator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdater;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\EnvironmentDoctor;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\InitCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ProcessComposerAvailabilityChecker;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\SelfUpdateCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Standalone\Exception\AmbiguousPlatformException;
 use VinceAmstoutz\SymfonySecurityAuditor\Standalone\Exception\MissingBundleExtensionException;
@@ -109,6 +112,7 @@ final readonly class StandaloneApplicationFactory
         $application = new Application(self::APPLICATION_NAME, (new ReportPackage())->version());
         $application->addCommand($this->initCommand());
         $application->addCommand($this->selfUpdateCommand());
+        $application->addCommand($this->doctorCommand());
         $application->addCommand($this->lazyAuditCommand());
 
         return $application;
@@ -148,6 +152,17 @@ final readonly class StandaloneApplicationFactory
                 new RunningBinaryLocator('/proc/self/exe', $this->runningBinaryPath, pathEnvironment: $this->pathEnvironment),
             ),
             (new ReportPackage())->version(),
+        );
+    }
+
+    private function doctorCommand(): DoctorCommand
+    {
+        return new DoctorCommand(
+            new EnvironmentDoctor(
+                $this->standaloneConfigLoader,
+                $this->xdgConfigPathResolver,
+                new ProcessComposerAvailabilityChecker(ProcessComposerAvailabilityChecker::defaultProcessBuilder()),
+            ),
         );
     }
 

--- a/tests/Phpunit/EndToEnd/StandaloneDoctorEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/StandaloneDoctorEndToEndTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\EndToEnd;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Standalone\StandaloneApplicationFactory;
+
+final class StandaloneDoctorEndToEndTest extends TestCase
+{
+    private Filesystem $filesystem;
+
+    private string $configHome;
+
+    private string $cacheHome;
+
+    private string $dataHome;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $suffix = bin2hex(random_bytes(6));
+        $this->configHome = sys_get_temp_dir().'/ssa-doctor-e2e-config-'.$suffix;
+        $this->cacheHome = sys_get_temp_dir().'/ssa-doctor-e2e-cache-'.$suffix;
+        $this->dataHome = sys_get_temp_dir().'/ssa-doctor-e2e-data-'.$suffix;
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove([$this->configHome, $this->cacheHome, $this->dataHome]);
+    }
+
+    public function test_the_standalone_doctor_reports_a_ready_environment_end_to_end(): void
+    {
+        $this->filesystem->dumpFile(
+            $this->configHome.'/symfony-security-auditor/config.yaml',
+            "platform:\n    openai:\n        api_key: 'sk-e2e'\nmodel: 'gpt-4'\n",
+        );
+        $this->filesystem->dumpFile($this->dataHome.'/symfony-security-auditor/vendor/autoload.php', "<?php\n");
+
+        $commandTester = $this->doctorCommandTester();
+
+        $exitCode = $commandTester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $commandTester->getDisplay();
+        self::assertStringContainsString('[OK] Configuration:', $display);
+        self::assertStringContainsString('[OK] Provider bridge:', $display);
+    }
+
+    public function test_the_standalone_doctor_fails_end_to_end_when_the_environment_is_not_configured(): void
+    {
+        $commandTester = $this->doctorCommandTester();
+
+        $exitCode = $commandTester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        $display = $commandTester->getDisplay();
+        self::assertStringContainsString('No provider is configured', $display);
+        self::assertStringContainsString('Not installed', $display);
+    }
+
+    private function doctorCommandTester(): CommandTester
+    {
+        $application = StandaloneApplicationFactory::fromEnvironment([
+            'XDG_CONFIG_HOME' => $this->configHome,
+            'XDG_CACHE_HOME' => $this->cacheHome,
+            'XDG_DATA_HOME' => $this->dataHome,
+        ])->create();
+
+        return new CommandTester($application->find(DoctorCommand::NAME));
+    }
+}

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfigResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ComposerAvailabilityCheckerInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCheckResult;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCheckStatus;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\EnvironmentDoctor;
+
+final class EnvironmentDoctorTest extends TestCase
+{
+    private string $configHome;
+
+    private string $cacheHome;
+
+    private string $dataHome;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(6));
+        $this->configHome = sys_get_temp_dir().'/ssa-doctor-config-'.$suffix;
+        $this->cacheHome = sys_get_temp_dir().'/ssa-doctor-cache-'.$suffix;
+        $this->dataHome = sys_get_temp_dir().'/ssa-doctor-data-'.$suffix;
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove([$this->configHome, $this->cacheHome, $this->dataHome]);
+    }
+
+    public function test_it_reports_every_check_green_when_the_environment_is_ready(): void
+    {
+        $this->writeConfig("platform:\n    openai:\n        api_key: 'sk-test'\nmodel: 'gpt-4'\n");
+        $this->installBridge();
+
+        $results = $this->doctorWith($this->resolver(), [], true)->diagnose();
+
+        self::assertEquals([
+            new DoctorCheckResult('Configuration', DoctorCheckStatus::Ok, 'Config resolves and the API-key variable is set.'),
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed.'),
+            new DoctorCheckResult('Composer', DoctorCheckStatus::Ok, 'Available.'),
+        ], $results);
+    }
+
+    public function test_it_fails_the_configuration_check_when_no_provider_is_configured(): void
+    {
+        $this->writeConfig("model: 'gpt-4'\n");
+
+        $results = $this->doctorWith($this->resolver(), [], true)->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('Configuration', DoctorCheckStatus::Failure, 'No provider is configured — run "init".'),
+            $results[0],
+        );
+    }
+
+    public function test_it_fails_the_api_key_check_when_the_referenced_variable_is_unset(): void
+    {
+        $this->writeConfig("platform:\n    openai:\n        api_key: '%env(OPENAI_API_KEY)%'\n");
+
+        $results = $this->doctorWith($this->resolver(), [], true)->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('API key', DoctorCheckStatus::Failure, MissingEnvironmentVariableException::forName('OPENAI_API_KEY')->getMessage()),
+            $results[0],
+        );
+    }
+
+    public function test_it_fails_the_configuration_check_when_the_config_file_is_malformed(): void
+    {
+        $this->writeConfig("platform: [a, b\n");
+
+        $results = $this->doctorWith($this->resolver(), [], true)->diagnose();
+
+        self::assertSame('Configuration', $results[0]->label);
+        self::assertSame(DoctorCheckStatus::Failure, $results[0]->status);
+        self::assertStringContainsString('is not valid YAML', $results[0]->detail);
+    }
+
+    public function test_it_fails_the_configuration_and_bridge_checks_when_the_home_directory_is_unresolvable(): void
+    {
+        $xdgConfigPathResolver = new XdgConfigPathResolver(null, null, null);
+
+        $results = $this->doctorWith($xdgConfigPathResolver, [], true)->diagnose();
+
+        $expectedMessage = UnresolvableConfigPathException::missingHome()->getMessage();
+        self::assertEquals(new DoctorCheckResult('Configuration', DoctorCheckStatus::Failure, $expectedMessage), $results[0]);
+        self::assertEquals(new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, $expectedMessage), $results[1]);
+    }
+
+    public function test_it_fails_the_bridge_check_when_the_provider_bridge_is_not_installed(): void
+    {
+        $this->writeConfig("platform:\n    openai:\n        api_key: 'sk-test'\n");
+
+        $results = $this->doctorWith($this->resolver(), [], true)->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, 'Not installed — run "init" to download it.'),
+            $results[1],
+        );
+    }
+
+    public function test_it_warns_when_composer_is_not_available(): void
+    {
+        $this->writeConfig("platform:\n    openai:\n        api_key: 'sk-test'\n");
+        $this->installBridge();
+
+        $results = $this->doctorWith($this->resolver(), [], false)->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('Composer', DoctorCheckStatus::Warning, 'Not found — needed only to run "init" or switch providers, not to audit.'),
+            $results[2],
+        );
+    }
+
+    /**
+     * @param array<string, string> $environment
+     */
+    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable): EnvironmentDoctor
+    {
+        $composerAvailabilityChecker = self::createStub(ComposerAvailabilityCheckerInterface::class);
+        $composerAvailabilityChecker->method('isAvailable')->willReturn($composerAvailable);
+
+        return new EnvironmentDoctor(
+            new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver($environment)),
+            $xdgConfigPathResolver,
+            $composerAvailabilityChecker,
+        );
+    }
+
+    private function resolver(): XdgConfigPathResolver
+    {
+        return new XdgConfigPathResolver($this->configHome, $this->cacheHome, null, $this->dataHome);
+    }
+
+    private function writeConfig(string $yaml): void
+    {
+        (new Filesystem())->dumpFile($this->configHome.'/symfony-security-auditor/config.yaml', $yaml);
+    }
+
+    private function installBridge(): void
+    {
+        (new Filesystem())->dumpFile($this->dataHome.'/symfony-security-auditor/vendor/autoload.php', "<?php\n");
+    }
+}

--- a/tests/Phpunit/Integration/Command/ProcessComposerAvailabilityCheckerTest.php
+++ b/tests/Phpunit/Integration/Command/ProcessComposerAvailabilityCheckerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\ProcessComposerAvailabilityChecker;
+
+final class ProcessComposerAvailabilityCheckerTest extends TestCase
+{
+    public function test_it_reports_composer_available_when_the_probe_succeeds(): void
+    {
+        $processComposerAvailabilityChecker = new ProcessComposerAvailabilityChecker(static fn (): Process => new Process(['true']));
+
+        self::assertTrue($processComposerAvailabilityChecker->isAvailable());
+    }
+
+    public function test_it_reports_composer_unavailable_when_the_probe_exits_non_zero(): void
+    {
+        $processComposerAvailabilityChecker = new ProcessComposerAvailabilityChecker(static fn (): Process => new Process(['false']));
+
+        self::assertFalse($processComposerAvailabilityChecker->isAvailable());
+    }
+
+    public function test_it_reports_composer_unavailable_when_the_probe_cannot_be_started(): void
+    {
+        $unlaunchableWorkingDirectory = sys_get_temp_dir().'/ssa-composer-missing-'.bin2hex(random_bytes(4));
+        $processComposerAvailabilityChecker = new ProcessComposerAvailabilityChecker(static fn (): Process => new Process(['true'], $unlaunchableWorkingDirectory));
+
+        self::assertFalse($processComposerAvailabilityChecker->isAvailable());
+    }
+
+    public function test_default_process_builder_probes_the_composer_version_with_a_timeout(): void
+    {
+        $process = (ProcessComposerAvailabilityChecker::defaultProcessBuilder())();
+
+        $commandLine = $process->getCommandLine();
+        self::assertStringContainsString("'composer'", $commandLine);
+        self::assertStringContainsString("'--version'", $commandLine);
+        self::assertSame(30.0, $process->getTimeout());
+    }
+}

--- a/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
@@ -99,6 +99,16 @@ final class StandaloneApplicationFactoryTest extends TestCase
         self::assertTrue($application->has('self-update'));
     }
 
+    public function test_it_registers_the_doctor_command(): void
+    {
+        $application = StandaloneApplicationFactory::fromEnvironment([
+            'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
+            'XDG_CACHE_HOME' => $this->cacheHome,
+        ])->create();
+
+        self::assertTrue($application->has('doctor'));
+    }
+
     public function test_it_registers_the_audit_command_as_visible(): void
     {
         $application = StandaloneApplicationFactory::fromEnvironment([

--- a/tests/Phpunit/Unit/Command/DoctorCommandTest.php
+++ b/tests/Phpunit/Unit/Command/DoctorCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCheckResult;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCheckStatus;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\EnvironmentDoctorInterface;
+
+final class DoctorCommandTest extends TestCase
+{
+    public function test_it_reports_success_when_no_check_fails(): void
+    {
+        $commandTester = $this->commandTester(
+            new DoctorCheckResult('Configuration', DoctorCheckStatus::Ok, 'Config resolves.'),
+            new DoctorCheckResult('Composer', DoctorCheckStatus::Warning, 'Not found.'),
+        );
+
+        self::assertSame(Command::SUCCESS, $commandTester->execute([]));
+    }
+
+    public function test_it_reports_failure_when_any_check_fails(): void
+    {
+        $commandTester = $this->commandTester(
+            new DoctorCheckResult('Configuration', DoctorCheckStatus::Ok, 'Config resolves.'),
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, 'Not installed.'),
+        );
+
+        self::assertSame(Command::FAILURE, $commandTester->execute([]));
+    }
+
+    public function test_it_renders_a_passing_check_with_an_ok_marker(): void
+    {
+        $commandTester = $this->commandTester(
+            new DoctorCheckResult('Composer', DoctorCheckStatus::Ok, 'Available.'),
+        );
+
+        $commandTester->execute([]);
+
+        self::assertStringContainsString('[OK] Composer: Available.', $commandTester->getDisplay());
+    }
+
+    public function test_it_renders_a_warning_check_as_a_warning_block(): void
+    {
+        $commandTester = $this->commandTester(
+            new DoctorCheckResult('Composer', DoctorCheckStatus::Warning, 'Not found.'),
+        );
+
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+        self::assertStringContainsString('[WARNING]', $display);
+        self::assertStringContainsString('Composer: Not found.', $display);
+    }
+
+    public function test_it_renders_a_failing_check_as_an_error_block(): void
+    {
+        $commandTester = $this->commandTester(
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, 'Not installed.'),
+        );
+
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+        self::assertStringContainsString('[ERROR]', $display);
+        self::assertStringContainsString('Provider bridge: Not installed.', $display);
+    }
+
+    private function commandTester(DoctorCheckResult ...$results): CommandTester
+    {
+        $environmentDoctor = self::createStub(EnvironmentDoctorInterface::class);
+        $environmentDoctor->method('diagnose')->willReturn($results);
+
+        return new CommandTester(new DoctorCommand($environmentDoctor));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `doctor` preflight command to the standalone binary so a
misconfigured environment surfaces up front instead of as a mid-run failure.
`symfony-security-auditor doctor` runs three checks and prints one line each,
then exits `0` when everything passes or only warns and `1` when any check
fails — so it slots into a CI preflight step
(`symfony-security-auditor doctor && symfony-security-auditor audit`).

| Check           | Verdict driver                                                                                                    |
| --------------- | ----------------------------------------------------------------------------------------------------------------- |
| Configuration   | `config.yaml` resolves, a `platform:` block is present, and any `%env(...)%` API-key variable it references is set |
| Provider bridge | the `symfony/ai-*` bridge autoloader is installed under the data directory (`init` downloads it)                   |
| Composer        | a runnable `composer` is reachable — a **warning** when absent, since it's needed only for `init`, not to audit    |

The command exists only in the standalone binary (the Composer bundle relies on
the application's own container/autoloader). `DoctorCommand` is a thin
orchestrator delegating to `EnvironmentDoctor`; composer detection routes
through Symfony `Process` (no raw shell), matching the project's
subprocess-only convention.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated across all three suites — `DoctorCommandTest` (Unit), `EnvironmentDoctorTest` + `ProcessComposerAvailabilityCheckerTest` (Integration), `StandaloneDoctorEndToEndTest` (EndToEnd, drives the real factory + `composer --version` subprocess), plus a registration test on `StandaloneApplicationFactoryTest`
- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `php -l` and prettier/markdownlint (composer deps aren't installable in the authoring environment)
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — every branch (each config-failure catch, both bridge outcomes, composer warn/ok, exit-code paths) is pinned by an assertion
- [x] No `createMock` without a matching `expects()` — uses `createStub` for the query-only `EnvironmentDoctorInterface` / `ComposerAvailabilityCheckerInterface`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)