### PR TITLE
feat(standalone): notify when a newer release is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
+- **The standalone binary now tells you when a newer release is available.**
+  After a command finishes on an interactive terminal, the binary prints a
+  one-line notice to stderr pointing at `self-update` when the installed version
+  is behind the latest GitHub release. The GitHub lookup is throttled to once
+  per 24 hours (cached under the XDG cache directory) and is fully best-effort:
+  it runs only on an interactive run (so piped/CI output and `--format=json`
+  stay clean), and any failure (offline, rate-limited) is swallowed and never
+  changes a command's exit code. Set `SSA_NO_UPDATE_CHECK=1` to disable it. The
+  notice exists only in the standalone binary (the Composer bundle updates
+  through `composer update`). Implemented by
+  `ThrottledUpdateAvailabilityNotifier` + `FilesystemUpdateCheckStore`
+  (`src/Audit/Infrastructure/SelfUpdate/`) and wired into the standalone
+  application through a console `TERMINATE` listener
+  (`UpdateAvailabilityConsoleListener`).
 - **One command installs _and_ configures the standalone binary via
   `SSA_INIT`.** `install.sh` now honors an `SSA_INIT` environment variable: with
   `SSA_INIT=1`, after the binary is downloaded and its SHA-256 checksum

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ bundle registration, bundle-level configuration, platform wiring via
   - [`mcp:serve`](#mcpserve--model-context-protocol-server)
   - [`self-update`](#self-update--updating-the-standalone-binary)
   - [`doctor`](#doctor--preflight-environment-check)
+  - [Update notifications](#update-notifications)
 
 > See also: [Architecture](architecture.md) · [Extending](extending.md) ·
 > [CI](ci.md) · [FAQ](faq.md) · [Troubleshooting](troubleshooting.md)
@@ -784,3 +785,25 @@ fails, so it drops into a CI preflight step:
 ```bash
 symfony-security-auditor doctor && symfony-security-auditor audit path/to/app
 ```
+
+### Update notifications
+
+When you run the [standalone binary](#standalone-configuration) interactively,
+it prints a one-line notice to **stderr** once a command finishes if a newer
+release is available:
+
+```text
+A new version (1.17.0) is available. Run "symfony-security-auditor self-update" to upgrade.
+```
+
+The check is designed to stay out of the way:
+
+- It runs **only on an interactive terminal**, so piped or CI runs — and
+  machine-readable stdout such as `--format=json` — are never touched.
+- The GitHub release lookup is **throttled to once per 24 hours** (the answer is
+  cached under the XDG cache directory), and any failure (offline, rate-limited)
+  is silent — it never changes a command's exit code.
+- It exists **only in the standalone binary**; the Composer bundle updates
+  through `composer update`.
+
+Set `SSA_NO_UPDATE_CHECK=1` to turn the check off entirely.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -133,6 +133,9 @@ following surface is BC-protected:
 - The `doctor` command name and its exit-code contract (`0` when every check
   passes or only warns, `1` when any check fails — see
   [CLI Reference → `doctor`](configuration.md#doctor--preflight-environment-check)).
+- The `SSA_NO_UPDATE_CHECK` environment variable, which disables the interactive
+  "update available" notice (see
+  [CLI Reference → Update notifications](configuration.md#update-notifications)).
 - The configuration path contract. On Linux/macOS the XDG Base Directory spec:
   the config file `$XDG_CONFIG_HOME/symfony-security-auditor/config.yaml`
   (falling back to `~/.config/…`), the cache directory

--- a/src/Audit/Infrastructure/SelfUpdate/FilesystemUpdateCheckStore.php
+++ b/src/Audit/Infrastructure/SelfUpdate/FilesystemUpdateCheckStore.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use DateTimeImmutable;
+use JsonException;
+use Override;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+
+/**
+ * Persists the last update check under the XDG cache directory as a small JSON
+ * document. Every I/O or decoding failure degrades to a cache miss (`read()`
+ * returns `null`) or a no-op (`write()`), logged but never thrown, so the update
+ * notice is only ever a best-effort convenience and can never abort a command.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class FilesystemUpdateCheckStore implements UpdateCheckStoreInterface
+{
+    private const string CACHE_FILENAME = 'update-check.json';
+
+    private const string CHECKED_AT_KEY = 'checked_at';
+
+    private const string LATEST_VERSION_KEY = 'latest_version';
+
+    public function __construct(
+        private XdgConfigPathResolver $xdgConfigPathResolver,
+        private Filesystem $filesystem,
+        private LoggerInterface $logger,
+    ) {}
+
+    #[Override]
+    public function read(): ?UpdateCheckState
+    {
+        $path = $this->cacheFilePath();
+        if (null === $path || !$this->filesystem->exists($path)) {
+            return null;
+        }
+
+        try {
+            $raw = $this->filesystem->readFile($path);
+        } catch (IOException $ioException) {
+            $this->logger->warning('Update-check cache is unreadable', ['error' => $ioException->getMessage()]);
+
+            return null;
+        }
+
+        return $this->parse($raw);
+    }
+
+    #[Override]
+    public function write(UpdateCheckState $updateCheckState): void
+    {
+        $path = $this->cacheFilePath();
+        if (null === $path) {
+            return;
+        }
+
+        $payload = json_encode([
+            self::CHECKED_AT_KEY => $updateCheckState->checkedAt->getTimestamp(),
+            self::LATEST_VERSION_KEY => $updateCheckState->latestVersion,
+        ]);
+        \assert(false !== $payload, 'A timestamp-and-version array is always JSON-encodable');
+
+        try {
+            $this->filesystem->dumpFile($path, $payload);
+        } catch (IOException $ioException) {
+            $this->logger->warning('Failed to write the update-check cache', ['error' => $ioException->getMessage()]);
+        }
+    }
+
+    private function parse(string $raw): ?UpdateCheckState
+    {
+        try {
+            $decoded = json_decode($raw, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (!\is_array($decoded)) {
+            return null;
+        }
+
+        $checkedAt = $decoded[self::CHECKED_AT_KEY] ?? null;
+        $latestVersion = $decoded[self::LATEST_VERSION_KEY] ?? null;
+
+        if (!\is_int($checkedAt) || !\is_string($latestVersion) || '' === $latestVersion) {
+            return null;
+        }
+
+        return new UpdateCheckState(new DateTimeImmutable(\sprintf('@%d', $checkedAt)), $latestVersion);
+    }
+
+    private function cacheFilePath(): ?string
+    {
+        try {
+            return \sprintf('%s/%s', $this->xdgConfigPathResolver->cacheDir(), self::CACHE_FILENAME);
+        } catch (UnresolvableConfigPathException) {
+            return null;
+        }
+    }
+}

--- a/src/Audit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifier.php
+++ b/src/Audit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifier.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use Override;
+use Psr\Clock\ClockInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\UnsupportedSelfUpdatePlatformException;
+
+/**
+ * Resolves the latest released version through the shared self-update machinery,
+ * throttling the network call to at most once per `throttleSeconds` by caching
+ * the answer. The GitHub call only ever happens when the cache is missing or
+ * stale; a failed call falls back to the last cached answer (or no notice), so
+ * the check is silent when offline and never blocks a run more than once a day.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class ThrottledUpdateAvailabilityNotifier implements UpdateAvailabilityNotifierInterface
+{
+    public const int DEFAULT_THROTTLE_SECONDS = 86_400;
+
+    private const string RELEASE_VERSION_PATTERN = '/^\d+\.\d+\.\d+/';
+
+    private const string NOTICE_TEMPLATE = 'A new version (%s) is available. Run "symfony-security-auditor self-update" to upgrade.';
+
+    public function __construct(
+        private SelfUpdaterInterface $selfUpdater,
+        private UpdateCheckStoreInterface $updateCheckStore,
+        private ClockInterface $clock,
+        private int $throttleSeconds = self::DEFAULT_THROTTLE_SECONDS,
+    ) {}
+
+    #[Override]
+    public function availableUpdateNotice(string $currentVersion): ?string
+    {
+        if (1 !== preg_match(self::RELEASE_VERSION_PATTERN, $currentVersion)) {
+            return null;
+        }
+
+        $latestVersion = $this->latestVersion($currentVersion);
+        if (null === $latestVersion) {
+            return null;
+        }
+
+        if (!version_compare($latestVersion, $currentVersion, '>')) {
+            return null;
+        }
+
+        return \sprintf(self::NOTICE_TEMPLATE, $latestVersion);
+    }
+
+    private function latestVersion(string $currentVersion): ?string
+    {
+        $cachedState = $this->updateCheckStore->read();
+        if ($cachedState instanceof UpdateCheckState && !$this->isStale($cachedState)) {
+            return $cachedState->latestVersion;
+        }
+
+        return $this->refreshedLatestVersion($currentVersion, $cachedState);
+    }
+
+    private function refreshedLatestVersion(string $currentVersion, ?UpdateCheckState $updateCheckState): ?string
+    {
+        try {
+            $latestVersion = $this->selfUpdater->run($currentVersion, true)->latestVersion;
+        } catch (SelfUpdateFailedException|UnsupportedSelfUpdatePlatformException) {
+            return $updateCheckState?->latestVersion;
+        }
+
+        $this->updateCheckStore->write(new UpdateCheckState($this->clock->now(), $latestVersion));
+
+        return $latestVersion;
+    }
+
+    private function isStale(UpdateCheckState $updateCheckState): bool
+    {
+        return $this->clock->now()->getTimestamp() - $updateCheckState->checkedAt->getTimestamp() >= $this->throttleSeconds;
+    }
+}

--- a/src/Audit/Infrastructure/SelfUpdate/UpdateAvailabilityNotifierInterface.php
+++ b/src/Audit/Infrastructure/SelfUpdate/UpdateAvailabilityNotifierInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface UpdateAvailabilityNotifierInterface
+{
+    /**
+     * Returns a one-line notice when a newer release than $currentVersion is
+     * available, or null when the running version is current, cannot be
+     * compared, or the check could not be performed.
+     */
+    public function availableUpdateNotice(string $currentVersion): ?string;
+}

--- a/src/Audit/Infrastructure/SelfUpdate/UpdateCheckState.php
+++ b/src/Audit/Infrastructure/SelfUpdate/UpdateCheckState.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+use DateTimeImmutable;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final readonly class UpdateCheckState
+{
+    public function __construct(
+        public DateTimeImmutable $checkedAt,
+        public string $latestVersion,
+    ) {}
+}

--- a/src/Audit/Infrastructure/SelfUpdate/UpdateCheckStoreInterface.php
+++ b/src/Audit/Infrastructure/SelfUpdate/UpdateCheckStoreInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+interface UpdateCheckStoreInterface
+{
+    public function read(): ?UpdateCheckState;
+
+    public function write(UpdateCheckState $updateCheckState): void;
+}

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -13,10 +13,15 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Standalone;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LazyCommand;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\BridgeInstallerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\ComposerBridgeInstaller;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MalformedProjectConfigException;
@@ -29,10 +34,12 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneP
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\YamlStandaloneConfigWriter;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\FilesystemUpdateCheckStore;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\GitHubBinaryAssetResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\ProcessReleaseClient;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\RunningBinaryLocator;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdater;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\ThrottledUpdateAvailabilityNotifier;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\EnvironmentDoctor;
@@ -53,6 +60,8 @@ final readonly class StandaloneApplicationFactory
 
     private const string PROJECT_CONFIG_FILENAME = '.symfony-security-auditor.yaml';
 
+    private const string UPDATE_CHECK_OPT_OUT_VARIABLE = 'SSA_NO_UPDATE_CHECK';
+
     public function __construct(
         private StandaloneConfigLoader $standaloneConfigLoader,
         private XdgConfigPathResolver $xdgConfigPathResolver,
@@ -61,6 +70,7 @@ final readonly class StandaloneApplicationFactory
         private StandaloneConsoleCommandFactory $standaloneConsoleCommandFactory = new StandaloneConsoleCommandFactory(),
         private string $runningBinaryPath = '',
         private string $pathEnvironment = '',
+        private ?UpdateAvailabilityConsoleListener $updateAvailabilityConsoleListener = null,
     ) {}
 
     /**
@@ -69,6 +79,8 @@ final readonly class StandaloneApplicationFactory
     public static function fromEnvironment(array $environment, ?string $runningBinaryPath = null): self
     {
         $xdgConfigPathResolver = self::resolverFromEnvironment($environment);
+        $resolvedBinaryPath = $runningBinaryPath ?? '';
+        $pathEnvironment = $environment['PATH'] ?? '';
 
         return new self(
             new StandaloneConfigLoader(
@@ -78,9 +90,23 @@ final readonly class StandaloneApplicationFactory
             ),
             $xdgConfigPathResolver,
             new ComposerBridgeInstaller(ComposerBridgeInstaller::defaultProcessBuilder()),
-            runningBinaryPath: $runningBinaryPath ?? '',
-            pathEnvironment: $environment['PATH'] ?? '',
+            runningBinaryPath: $resolvedBinaryPath,
+            pathEnvironment: $pathEnvironment,
+            updateAvailabilityConsoleListener: self::updateAvailabilityConsoleListener(
+                $xdgConfigPathResolver,
+                $resolvedBinaryPath,
+                $pathEnvironment,
+                self::updateChecksDisabled($environment),
+            ),
         );
+    }
+
+    /**
+     * @param array<string, string> $environment
+     */
+    public static function updateChecksDisabled(array $environment): bool
+    {
+        return '' !== ($environment[self::UPDATE_CHECK_OPT_OUT_VARIABLE] ?? '');
     }
 
     /**
@@ -114,6 +140,7 @@ final readonly class StandaloneApplicationFactory
         $application->addCommand($this->selfUpdateCommand());
         $application->addCommand($this->doctorCommand());
         $application->addCommand($this->lazyAuditCommand());
+        $this->registerUpdateAvailabilityNotice($application);
 
         return $application;
     }
@@ -146,13 +173,47 @@ final readonly class StandaloneApplicationFactory
     private function selfUpdateCommand(): SelfUpdateCommand
     {
         return new SelfUpdateCommand(
-            new SelfUpdater(
-                new ProcessReleaseClient(ProcessReleaseClient::defaultProcessBuilder()),
-                new GitHubBinaryAssetResolver(\PHP_OS_FAMILY, php_uname('m')),
-                new RunningBinaryLocator('/proc/self/exe', $this->runningBinaryPath, pathEnvironment: $this->pathEnvironment),
-            ),
+            self::selfUpdater($this->runningBinaryPath, $this->pathEnvironment),
             (new ReportPackage())->version(),
         );
+    }
+
+    private static function selfUpdater(string $runningBinaryPath, string $pathEnvironment): SelfUpdater
+    {
+        return new SelfUpdater(
+            new ProcessReleaseClient(ProcessReleaseClient::defaultProcessBuilder()),
+            new GitHubBinaryAssetResolver(\PHP_OS_FAMILY, php_uname('m')),
+            new RunningBinaryLocator('/proc/self/exe', $runningBinaryPath, pathEnvironment: $pathEnvironment),
+        );
+    }
+
+    private static function updateAvailabilityConsoleListener(
+        XdgConfigPathResolver $xdgConfigPathResolver,
+        string $runningBinaryPath,
+        string $pathEnvironment,
+        bool $disabled,
+    ): UpdateAvailabilityConsoleListener {
+        return new UpdateAvailabilityConsoleListener(
+            new ThrottledUpdateAvailabilityNotifier(
+                self::selfUpdater($runningBinaryPath, $pathEnvironment),
+                new FilesystemUpdateCheckStore($xdgConfigPathResolver, new Filesystem(), new NullLogger()),
+                new NativeClock(),
+            ),
+            (new ReportPackage())->version(),
+            $disabled,
+        );
+    }
+
+    private function registerUpdateAvailabilityNotice(Application $application): void
+    {
+        if (!$this->updateAvailabilityConsoleListener instanceof UpdateAvailabilityConsoleListener) {
+            return;
+        }
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(ConsoleEvents::TERMINATE, $this->updateAvailabilityConsoleListener);
+
+        $application->setDispatcher($eventDispatcher);
     }
 
     private function doctorCommand(): DoctorCommand

--- a/src/Standalone/UpdateAvailabilityConsoleListener.php
+++ b/src/Standalone/UpdateAvailabilityConsoleListener.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Standalone;
+
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateAvailabilityNotifierInterface;
+
+/**
+ * Prints an "update available" notice to stderr once a command finishes, but
+ * only on an interactive run so machine-readable stdout (e.g. `--format=json`)
+ * and CI logs stay clean. The version check itself is delegated and best-effort,
+ * so this never changes the exit code.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class UpdateAvailabilityConsoleListener
+{
+    public function __construct(
+        private UpdateAvailabilityNotifierInterface $updateAvailabilityNotifier,
+        private string $currentVersion,
+        private bool $disabled,
+    ) {}
+
+    public function __invoke(ConsoleTerminateEvent $consoleTerminateEvent): void
+    {
+        if ($this->disabled) {
+            return;
+        }
+
+        if (!$consoleTerminateEvent->getInput()->isInteractive()) {
+            return;
+        }
+
+        $notice = $this->updateAvailabilityNotifier->availableUpdateNotice($this->currentVersion);
+        if (null === $notice) {
+            return;
+        }
+
+        $this->errorOutput($consoleTerminateEvent->getOutput())->writeln(\sprintf('<comment>%s</comment>', $notice));
+    }
+
+    private function errorOutput(OutputInterface $output): OutputInterface
+    {
+        return $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+    }
+}

--- a/tests/Phpunit/EndToEnd/StandaloneUpdateNoticeEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/StandaloneUpdateNoticeEndToEndTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\EndToEnd;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\BridgeInstallerInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfigResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateAvailabilityNotifierInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Standalone\StandaloneApplicationFactory;
+use VinceAmstoutz\SymfonySecurityAuditor\Standalone\UpdateAvailabilityConsoleListener;
+
+final class StandaloneUpdateNoticeEndToEndTest extends TestCase
+{
+    private const string NOTICE = 'A new version (2.0.0) is available.';
+
+    private Filesystem $filesystem;
+
+    private string $configHome;
+
+    private string $cacheHome;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $suffix = bin2hex(random_bytes(6));
+        $this->configHome = sys_get_temp_dir().'/ssa-update-e2e-config-'.$suffix;
+        $this->cacheHome = sys_get_temp_dir().'/ssa-update-e2e-cache-'.$suffix;
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove([$this->configHome, $this->cacheHome]);
+    }
+
+    public function test_it_prints_the_update_notice_to_stderr_after_a_command_on_an_interactive_run(): void
+    {
+        $applicationTester = $this->runListCommand(self::NOTICE, false, true);
+
+        self::assertStringContainsString(self::NOTICE, $applicationTester->getErrorOutput());
+    }
+
+    public function test_it_keeps_stdout_free_of_the_update_notice(): void
+    {
+        $applicationTester = $this->runListCommand(self::NOTICE, false, true);
+
+        self::assertStringNotContainsString(self::NOTICE, $applicationTester->getDisplay());
+    }
+
+    public function test_it_stays_silent_on_a_non_interactive_run(): void
+    {
+        $applicationTester = $this->runListCommand(self::NOTICE, false, false);
+
+        self::assertStringNotContainsString(self::NOTICE, $applicationTester->getErrorOutput());
+    }
+
+    public function test_it_stays_silent_when_update_checks_are_disabled(): void
+    {
+        $applicationTester = $this->runListCommand(self::NOTICE, true, true);
+
+        self::assertStringNotContainsString(self::NOTICE, $applicationTester->getErrorOutput());
+    }
+
+    private function runListCommand(string $notice, bool $disabled, bool $interactive): ApplicationTester
+    {
+        $updateAvailabilityNotifier = self::createStub(UpdateAvailabilityNotifierInterface::class);
+        $updateAvailabilityNotifier->method('availableUpdateNotice')->willReturn($notice);
+
+        $xdgConfigPathResolver = new XdgConfigPathResolver($this->configHome, $this->cacheHome, null);
+        $application = (new StandaloneApplicationFactory(
+            new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver()),
+            $xdgConfigPathResolver,
+            self::createStub(BridgeInstallerInterface::class),
+            updateAvailabilityConsoleListener: new UpdateAvailabilityConsoleListener($updateAvailabilityNotifier, '1.0.0', $disabled),
+        ))->create();
+        $application->setAutoExit(false);
+
+        $applicationTester = new ApplicationTester($application);
+        $applicationTester->run(['command' => 'list'], ['interactive' => $interactive, 'capture_stderr_separately' => true]);
+
+        return $applicationTester;
+    }
+}

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/FilesystemUpdateCheckStoreTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/FilesystemUpdateCheckStoreTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Infrastructure\SelfUpdate;
+
+use DateTimeImmutable;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\FilesystemUpdateCheckStore;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateCheckState;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Infrastructure\SelfUpdate\Fixture\RecordingLogger;
+
+final class FilesystemUpdateCheckStoreTest extends TestCase
+{
+    private Filesystem $filesystem;
+
+    private string $cacheHome;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->cacheHome = sys_get_temp_dir().'/ssa-update-cache-'.bin2hex(random_bytes(6));
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->cacheHome);
+    }
+
+    public function test_it_round_trips_a_state(): void
+    {
+        $filesystemUpdateCheckStore = $this->resolvableStore();
+        $filesystemUpdateCheckStore->write(new UpdateCheckState(new DateTimeImmutable('@1700000000'), '2.0.0'));
+
+        self::assertEquals(new UpdateCheckState(new DateTimeImmutable('@1700000000'), '2.0.0'), $filesystemUpdateCheckStore->read());
+    }
+
+    public function test_it_treats_a_missing_cache_as_absent(): void
+    {
+        self::assertNull($this->resolvableStore()->read());
+    }
+
+    public function test_it_treats_malformed_json_as_absent(): void
+    {
+        $this->filesystem->dumpFile($this->cacheFile(), 'not json{');
+
+        self::assertNull($this->resolvableStore()->read());
+    }
+
+    #[DataProvider('structurallyInvalidPayloads')]
+    public function test_it_rejects_a_structurally_invalid_payload(string $payload): void
+    {
+        $this->filesystem->dumpFile($this->cacheFile(), $payload);
+
+        self::assertNull($this->resolvableStore()->read());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function structurallyInvalidPayloads(): iterable
+    {
+        yield 'json null' => ['null'];
+        yield 'json scalar' => ['42'];
+        yield 'missing keys' => ['{}'];
+        yield 'checked_at is not an integer' => ['{"checked_at":"soon","latest_version":"2.0.0"}'];
+        yield 'latest_version is not a string' => ['{"checked_at":1700000000,"latest_version":5}'];
+        yield 'latest_version is empty' => ['{"checked_at":1700000000,"latest_version":""}'];
+    }
+
+    public function test_it_neither_reads_nor_writes_when_the_cache_path_is_unresolvable(): void
+    {
+        $filesystemUpdateCheckStore = $this->unresolvableStore();
+        $filesystemUpdateCheckStore->write(new UpdateCheckState(new DateTimeImmutable('@1700000000'), '2.0.0'));
+
+        self::assertNull($filesystemUpdateCheckStore->read());
+    }
+
+    public function test_it_treats_an_unreadable_cache_entry_as_absent(): void
+    {
+        $this->filesystem->mkdir($this->cacheFile());
+
+        self::assertNull($this->resolvableStore()->read());
+    }
+
+    public function test_it_logs_the_error_when_the_cache_entry_is_unreadable(): void
+    {
+        $this->filesystem->mkdir($this->cacheFile());
+        $recordingLogger = new RecordingLogger();
+
+        $this->resolvableStore($recordingLogger)->read();
+
+        self::assertSame([['error']], $recordingLogger->contextKeys());
+    }
+
+    public function test_it_silently_skips_a_failed_write(): void
+    {
+        $this->filesystem->dumpFile($this->cacheDir(), 'blocks the cache directory');
+
+        $this->resolvableStore()->write(new UpdateCheckState(new DateTimeImmutable('@1700000000'), '2.0.0'));
+
+        self::assertNull($this->resolvableStore()->read());
+    }
+
+    public function test_it_logs_the_error_when_writing_the_cache_fails(): void
+    {
+        $this->filesystem->dumpFile($this->cacheDir(), 'blocks the cache directory');
+        $recordingLogger = new RecordingLogger();
+
+        $this->resolvableStore($recordingLogger)->write(new UpdateCheckState(new DateTimeImmutable('@1700000000'), '2.0.0'));
+
+        self::assertSame([['error']], $recordingLogger->contextKeys());
+    }
+
+    private function resolvableStore(?LoggerInterface $logger = null): FilesystemUpdateCheckStore
+    {
+        return new FilesystemUpdateCheckStore(new XdgConfigPathResolver(null, $this->cacheHome, null), $this->filesystem, $logger ?? new NullLogger());
+    }
+
+    private function unresolvableStore(): FilesystemUpdateCheckStore
+    {
+        return new FilesystemUpdateCheckStore(new XdgConfigPathResolver(null, null, null), $this->filesystem, new NullLogger());
+    }
+
+    private function cacheDir(): string
+    {
+        return $this->cacheHome.'/symfony-security-auditor';
+    }
+
+    private function cacheFile(): string
+    {
+        return $this->cacheDir().'/update-check.json';
+    }
+}

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/Fixture/RecordingLogger.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/Fixture/RecordingLogger.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Infrastructure\SelfUpdate\Fixture;
+
+use Override;
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+final class RecordingLogger extends AbstractLogger
+{
+    /**
+     * @var list<array<array-key, mixed>>
+     */
+    public array $contexts = [];
+
+    /**
+     * @param array<array-key, mixed> $context
+     *
+     * @throws void
+     */
+    #[Override]
+    public function log(mixed $level, string|Stringable $message, array $context = []): void
+    {
+        $this->contexts[] = $context;
+    }
+
+    /**
+     * @return list<list<array-key>>
+     */
+    public function contextKeys(): array
+    {
+        return array_map(static fn (array $context): array => array_keys($context), $this->contexts);
+    }
+}

--- a/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Standalone;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -107,6 +108,36 @@ final class StandaloneApplicationFactoryTest extends TestCase
         ])->create();
 
         self::assertTrue($application->has('doctor'));
+    }
+
+    public function test_it_builds_the_application_when_update_checks_are_disabled(): void
+    {
+        $application = StandaloneApplicationFactory::fromEnvironment([
+            'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
+            'XDG_CACHE_HOME' => $this->cacheHome,
+            'SSA_NO_UPDATE_CHECK' => '1',
+        ])->create();
+
+        self::assertTrue($application->has('audit:run'));
+    }
+
+    /**
+     * @param array<string, string> $environment
+     */
+    #[DataProvider('updateCheckOptOutCases')]
+    public function test_it_reports_whether_update_checks_are_disabled(array $environment, bool $expected): void
+    {
+        self::assertSame($expected, StandaloneApplicationFactory::updateChecksDisabled($environment));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>, bool}>
+     */
+    public static function updateCheckOptOutCases(): iterable
+    {
+        yield 'opt-out variable set' => [['SSA_NO_UPDATE_CHECK' => '1'], true];
+        yield 'opt-out variable absent' => [[], false];
+        yield 'opt-out variable empty' => [['SSA_NO_UPDATE_CHECK' => ''], false];
     }
 
     public function test_it_registers_the_audit_command_as_visible(): void

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/Fixture/FakeSelfUpdater.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/Fixture/FakeSelfUpdater.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate\Fixture;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateResult;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdaterInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateStatus;
+
+final class FakeSelfUpdater implements SelfUpdaterInterface
+{
+    public int $calls = 0;
+
+    public ?bool $lastCheckOnly = null;
+
+    public function __construct(
+        public string $latestVersion = '0.0.0',
+        public bool $throws = false,
+    ) {}
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    #[Override]
+    public function run(string $currentVersion, bool $checkOnly): SelfUpdateResult
+    {
+        ++$this->calls;
+        $this->lastCheckOnly = $checkOnly;
+
+        if ($this->throws) {
+            throw SelfUpdateFailedException::forFailedDownload('https://example.test');
+        }
+
+        return new SelfUpdateResult(SelfUpdateStatus::UpdateAvailable, $currentVersion, $this->latestVersion);
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/Fixture/InMemoryUpdateCheckStore.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/Fixture/InMemoryUpdateCheckStore.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate\Fixture;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateCheckState;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateCheckStoreInterface;
+
+final class InMemoryUpdateCheckStore implements UpdateCheckStoreInterface
+{
+    public function __construct(
+        private ?UpdateCheckState $updateCheckState = null,
+    ) {}
+
+    #[Override]
+    public function read(): ?UpdateCheckState
+    {
+        return $this->updateCheckState;
+    }
+
+    #[Override]
+    public function write(UpdateCheckState $updateCheckState): void
+    {
+        $this->updateCheckState = $updateCheckState;
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifierTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifierTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\ThrottledUpdateAvailabilityNotifier;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateCheckState;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate\Fixture\FakeSelfUpdater;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate\Fixture\InMemoryUpdateCheckStore;
+
+final class ThrottledUpdateAvailabilityNotifierTest extends TestCase
+{
+    private const string EXPECTED_NOTICE = 'A new version (2.0.0) is available. Run "symfony-security-auditor self-update" to upgrade.';
+
+    public function test_it_reports_a_newer_version_as_available(): void
+    {
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier(
+            new FakeSelfUpdater('2.0.0'),
+            new InMemoryUpdateCheckStore(),
+            new MockClock('2026-01-01 00:00:00'),
+        );
+
+        self::assertSame(self::EXPECTED_NOTICE, $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0'));
+    }
+
+    public function test_it_reports_no_notice_when_already_on_the_latest_version(): void
+    {
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier(
+            new FakeSelfUpdater('1.0.0'),
+            new InMemoryUpdateCheckStore(),
+            new MockClock('2026-01-01 00:00:00'),
+        );
+
+        self::assertNull($throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0'));
+    }
+
+    public function test_it_reports_no_notice_when_the_running_version_is_newer(): void
+    {
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier(
+            new FakeSelfUpdater('1.0.0'),
+            new InMemoryUpdateCheckStore(),
+            new MockClock('2026-01-01 00:00:00'),
+        );
+
+        self::assertNull($throttledUpdateAvailabilityNotifier->availableUpdateNotice('2.0.0'));
+    }
+
+    public function test_it_performs_a_check_only_lookup(): void
+    {
+        $fakeSelfUpdater = new FakeSelfUpdater('2.0.0');
+
+        (new ThrottledUpdateAvailabilityNotifier($fakeSelfUpdater, new InMemoryUpdateCheckStore(), new MockClock('2026-01-01 00:00:00')))
+            ->availableUpdateNotice('1.0.0');
+
+        self::assertTrue($fakeSelfUpdater->lastCheckOnly);
+    }
+
+    #[DataProvider('nonReleaseVersions')]
+    public function test_it_skips_the_network_check_for_a_non_release_version(string $currentVersion): void
+    {
+        $fakeSelfUpdater = new FakeSelfUpdater('2.0.0');
+
+        (new ThrottledUpdateAvailabilityNotifier($fakeSelfUpdater, new InMemoryUpdateCheckStore(), new MockClock('2026-01-01 00:00:00')))
+            ->availableUpdateNotice($currentVersion);
+
+        self::assertSame(0, $fakeSelfUpdater->calls);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function nonReleaseVersions(): iterable
+    {
+        yield 'unknown sentinel' => ['unknown'];
+        yield 'development branch' => ['dev-main'];
+        yield 'two-segment version' => ['1.0'];
+    }
+
+    public function test_it_returns_no_notice_when_the_check_fails_without_a_cached_answer(): void
+    {
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier(
+            new FakeSelfUpdater(throws: true),
+            new InMemoryUpdateCheckStore(),
+            new MockClock('2026-01-01 00:00:00'),
+        );
+
+        self::assertNull($throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0'));
+    }
+
+    public function test_it_falls_back_to_the_cached_version_when_the_check_fails(): void
+    {
+        $mockClock = new MockClock('2026-01-01 00:00:00');
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier(
+            new FakeSelfUpdater(throws: true),
+            new InMemoryUpdateCheckStore(new UpdateCheckState($mockClock->now()->modify('-2 days'), '2.0.0')),
+            $mockClock,
+        );
+
+        self::assertSame(self::EXPECTED_NOTICE, $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0'));
+    }
+
+    public function test_it_serves_the_cached_version_just_under_the_daily_throttle_window(): void
+    {
+        $mockClock = new MockClock('2026-01-01 00:00:00');
+        $fakeSelfUpdater = new FakeSelfUpdater('2.0.0');
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier($fakeSelfUpdater, new InMemoryUpdateCheckStore(), $mockClock);
+
+        $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
+
+        $fakeSelfUpdater->latestVersion = '3.0.0';
+        $mockClock->sleep(86_399);
+
+        self::assertSame(self::EXPECTED_NOTICE, $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0'));
+    }
+
+    public function test_it_re_checks_once_the_daily_throttle_window_elapses(): void
+    {
+        $mockClock = new MockClock('2026-01-01 00:00:00');
+        $fakeSelfUpdater = new FakeSelfUpdater('2.0.0');
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier($fakeSelfUpdater, new InMemoryUpdateCheckStore(), $mockClock);
+
+        $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
+
+        $fakeSelfUpdater->latestVersion = '3.0.0';
+        $mockClock->sleep(86_400);
+
+        self::assertSame(
+            'A new version (3.0.0) is available. Run "symfony-security-auditor self-update" to upgrade.',
+            $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0'),
+        );
+    }
+}

--- a/tests/Phpunit/Unit/Standalone/UpdateAvailabilityConsoleListenerTest.php
+++ b/tests/Phpunit/Unit/Standalone/UpdateAvailabilityConsoleListenerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Standalone;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateAvailabilityNotifierInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Standalone\UpdateAvailabilityConsoleListener;
+
+final class UpdateAvailabilityConsoleListenerTest extends TestCase
+{
+    private const string NOTICE = 'An update is available.';
+
+    public function test_it_writes_the_notice_to_the_error_output_on_an_interactive_run(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $consoleOutput = new ConsoleOutput();
+        $consoleOutput->setErrorOutput($bufferedOutput);
+
+        ($this->listenerReturning(self::NOTICE))($this->terminateEvent($consoleOutput, true));
+
+        self::assertStringContainsString(self::NOTICE, $bufferedOutput->fetch());
+    }
+
+    public function test_it_writes_to_the_provided_output_when_it_is_not_a_console_output(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+
+        ($this->listenerReturning(self::NOTICE))($this->terminateEvent($bufferedOutput, true));
+
+        self::assertStringContainsString(self::NOTICE, $bufferedOutput->fetch());
+    }
+
+    public function test_it_stays_silent_on_a_non_interactive_run(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+
+        ($this->listenerReturning(self::NOTICE))($this->terminateEvent($bufferedOutput, false));
+
+        self::assertSame('', $bufferedOutput->fetch());
+    }
+
+    public function test_it_stays_silent_when_no_update_is_available(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+
+        ($this->listenerReturning(null))($this->terminateEvent($bufferedOutput, true));
+
+        self::assertSame('', $bufferedOutput->fetch());
+    }
+
+    public function test_it_stays_silent_when_update_checks_are_disabled(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+
+        ($this->listenerReturning(self::NOTICE, true))($this->terminateEvent($bufferedOutput, true));
+
+        self::assertSame('', $bufferedOutput->fetch());
+    }
+
+    private function listenerReturning(?string $notice, bool $disabled = false): UpdateAvailabilityConsoleListener
+    {
+        $updateAvailabilityNotifier = self::createStub(UpdateAvailabilityNotifierInterface::class);
+        $updateAvailabilityNotifier->method('availableUpdateNotice')->willReturn($notice);
+
+        return new UpdateAvailabilityConsoleListener($updateAvailabilityNotifier, '1.0.0', $disabled);
+    }
+
+    private function terminateEvent(OutputInterface $output, bool $interactive): ConsoleTerminateEvent
+    {
+        $arrayInput = new ArrayInput([]);
+        $arrayInput->setInteractive($interactive);
+
+        return new ConsoleTerminateEvent(new Command('test'), $arrayInput, $output, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an "update available" notice to the standalone binary. After a command
finishes **on an interactive terminal**, the binary prints a one-line notice to
**stderr** pointing at `self-update` when the installed version is behind the
latest GitHub release:

```text
A new version (1.17.0) is available. Run "symfony-security-auditor self-update" to upgrade.
```

The check is best-effort and stays out of the way:

- **Interactive only** — piped/CI runs and machine-readable stdout
  (`--format=json`/`sarif`) are never touched (the notice goes to stderr, gated
  on `Input::isInteractive()`).
- **Throttled to once per 24h** — the GitHub release lookup is cached under the
  XDG cache directory; between checks the cached answer is reused with no network
  call.
- **Never fatal** — any failure (offline, rate-limited, unresolvable/unwritable
  cache) is swallowed and logged; it never changes a command's exit code.
- **Standalone only** — the Composer bundle updates through `composer update`.

Opt out with `SSA_NO_UPDATE_CHECK=1`.

### Design

- `ThrottledUpdateAvailabilityNotifier` (`src/Audit/Infrastructure/SelfUpdate/`) reuses the existing `SelfUpdater` check-only path for the version lookup and throttles it via `UpdateCheckStoreInterface` + a PSR-20 clock.
- `FilesystemUpdateCheckStore` persists `{checked_at, latest_version}` as JSON under the XDG cache dir, degrading every I/O/decoding failure to a cache miss (mirrors `LockfileHashedAdvisoryCache`).
- `UpdateAvailabilityConsoleListener` (`src/Standalone/`) renders the notice to stderr from a console `TERMINATE` event.
- `StandaloneApplicationFactory` builds and wires the listener onto the application's event dispatcher, and reads the opt-out variable.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added or updated — `ThrottledUpdateAvailabilityNotifierTest` (Unit; version compare, non-release guard, throttle-window boundary, offline fallback), `UpdateAvailabilityConsoleListenerTest` (Unit; interactive gate, stderr vs plain output, silence cases), `FilesystemUpdateCheckStoreTest` (Integration; round-trip, malformed/invalid payloads, unresolvable/unreadable/failed-write paths), plus opt-out coverage on `StandaloneApplicationFactoryTest`
- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `php -l` and prettier/markdownlint (composer deps aren't installable in the authoring environment)
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — throttle boundary, version-compare branches, and each store degradation path are pinned by assertions
- [x] No `createMock` without a matching `expects()` — uses `createStub` and behavior fixtures (`FakeSelfUpdater`, `InMemoryUpdateCheckStore`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)