### PR TITLE
fix(standalone): throttle failed update checks

### DIFF
--- a/src/Audit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifier.php
+++ b/src/Audit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifier.php
@@ -74,7 +74,7 @@ final readonly class ThrottledUpdateAvailabilityNotifier implements UpdateAvaila
         try {
             $latestVersion = $this->selfUpdater->run($currentVersion, true)->latestVersion;
         } catch (SelfUpdateFailedException|UnsupportedSelfUpdatePlatformException) {
-            $latestVersion = $updateCheckState?->latestVersion ?? $currentVersion;
+            $latestVersion = $updateCheckState->latestVersion ?? $currentVersion;
         }
 
         $this->updateCheckStore->write(new UpdateCheckState($this->clock->now(), $latestVersion));

--- a/src/Audit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifier.php
+++ b/src/Audit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifier.php
@@ -22,8 +22,9 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Excepti
  * Resolves the latest released version through the shared self-update machinery,
  * throttling the network call to at most once per `throttleSeconds` by caching
  * the answer. The GitHub call only ever happens when the cache is missing or
- * stale; a failed call falls back to the last cached answer (or no notice), so
- * the check is silent when offline and never blocks a run more than once a day.
+ * stale; a failed call falls back to the last cached answer (or no notice) and
+ * still refreshes the throttle window, so the check is silent when offline and
+ * never blocks a run more than once a day.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -50,9 +51,6 @@ final readonly class ThrottledUpdateAvailabilityNotifier implements UpdateAvaila
         }
 
         $latestVersion = $this->latestVersion($currentVersion);
-        if (null === $latestVersion) {
-            return null;
-        }
 
         if (!version_compare($latestVersion, $currentVersion, '>')) {
             return null;
@@ -61,7 +59,7 @@ final readonly class ThrottledUpdateAvailabilityNotifier implements UpdateAvaila
         return \sprintf(self::NOTICE_TEMPLATE, $latestVersion);
     }
 
-    private function latestVersion(string $currentVersion): ?string
+    private function latestVersion(string $currentVersion): string
     {
         $cachedState = $this->updateCheckStore->read();
         if ($cachedState instanceof UpdateCheckState && !$this->isStale($cachedState)) {
@@ -71,12 +69,12 @@ final readonly class ThrottledUpdateAvailabilityNotifier implements UpdateAvaila
         return $this->refreshedLatestVersion($currentVersion, $cachedState);
     }
 
-    private function refreshedLatestVersion(string $currentVersion, ?UpdateCheckState $updateCheckState): ?string
+    private function refreshedLatestVersion(string $currentVersion, ?UpdateCheckState $updateCheckState): string
     {
         try {
             $latestVersion = $this->selfUpdater->run($currentVersion, true)->latestVersion;
         } catch (SelfUpdateFailedException|UnsupportedSelfUpdatePlatformException) {
-            return $updateCheckState?->latestVersion;
+            $latestVersion = $updateCheckState?->latestVersion ?? $currentVersion;
         }
 
         $this->updateCheckStore->write(new UpdateCheckState($this->clock->now(), $latestVersion));

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifierTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifierTest.php
@@ -112,6 +112,48 @@ final class ThrottledUpdateAvailabilityNotifierTest extends TestCase
         self::assertSame(self::EXPECTED_NOTICE, $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0'));
     }
 
+    public function test_it_throttles_the_lookup_after_a_failed_check(): void
+    {
+        $fakeSelfUpdater = new FakeSelfUpdater(throws: true);
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier(
+            $fakeSelfUpdater,
+            new InMemoryUpdateCheckStore(),
+            new MockClock('2026-01-01 00:00:00'),
+        );
+
+        $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
+        $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
+
+        self::assertSame(1, $fakeSelfUpdater->calls);
+    }
+
+    public function test_it_re_checks_a_failed_lookup_once_the_throttle_window_elapses(): void
+    {
+        $mockClock = new MockClock('2026-01-01 00:00:00');
+        $fakeSelfUpdater = new FakeSelfUpdater(throws: true);
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier($fakeSelfUpdater, new InMemoryUpdateCheckStore(), $mockClock);
+
+        $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
+        $mockClock->sleep(86_400);
+        $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
+
+        self::assertSame(2, $fakeSelfUpdater->calls);
+    }
+
+    public function test_it_keeps_the_cached_answer_across_a_failed_refresh(): void
+    {
+        $mockClock = new MockClock('2026-01-01 00:00:00');
+        $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier(
+            new FakeSelfUpdater(throws: true),
+            new InMemoryUpdateCheckStore(new UpdateCheckState($mockClock->now()->modify('-2 days'), '2.0.0')),
+            $mockClock,
+        );
+
+        $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
+
+        self::assertSame(self::EXPECTED_NOTICE, $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0'));
+    }
+
     public function test_it_serves_the_cached_version_just_under_the_daily_throttle_window(): void
     {
         $mockClock = new MockClock('2026-01-01 00:00:00');

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifierTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/ThrottledUpdateAvailabilityNotifierTest.php
@@ -134,6 +134,7 @@ final class ThrottledUpdateAvailabilityNotifierTest extends TestCase
         $throttledUpdateAvailabilityNotifier = new ThrottledUpdateAvailabilityNotifier($fakeSelfUpdater, new InMemoryUpdateCheckStore(), $mockClock);
 
         $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
+
         $mockClock->sleep(86_400);
         $throttledUpdateAvailabilityNotifier->availableUpdateNotice('1.0.0');
 


### PR DESCRIPTION
## Summary

The 24h update-check throttle only held on the success path. `ThrottledUpdateAvailabilityNotifier::refreshedLatestVersion()` wrote the check state after a successful lookup, but a failed one (`SelfUpdateFailedException` / `UnsupportedSelfUpdatePlatformException`) returned early without recording the attempt — so with a missing or stale cache, `isStale()` stayed true and **every interactive command re-ran the GitHub lookup**.

Concretely: behind a firewall that blackholes `api.github.com` (or on a rate-limited network), every `audit`/`doctor`/`list` spawned `curl --connect-timeout 30` synchronously at `TERMINATE` and hung the terminal up to 30 s at exit, on every run — contradicting the class contract ("never blocks a run more than once a day"), `docs/configuration.md`, and the `Unreleased` changelog entry ("throttled to once per 24 hours").

### Fix

Persist the check state on failure too, keeping the last cached answer (or the current version when there is none) so the throttle window always advances:

- **Offline with no cache** — one failed lookup per 24h, no notice (unchanged output, no repeated stalls).
- **Offline with a cached answer** — the cached version keeps serving (unchanged), and the window refreshes instead of re-attempting every run.
- **Window elapses** — the lookup retries as before.

`latestVersion()` can no longer return null, so the signatures tighten to `string` and the dead null-branch in `availableUpdateNotice()` goes away. The existing changelog/docs wording is what this makes true, so no new changelog entry.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — `ThrottledUpdateAvailabilityNotifierTest`: a failed check throttles the next lookup (single `SelfUpdater` call across two runs), retries once the window elapses, and keeps serving the cached answer across a failed refresh (pins that the failure write preserves the cached version rather than clobbering it)
- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `php -l` (composer deps aren't installable in the authoring environment)
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — the failure-write, null-coalesce fallback, and throttle-boundary branches are each pinned by an assertion
- [x] No `createMock` without a matching `expects()` — behavior fixtures only (`FakeSelfUpdater`, `InMemoryUpdateCheckStore`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)