### PR TITLE
fix(standalone): skip update notice after self-update

### DIFF
--- a/src/Standalone/UpdateAvailabilityConsoleListener.php
+++ b/src/Standalone/UpdateAvailabilityConsoleListener.php
@@ -17,12 +17,15 @@ use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateAvailabilityNotifierInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\SelfUpdateCommand;
 
 /**
  * Prints an "update available" notice to stderr once a command finishes, but
  * only on an interactive run so machine-readable stdout (e.g. `--format=json`)
- * and CI logs stay clean. The version check itself is delegated and best-effort,
- * so this never changes the exit code.
+ * and CI logs stay clean, and never after `self-update` itself — the running
+ * process still reports the replaced binary's version, so the notice would
+ * advertise the release that was just installed. The version check itself is
+ * delegated and best-effort, so this never changes the exit code.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -41,6 +44,10 @@ final readonly class UpdateAvailabilityConsoleListener
         }
 
         if (!$consoleTerminateEvent->getInput()->isInteractive()) {
+            return;
+        }
+
+        if (SelfUpdateCommand::NAME === $consoleTerminateEvent->getCommand()?->getName()) {
             return;
         }
 

--- a/tests/Phpunit/Unit/Standalone/UpdateAvailabilityConsoleListenerTest.php
+++ b/tests/Phpunit/Unit/Standalone/UpdateAvailabilityConsoleListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateAvailabilityNotifierInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\SelfUpdateCommand;
 use VinceAmstoutz\SymfonySecurityAuditor\Standalone\UpdateAvailabilityConsoleListener;
 
 final class UpdateAvailabilityConsoleListenerTest extends TestCase
@@ -74,6 +75,15 @@ final class UpdateAvailabilityConsoleListenerTest extends TestCase
         self::assertSame('', $bufferedOutput->fetch());
     }
 
+    public function test_it_stays_silent_after_self_update_itself(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+
+        ($this->listenerReturning(self::NOTICE))($this->terminateEvent($bufferedOutput, true, SelfUpdateCommand::NAME));
+
+        self::assertSame('', $bufferedOutput->fetch());
+    }
+
     private function listenerReturning(?string $notice, bool $disabled = false): UpdateAvailabilityConsoleListener
     {
         $updateAvailabilityNotifier = self::createStub(UpdateAvailabilityNotifierInterface::class);
@@ -82,11 +92,11 @@ final class UpdateAvailabilityConsoleListenerTest extends TestCase
         return new UpdateAvailabilityConsoleListener($updateAvailabilityNotifier, '1.0.0', $disabled);
     }
 
-    private function terminateEvent(OutputInterface $output, bool $interactive): ConsoleTerminateEvent
+    private function terminateEvent(OutputInterface $output, bool $interactive, string $commandName = 'test'): ConsoleTerminateEvent
     {
         $arrayInput = new ArrayInput([]);
         $arrayInput->setInteractive($interactive);
 
-        return new ConsoleTerminateEvent(new Command('test'), $arrayInput, $output, 0);
+        return new ConsoleTerminateEvent(new Command($commandName), $arrayInput, $output, 0);
     }
 }


### PR DESCRIPTION
## Summary

A successful interactive `self-update` ended with the tool contradicting itself:

```text
[OK] Updated from 1.16.0 to 1.17.0.
A new version (1.17.0) is available. Run "symfony-security-auditor self-update" to upgrade.
```

`UpdateAvailabilityConsoleListener` runs on `ConsoleEvents::TERMINATE` for **every** command — including `self-update` — and compares against the version constant baked into the still-running process, which after the on-disk binary was replaced is still the *old* version. The guided flow makes this deterministic: the notice that motivated the upgrade already cached the latest version inside the 24h window, so the listener re-prints it right after the update succeeds (and with a cold cache it performs a second GitHub lookup in the same invocation and prints it anyway). Users read that as "the update failed" and re-run it.

### Fix

Skip the notice when the terminated command is `self-update` (matched against `SelfUpdateCommand::NAME`). All other commands keep the existing interactive/stderr behavior.

The `Unreleased` changelog entry describes the notice feature at the level of "after a command finishes"; the exclusion is an internal correction to that unreleased behavior, so no new entry.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — `UpdateAvailabilityConsoleListenerTest::test_it_stays_silent_after_self_update_itself` (terminate event for a command named `self-update`, notifier reporting an available update, expects no output; kills the equality-negation mutant together with the existing named-command tests)
- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `php -l` (composer deps aren't installable in the authoring environment); `getCommand(): ?Command` on both supported Symfony lines, so the nullsafe access is exact
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — both branches of the new guard are exercised
- [x] No `createMock` without a matching `expects()` — `createStub` only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)