### PR TITLE
fix(standalone): fail fast on unsupported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,13 +88,13 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   path (native Windows), and the update notice stays silent there.** The
   platform check in `GitHubBinaryAssetResolver` only ran on the real-update
   path, so on Windows `self-update` performed the GitHub lookup first and then
-  either threw `UnsupportedSelfUpdatePlatformException` or — when already on
-  the latest release — misleadingly reported "Already up to date", while the
-  new update notice pointed Windows users at a command that can never succeed
-  there. `SelfUpdater::run()` now asserts platform support before any network
-  call: `self-update` fails immediately with the download-from-releases-page
-  guidance, and the throttled notice check treats the platform as
-  check-failed, so no notice is printed on Windows.
+  either threw `UnsupportedSelfUpdatePlatformException` or — when already on the
+  latest release — misleadingly reported "Already up to date", while the new
+  update notice pointed Windows users at a command that can never succeed there.
+  `SelfUpdater::run()` now asserts platform support before any network call:
+  `self-update` fails immediately with the download-from-releases-page guidance,
+  and the throttled notice check treats the platform as check-failed, so no
+  notice is printed on Windows.
 - **`install.sh` no longer fails silently when the `wget` fallback hits an HTTP
   error.** The `wget` download path in `download()` used `-q`, which suppresses
   wget's error output, so a failed request (e.g. a 404 for a missing release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **`self-update` now fails fast on platforms without a published self-update
+  path (native Windows), and the update notice stays silent there.** The
+  platform check in `GitHubBinaryAssetResolver` only ran on the real-update
+  path, so on Windows `self-update` performed the GitHub lookup first and then
+  either threw `UnsupportedSelfUpdatePlatformException` or — when already on
+  the latest release — misleadingly reported "Already up to date", while the
+  new update notice pointed Windows users at a command that can never succeed
+  there. `SelfUpdater::run()` now asserts platform support before any network
+  call: `self-update` fails immediately with the download-from-releases-page
+  guidance, and the throttled notice check treats the platform as
+  check-failed, so no notice is printed on Windows.
 - **`install.sh` no longer fails silently when the `wget` fallback hits an HTTP
   error.** The `wget` download path in `download()` used `-q`, which suppresses
   wget's error output, so a failed request (e.g. a 404 for a missing release

--- a/src/Audit/Infrastructure/SelfUpdate/GitHubBinaryAssetResolver.php
+++ b/src/Audit/Infrastructure/SelfUpdate/GitHubBinaryAssetResolver.php
@@ -38,6 +38,15 @@ final readonly class GitHubBinaryAssetResolver
     /**
      * @throws UnsupportedSelfUpdatePlatformException
      */
+    public function assertSupportedPlatform(): void
+    {
+        $this->osSlug();
+        $this->architectureSlug();
+    }
+
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
     public function resolve(string $version): GitHubBinaryAsset
     {
         $assetName = \sprintf('%s-%s-%s', self::BINARY_NAME, $this->osSlug(), $this->architectureSlug());

--- a/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
+++ b/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
@@ -39,6 +39,8 @@ final readonly class SelfUpdater implements SelfUpdaterInterface
     #[Override]
     public function run(string $currentVersion, bool $checkOnly): SelfUpdateResult
     {
+        $this->gitHubBinaryAssetResolver->assertSupportedPlatform();
+
         $latestVersion = $this->latestVersion();
 
         if (!version_compare($latestVersion, $currentVersion, '>')) {

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/Fixture/FakeReleaseClient.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/Fixture/FakeReleaseClient.php
@@ -21,6 +21,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Release
 
 final class FakeReleaseClient implements ReleaseClientInterface
 {
+    public int $requests = 0;
+
     /**
      * @param array<string, string> $bodies keyed by URL
      */
@@ -32,6 +34,8 @@ final class FakeReleaseClient implements ReleaseClientInterface
     #[Override]
     public function get(string $url): string
     {
+        ++$this->requests;
+
         return $this->bodies[$url] ?? throw SelfUpdateFailedException::forFailedDownload($url);
     }
 
@@ -41,6 +45,8 @@ final class FakeReleaseClient implements ReleaseClientInterface
     #[Override]
     public function download(string $url, string $destination): void
     {
+        ++$this->requests;
+
         try {
             (new Filesystem())->dumpFile($destination, $this->downloadPayload);
         } catch (IOException $ioException) {

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
@@ -162,6 +162,26 @@ final class SelfUpdaterTest extends TestCase
      * @throws SelfUpdateFailedException
      * @throws UnsupportedSelfUpdatePlatformException
      */
+    public function test_it_refuses_an_unsupported_platform_without_contacting_github(): void
+    {
+        $fakeReleaseClient = new FakeReleaseClient([]);
+        $locator = self::createStub(RunningBinaryLocatorInterface::class);
+        $locator->method('path')->willReturn($this->binaryPath);
+        $selfUpdater = new SelfUpdater($fakeReleaseClient, new GitHubBinaryAssetResolver('Windows', 'x86_64'), $locator);
+
+        try {
+            $this->expectException(UnsupportedSelfUpdatePlatformException::class);
+
+            $selfUpdater->run('1.0.0', true);
+        } finally {
+            self::assertSame(0, $fakeReleaseClient->requests);
+        }
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
     #[DataProvider('unresolvableLatestVersionPayloads')]
     public function test_it_rejects_an_unresolvable_latest_version(string $apiBody): void
     {

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/GitHubBinaryAssetResolverTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/GitHubBinaryAssetResolverTest.php
@@ -67,4 +67,15 @@ final class GitHubBinaryAssetResolverTest extends TestCase
         yield 'unsupported bsd operating system' => ['BSD', 'x86_64'];
         yield 'unsupported architecture' => ['Linux', 'riscv64'];
     }
+
+    /**
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
+    #[DataProvider('unsupportedPlatformCases')]
+    public function test_it_reports_an_unsupported_platform_without_an_asset_lookup(string $osFamily, string $machine): void
+    {
+        $this->expectException(UnsupportedSelfUpdatePlatformException::class);
+
+        (new GitHubBinaryAssetResolver($osFamily, $machine))->assertSupportedPlatform();
+    }
 }


### PR DESCRIPTION
## Summary

The Windows standalone binary nagged users toward a command that can never work there. `GitHubBinaryAssetResolver::osSlug()` only maps `Linux`/`Darwin` and throws for Windows — but that check only ran on the **real-update** path (`resolve()` inside `replaceBinary()`). Two consequences:

- The update notice's check-only lookup succeeded on Windows, so every interactive command printed `A new version (X) is available. Run "symfony-security-auditor self-update" to upgrade.` — and following that instruction deterministically failed with `UnsupportedSelfUpdatePlatformException`, with the nag reappearing on every subsequent command.
- `self-update` on Windows did a full GitHub roundtrip first, then either threw, or — when already on the latest release — misleadingly reported `Already up to date` as if the platform could self-update.

### Fix

`SelfUpdater::run()` asserts platform support first, via a new `GitHubBinaryAssetResolver::assertSupportedPlatform()`, before any network call:

- `self-update` on Windows fails immediately with the existing download-from-releases-page guidance (no curl spawned).
- `ThrottledUpdateAvailabilityNotifier` already catches `UnsupportedSelfUpdatePlatformException`, so the notice stays silent on unsupported platforms — that pre-existing catch finally has a code path that reaches it.

Changelog entry added under `Unreleased → Fixed` (the `self-update` half changes released behavior).

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — `GitHubBinaryAssetResolverTest` covers `assertSupportedPlatform()` across the unsupported-platform provider (kills the two statement-removal mutants via the `Windows/x86_64` and `Linux/riscv64` cases); `SelfUpdaterTest::test_it_refuses_an_unsupported_platform_without_contacting_github` pins the no-network claim with a request counter on `FakeReleaseClient`
- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `php -l` and `prettier --check CHANGELOG.md` (composer deps aren't installable in the authoring environment)
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — the happy path of the new assertion is exercised by every existing Linux-resolver `SelfUpdaterTest` case
- [x] No `createMock` without a matching `expects()` — `createStub` and behavior fixtures only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)