### PR TITLE
fix(command): normalize provider slugs in init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **`init` no longer writes an unbootable configuration when the provider is
+  spelled as a bridge package slug (`open-ai`, `deep-seek`, …).** `init` never
+  validated the provider value: for the seven hyphenated package slugs
+  (`open-ai`, `open-responses`, `deep-seek`, `vertex-ai`, `hugging-face`,
+  `eleven-labs`, `amazee-ai`) the bridge install genuinely succeeded — they are
+  real package names — and `config.yaml` was written with a platform key
+  `symfony/ai` does not recognize, so `init` exited 0 with a success message
+  while every later `audit` aborted at container build. A new
+  `ProviderKeyNormalizer` (`src/Audit/Infrastructure/Bridge/`) now trims,
+  lowercases, and folds package slugs back to their platform config keys
+  (`open-ai` → `openai`) before the configuration is written and the bridge
+  installed.
 - **`self-update` now fails fast on platforms without a published self-update
   path (native Windows), and the update notice stays silent there.** The
   platform check in `GitHubBinaryAssetResolver` only ran on the real-update

--- a/src/Audit/Infrastructure/Bridge/ComposerBridgeInstaller.php
+++ b/src/Audit/Infrastructure/Bridge/ComposerBridgeInstaller.php
@@ -39,7 +39,7 @@ final readonly class ComposerBridgeInstaller implements BridgeInstallerInterface
      *
      * @var array<string, string>
      */
-    private const array PACKAGE_SLUG_OVERRIDES = [
+    public const array PACKAGE_SLUG_OVERRIDES = [
         'openai' => 'open-ai',
         'openresponses' => 'open-responses',
         'deepseek' => 'deep-seek',

--- a/src/Audit/Infrastructure/Bridge/ProviderKeyNormalizer.php
+++ b/src/Audit/Infrastructure/Bridge/ProviderKeyNormalizer.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge;
+
+use function Symfony\Component\String\u;
+
+/**
+ * Folds a user-supplied provider spelling back to the `symfony/ai` platform
+ * config key the rest of the stack expects: trims and lowercases the input and
+ * maps the hyphenated bridge package slugs (`open-ai`, `deep-seek`, …) to their
+ * config keys (`openai`, `deepseek`). Without this, `init --provider=open-ai`
+ * installs a real bridge package but writes a platform key no container can
+ * ever boot from.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class ProviderKeyNormalizer
+{
+    public function normalize(string $provider): string
+    {
+        $configKey = u($provider)->trim()->lower()->toString();
+
+        return array_flip(ComposerBridgeInstaller::PACKAGE_SLUG_OVERRIDES)[$configKey] ?? $configKey;
+    }
+}

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\BridgeInstallerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\Exception\BridgeInstallationFailedException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\ProviderKeyNormalizer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigFactoryInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigWriterInterface;
@@ -41,6 +42,7 @@ final readonly class InitCommand
         private StandaloneConfigWriterInterface $standaloneConfigWriter,
         private BridgeInstallerInterface $bridgeInstaller,
         private Filesystem $filesystem = new Filesystem(),
+        private ProviderKeyNormalizer $providerKeyNormalizer = new ProviderKeyNormalizer(),
     ) {}
 
     /**
@@ -65,6 +67,7 @@ final readonly class InitCommand
         }
 
         $provider ??= $this->ask($symfonyStyle, 'Which AI provider do you want to use? (any symfony/ai platform — e.g. anthropic, openai, gemini, mistral, ollama)', 'anthropic');
+        $provider = $this->providerKeyNormalizer->normalize($provider);
         $model ??= $this->ask($symfonyStyle, 'Which model should the auditor use?', 'claude-opus-4-8');
         $envVar ??= $this->ask($symfonyStyle, 'Which environment variable holds the API key?', $this->defaultApiKeyVariable($provider));
 

--- a/tests/Phpunit/Integration/Command/InitCommandTest.php
+++ b/tests/Phpunit/Integration/Command/InitCommandTest.php
@@ -87,14 +87,41 @@ final class InitCommandTest extends TestCase
     public function test_it_strips_invalid_characters_when_deriving_the_api_key_variable_from_the_provider(): void
     {
         $commandTester = $this->commandTester();
-        $commandTester->setInputs(['open-ai', 'gpt-5.4', '']);
+        $commandTester->setInputs(['my-ai', 'my-model', '']);
 
         $commandTester->execute([]);
 
         self::assertSame(
-            ['provider' => 'open-ai', 'platform' => ['open-ai' => ['api_key' => '%env(OPENAI_API_KEY)%']], 'model' => 'gpt-5.4'],
+            ['provider' => 'my-ai', 'platform' => ['my-ai' => ['api_key' => '%env(MYAI_API_KEY)%']], 'model' => 'my-model'],
             Yaml::parseFile($this->configFile()),
         );
+    }
+
+    public function test_it_folds_a_bridge_package_slug_to_the_platform_config_key(): void
+    {
+        $commandTester = $this->commandTester();
+
+        $commandTester->execute(
+            ['--provider' => 'open-ai', '--model' => 'gpt-5.4'],
+            ['interactive' => false],
+        );
+
+        self::assertSame(
+            ['provider' => 'openai', 'platform' => ['openai' => ['api_key' => '%env(OPENAI_API_KEY)%']], 'model' => 'gpt-5.4'],
+            Yaml::parseFile($this->configFile()),
+        );
+    }
+
+    public function test_it_installs_the_bridge_under_the_normalized_provider_key(): void
+    {
+        $commandTester = $this->commandTester();
+
+        $commandTester->execute(
+            ['--provider' => 'Open-AI', '--model' => 'gpt-5.4'],
+            ['interactive' => false],
+        );
+
+        self::assertSame([['openai', $this->dataHome.'/symfony-security-auditor']], $this->recordingBridgeInstaller->installations);
     }
 
     public function test_it_uses_the_provider_model_and_env_var_options_without_prompting(): void

--- a/tests/Phpunit/Unit/Infrastructure/Bridge/ProviderKeyNormalizerTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Bridge/ProviderKeyNormalizerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Bridge;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\ProviderKeyNormalizer;
+
+final class ProviderKeyNormalizerTest extends TestCase
+{
+    #[DataProvider('providerSpellings')]
+    public function test_it_folds_a_provider_spelling_to_the_platform_config_key(string $provider, string $expectedConfigKey): void
+    {
+        self::assertSame($expectedConfigKey, (new ProviderKeyNormalizer())->normalize($provider));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function providerSpellings(): iterable
+    {
+        yield 'config key kept as-is' => ['anthropic', 'anthropic'];
+        yield 'unknown provider kept as-is' => ['my-ai', 'my-ai'];
+        yield 'uppercase folded to the config key' => ['Anthropic', 'anthropic'];
+        yield 'surrounding whitespace trimmed' => [' openai ', 'openai'];
+        yield 'openai package slug' => ['open-ai', 'openai'];
+        yield 'openresponses package slug' => ['open-responses', 'openresponses'];
+        yield 'deepseek package slug' => ['deep-seek', 'deepseek'];
+        yield 'vertexai package slug' => ['vertex-ai', 'vertexai'];
+        yield 'huggingface package slug' => ['hugging-face', 'huggingface'];
+        yield 'elevenlabs package slug' => ['eleven-labs', 'elevenlabs'];
+        yield 'amazeeai package slug' => ['amazee-ai', 'amazeeai'];
+        yield 'uppercase package slug' => ['Open-AI', 'openai'];
+    }
+}


### PR DESCRIPTION
## Summary

`init --provider=open-ai --model=gpt-5.4 --no-interaction` succeeded end to end and produced a configuration that can never boot.

`init` accepted any provider string verbatim. `ComposerBridgeInstaller::PACKAGE_SLUG_OVERRIDES` only maps config key → package slug, so for the seven hyphenated slugs (`open-ai`, `open-responses`, `deep-seek`, `vertex-ai`, `hugging-face`, `eleven-labs`, `amazee-ai`) the whole flow passed: `symfony/ai-open-ai-platform` is a real package, the bridge install succeeded, `config.yaml` was written with `platform: { open-ai: … }`, and the command printed its success message and exited 0 — while every subsequent `audit` aborted at container build, because `symfony/ai` only recognizes the unhyphenated config keys. A user who found the tool via the bridge package name on Packagist hits this directly, and the new scriptable options make it an easy automation trap.

### Fix

A new `ProviderKeyNormalizer` (`src/Audit/Infrastructure/Bridge/`) trims, lowercases, and folds package slugs back to their platform config keys — `open-ai` → `openai`, `Anthropic` → `anthropic` — before the configuration is written and the bridge installed. The reverse map is `array_flip` of the installer's `PACKAGE_SLUG_OVERRIDES` (now a public const), so there is a single source of truth for the slug spellings. Unknown providers still pass through untouched ("any symfony/ai platform" stays open-ended), and the derived `<PROVIDER>_API_KEY` default now always reflects the normalized key.

Changelog entry added under `Unreleased → Fixed` (interactive `init` shipped in an earlier release with the same weakness).

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — `ProviderKeyNormalizerTest` (all seven slugs, case folding, trimming, config-key/unknown passthrough), `InitCommandTest` (slug option produces the `openai` config + bridge installed under the normalized key); the existing test that pinned the broken `open-ai` output now uses an unknown provider to keep pinning the env-var derivation rule
- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `php -l` and `prettier@3.6.2 --check` (composer deps aren't installable in the authoring environment)
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — every map entry, the trim, and the lowercase fold are pinned by provider cases
- [x] No `createMock` without a matching `expects()` — behavior fixture (`RecordingBridgeInstaller`) only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)