### PR TITLE
docs: correct Git Bash install guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,9 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 - **The standalone install docs now lead with the cross-platform `curl … | sh`
   one-liner**, with the PowerShell `irm … | iex` command demoted to the
   native-Windows fallback — the single `curl` command covers Linux, macOS, and
-  Windows under WSL or Git Bash.
+  Windows under WSL. On the Windows POSIX shells (Git Bash / MSYS / Cygwin) the
+  native binary is the right artifact, so `install.sh` redirects them to the
+  PowerShell installer instead (see below).
 - **`install.sh` now points Windows POSIX-shell users (Git Bash / MSYS / Cygwin)
   at the PowerShell installer.** It previously failed there with a generic
   "download the `.exe`" message; it now detects a `MINGW*`/`MSYS*`/`CYGWIN*`

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Linux, macOS, and Windows.
 
 ### 1. Install
 
-**One command — Linux, macOS, and Windows (under WSL or Git Bash):**
+**One command — Linux, macOS, and Windows (under WSL):**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh | sh
@@ -101,7 +101,9 @@ curl -fsSL https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-audi
 binary, and verifies its SHA-256 checksum before installing — anywhere you have
 a POSIX shell.
 
-**Native Windows (PowerShell)** — when you are not using WSL or Git Bash:
+**Native Windows (PowerShell)** — when you are not using WSL; Git Bash / MSYS /
+Cygwin users need this installer too (`install.sh` detects those shells and
+points here):
 
 ```powershell
 irm https://raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.ps1 | iex


### PR DESCRIPTION
## Summary

`README.md` leads the install section with "**One command — Linux, macOS, and Windows (under WSL or Git Bash)**" directly above the `curl … | sh` snippet — but `install.sh` (in the same release range) deliberately detects `MINGW*`/`MSYS*`/`CYGWIN*` shells and exits with a redirect to the PowerShell installer, because the native Windows `.exe` is the right artifact there. So on one of the two Windows environments the README explicitly names, the documented one-liner installs nothing.

This scopes the claim to WSL and tells Git Bash / MSYS / Cygwin users up front that the PowerShell installer is the one to run (matching what `install.sh` itself prints), in both the README and the `Unreleased` changelog entry that repeated the claim. Docs only — the installer behavior is intentional and unchanged.

## Type of change

- [x] Documentation

## Checklist

- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `prettier@3.6.2 --check "**/*.md"`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)