### PR TITLE
fix(standalone): locate only executable binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **`self-update`'s macOS fallbacks accept only executable regular files, so a
+  same-named stray file or directory is never replaced instead of the running
+  binary.** Without `/proc/self/exe`, `RunningBinaryLocator` `realpath()`ed the
+  invoked name against the working directory and then across `PATH`, taking the
+  first hit of any kind — unlike the shell, it never checked what it found. A
+  stray `symfony-security-auditor` file in the current directory (or a directory
+  on `PATH`) could be selected: a regular file was silently overwritten by the
+  downloaded release while the real binary stayed outdated (and the update
+  notice kept re-appearing), and a directory made the replacement fail. Both
+  fallbacks now require an executable regular file, the way the shell resolves
+  commands.
 - **`init` no longer writes an unbootable configuration when the provider is
   spelled as a bridge package slug (`open-ai`, `deep-seek`, …).** `init` never
   validated the provider value: for the seven hyphenated package slugs

--- a/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocator.php
+++ b/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocator.php
@@ -25,7 +25,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Excepti
  * `/proc/self/exe` (Linux); elsewhere (notably macOS, which has no
  * `/proc/self/exe`) it falls back to the resolved entry path, and — when the
  * binary was invoked by a bare name found on `PATH` so the entry path is not a
- * resolvable file — to a `PATH` lookup of that name.
+ * resolvable file — to a `PATH` lookup of that name. Both fallbacks accept only
+ * an executable regular file, the way the shell resolves commands, so a
+ * same-named stray file or directory is never mistaken for the running binary
+ * and overwritten by an update.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -72,8 +75,8 @@ final readonly class RunningBinaryLocator implements RunningBinaryLocatorInterfa
             return null;
         }
 
-        $resolved = realpath($this->invokedScriptPath);
-        if (false !== $resolved) {
+        $resolved = $this->executableFile(realpath($this->invokedScriptPath));
+        if (null !== $resolved) {
             return $resolved;
         }
 
@@ -87,12 +90,17 @@ final readonly class RunningBinaryLocator implements RunningBinaryLocatorInterfa
                 continue;
             }
 
-            $candidate = realpath($directory.\DIRECTORY_SEPARATOR.$this->invokedScriptPath);
-            if (false !== $candidate) {
+            $candidate = $this->executableFile(realpath($directory.\DIRECTORY_SEPARATOR.$this->invokedScriptPath));
+            if (null !== $candidate) {
                 return $candidate;
             }
         }
 
         return null;
+    }
+
+    private function executableFile(false|string $path): ?string
+    {
+        return \is_string($path) && is_file($path) && is_executable($path) ? $path : null;
     }
 }

--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
@@ -71,7 +71,7 @@ final class RunningBinaryLocatorTest extends TestCase
     public function test_it_falls_back_to_the_resolved_invoked_script_when_proc_self_exe_is_absent(): void
     {
         $invokedScript = $this->workingDirectory.'/invoked-binary';
-        (new Filesystem())->touch($invokedScript);
+        $this->createExecutableBinary($invokedScript);
 
         self::assertSame($invokedScript, (new RunningBinaryLocator($this->workingDirectory.'/missing', $invokedScript, 'micro'))->path());
     }
@@ -84,7 +84,7 @@ final class RunningBinaryLocatorTest extends TestCase
         $binDirectory = $this->workingDirectory.'/real-bin';
         $decoyDirectory = $this->workingDirectory.'/decoy-bin';
         (new Filesystem())->mkdir([$decoyDirectory, $binDirectory]);
-        (new Filesystem())->touch($binDirectory.'/symfony-security-auditor');
+        $this->createExecutableBinary($binDirectory.'/symfony-security-auditor');
         $pathEnvironment = $decoyDirectory.\PATH_SEPARATOR.$binDirectory;
 
         self::assertSame(
@@ -100,13 +100,74 @@ final class RunningBinaryLocatorTest extends TestCase
     {
         $binDirectory = $this->workingDirectory.'/real-bin';
         (new Filesystem())->mkdir($binDirectory);
-        (new Filesystem())->touch($binDirectory.'/symfony-security-auditor');
+        $this->createExecutableBinary($binDirectory.'/symfony-security-auditor');
         $pathEnvironment = \PATH_SEPARATOR.$binDirectory;
 
         self::assertSame(
             $binDirectory.'/symfony-security-auditor',
             (new RunningBinaryLocator($this->workingDirectory.'/missing', 'symfony-security-auditor', 'micro', $pathEnvironment))->path(),
         );
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_skips_a_non_executable_path_entry_and_keeps_searching(): void
+    {
+        $decoyDirectory = $this->workingDirectory.'/decoy-bin';
+        $binDirectory = $this->workingDirectory.'/real-bin';
+        (new Filesystem())->mkdir([$decoyDirectory, $binDirectory]);
+        (new Filesystem())->dumpFile($decoyDirectory.'/symfony-security-auditor', 'not the binary');
+        (new Filesystem())->chmod($decoyDirectory.'/symfony-security-auditor', 0o644);
+        $this->createExecutableBinary($binDirectory.'/symfony-security-auditor');
+        $pathEnvironment = $decoyDirectory.\PATH_SEPARATOR.$binDirectory;
+
+        self::assertSame(
+            $binDirectory.'/symfony-security-auditor',
+            (new RunningBinaryLocator($this->workingDirectory.'/missing', 'symfony-security-auditor', 'micro', $pathEnvironment))->path(),
+        );
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_skips_a_path_directory_entry_named_like_the_binary(): void
+    {
+        $decoyDirectory = $this->workingDirectory.'/decoy-bin';
+        $binDirectory = $this->workingDirectory.'/real-bin';
+        (new Filesystem())->mkdir([$decoyDirectory.'/symfony-security-auditor', $binDirectory]);
+        $this->createExecutableBinary($binDirectory.'/symfony-security-auditor');
+        $pathEnvironment = $decoyDirectory.\PATH_SEPARATOR.$binDirectory;
+
+        self::assertSame(
+            $binDirectory.'/symfony-security-auditor',
+            (new RunningBinaryLocator($this->workingDirectory.'/missing', 'symfony-security-auditor', 'micro', $pathEnvironment))->path(),
+        );
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_it_skips_a_same_named_non_executable_working_directory_entry(): void
+    {
+        $workingDirectoryBefore = getcwd();
+        self::assertIsString($workingDirectoryBefore);
+        (new Filesystem())->dumpFile($this->workingDirectory.'/symfony-security-auditor', 'not the binary');
+        (new Filesystem())->chmod($this->workingDirectory.'/symfony-security-auditor', 0o644);
+        $binDirectory = $this->workingDirectory.'/real-bin';
+        (new Filesystem())->mkdir($binDirectory);
+        $this->createExecutableBinary($binDirectory.'/symfony-security-auditor');
+
+        chdir($this->workingDirectory);
+
+        try {
+            self::assertSame(
+                $binDirectory.'/symfony-security-auditor',
+                (new RunningBinaryLocator($this->workingDirectory.'/missing', 'symfony-security-auditor', 'micro', $binDirectory))->path(),
+            );
+        } finally {
+            chdir($workingDirectoryBefore);
+        }
     }
 
     /**
@@ -163,5 +224,11 @@ final class RunningBinaryLocatorTest extends TestCase
         $this->expectExceptionMessage('running under the "cli" PHP SAPI');
 
         (new RunningBinaryLocator($procSelfExe, '', 'cli'))->path();
+    }
+
+    private function createExecutableBinary(string $path): void
+    {
+        (new Filesystem())->dumpFile($path, 'binary');
+        (new Filesystem())->chmod($path, 0o755);
     }
 }


### PR DESCRIPTION
## Summary

On macOS (no `/proc/self/exe`), `RunningBinaryLocator` resolved the invoked name with `realpath()` against the working directory and then across `PATH`, accepting the **first hit of any kind** — unlike the shell, it never checked what it found. With a bare-name invocation (`symfony-security-auditor self-update`), a same-named entry could shadow the real binary:

- a stray `symfony-security-auditor` **regular file** in the current directory (a previously downloaded asset, a same-named clone artifact) was selected and silently **overwritten** by the downloaded release — `Updated from X to Y` reported, the real binary left outdated, and the update notice re-appearing on every run;
- a **directory** with that name (in the CWD or on an earlier `PATH` entry) made the replacement `rename()` fail.

### Fix

Both fallbacks (`resolvedEntryPath()` and the `PATH` walk) now accept only an **executable regular file** — the same rule the shell applies when it resolved the command in the first place. The kernel-reported `/proc/self/exe` path is authoritative and unchanged.

Changelog entry under `Unreleased → Fixed`.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — `RunningBinaryLocatorTest`: skips a non-executable `PATH` entry (kills the `is_executable` mutant), skips a directory entry named like the binary (kills the `is_file` mutant), and skips a same-named non-executable working-directory entry (the bare-name `realpath` branch); existing fixtures that legitimately stand in for the running binary are now created executable
- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `php -l` and `prettier@3.6.2 --check "**/*.md"` (composer deps aren't installable in the authoring environment)
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — each predicate in the new `executableFile()` guard is pinned by a dedicated skip test
- [x] No `createMock` without a matching `expects()` — filesystem fixtures only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)