### PR TITLE
fix(standalone): honor SSA_NO_UPDATE_CHECK=0

### DIFF
--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -106,7 +106,7 @@ final readonly class StandaloneApplicationFactory
      */
     public static function updateChecksDisabled(array $environment): bool
     {
-        return '' !== ($environment[self::UPDATE_CHECK_OPT_OUT_VARIABLE] ?? '');
+        return !\in_array($environment[self::UPDATE_CHECK_OPT_OUT_VARIABLE] ?? '', ['', '0'], true);
     }
 
     /**

--- a/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
@@ -138,6 +138,8 @@ final class StandaloneApplicationFactoryTest extends TestCase
         yield 'opt-out variable set' => [['SSA_NO_UPDATE_CHECK' => '1'], true];
         yield 'opt-out variable absent' => [[], false];
         yield 'opt-out variable empty' => [['SSA_NO_UPDATE_CHECK' => ''], false];
+        yield 'opt-out variable explicitly zero' => [['SSA_NO_UPDATE_CHECK' => '0'], false];
+        yield 'opt-out variable set to an arbitrary value' => [['SSA_NO_UPDATE_CHECK' => 'true'], true];
     }
 
     public function test_it_registers_the_audit_command_as_visible(): void


### PR DESCRIPTION
## Summary

`StandaloneApplicationFactory::updateChecksDisabled()` treated **any** non-empty value of `SSA_NO_UPDATE_CHECK` as an opt-out — so `SSA_NO_UPDATE_CHECK=0`, the natural way to say "leave the check on" (e.g. flipping a previously exported `1` back), *disabled* the update notice, contradicting the documented `SSA_NO_UPDATE_CHECK=1` contract.

Only a non-empty value other than `'0'` now opts out. `1`, `true`, or any other truthy-looking value still disable the check, so existing opt-outs keep working; the documented behavior is unchanged (`=1` disables), which is why the changelog's existing `Unreleased` entry for the notice feature stays as-is.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated — two new `updateCheckOptOutCases` provider entries: `'0'` keeps checks enabled, an arbitrary non-empty value still disables (pins the `in_array` haystack against mutation)
- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `php -l` (composer deps aren't installable in the authoring environment)
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — both directions of the predicate are pinned by the provider
- [x] No `createMock` without a matching `expects()` — pure data-provider test
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)