### PR TITLE
docs: correct init options adoption claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,10 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   (or, non-interactively, to its default: `anthropic`, `claude-opus-4-8`, and a
   `<PROVIDER>_API_KEY` variable derived from the resolved provider). This lets a
   single command configure any provider — e.g.
-  `init --provider=openai --model=gpt-5.4 --no-interaction` — which the
-  standalone installer's `SSA_INIT` flow and the GitHub Action use to set up
-  non-interactively. Documented in
+  `init --provider=openai --model=gpt-5.4 --no-interaction`. The standalone
+  installer's `SSA_INIT` no-terminal fallback and the GitHub Action run plain
+  `init --no-interaction` (the Anthropic defaults); pass the options yourself to
+  script a different provider. Documented in
   [`docs/configuration.md`](docs/configuration.md#standalone-configuration).
 - **`init --force` overwrites an existing configuration without asking.**
   Non-interactive reconfiguration was previously impossible: with a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -474,8 +474,10 @@ the matching prompt. Any option left out falls back to its interactive prompt
 and `<PROVIDER>_API_KEY` respectively). When a configuration already exists,
 `init` asks before overwriting it — and declines by default under
 `--no-interaction` — so scripted reconfiguration needs `--force` to replace the
-existing file without asking. This is what the `SSA_INIT` installer flag and the
-GitHub Action rely on to configure non-interactively:
+existing file without asking. The `SSA_INIT` installer flag's no-terminal
+fallback and the GitHub Action run plain `init --no-interaction`, which keeps
+those Anthropic defaults — pass the options yourself to script any other
+provider:
 
 ```bash
 symfony-security-auditor init --provider=openai --model=gpt-5.4 --no-interaction


### PR DESCRIPTION
## Summary

The `Unreleased` changelog entry for the scriptable `init` options says the single-command configuration is "…which the standalone installer's `SSA_INIT` flow and the GitHub Action **use** to set up non-interactively", and `docs/configuration.md` repeats it ("This is what the `SSA_INIT` installer flag and the GitHub Action rely on"). Neither is accurate: `install.sh`'s no-terminal fallback runs plain `init --no-interaction` (`install.sh:108`) and the GitHub Action's standalone configure step does the same (`action.yml:115`) — both keep the Anthropic defaults and pass none of the new options.

Reword both places to describe reality: the entry points default to `init --no-interaction`, and users script a different provider by passing `--provider`/`--model`/`--env-var` themselves. Docs only.

## Type of change

- [x] Documentation

## Checklist

- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `prettier@3.6.2 --check "**/*.md"`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)