### PR TITLE
docs: FAQ on auditing older Symfony and PHP

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -364,12 +364,27 @@ See [Configuration → Model Options](configuration.md#model-options).
 
 ### What PHP versions are supported?
 
-PHP **8.3+**. PHP 8.4 and 8.5 are supported via the CI matrix.
+Installing the **bundle** requires PHP **8.3+** in the host application (PHP 8.4
+and 8.5 are covered by the CI matrix). The **standalone binary** bundles its own
+PHP runtime, so the PHP version of the audited project does not matter.
 
 ### What Symfony versions are supported?
 
-Symfony **7.4+** and Symfony **8.x**. Check `composer.json` for the
-authoritative constraint.
+Installing the **bundle** requires Symfony **7.4+** or **8.x** in the host
+application — check `composer.json` for the authoritative constraint. The
+**standalone binary** imposes no Symfony version on the project it audits.
+
+### Can I audit a project on an older Symfony or PHP version?
+
+Yes — use the [standalone binary](../README.md#standalone-tool-binary) (or the
+GitHub Action, which installs it for you). The auditor never executes the
+audited project's code — it reads the sources — so a Symfony 4/5 app on an older
+PHP can be audited without adding any dependency to it. One caveat: detection is
+tuned for attribute- and YAML-era Symfony (`#[Route]`, `#[IsGranted]`,
+`security.yaml`). On annotation-based apps (`@Route`, `@IsGranted`) the LLM
+still reads the annotations in context, but the deterministic parsers that
+enrich the mapping stage target attributes, so route and access-control mapping
+may be less complete.
 
 ### Does it work on non-Symfony PHP projects?
 


### PR DESCRIPTION
## Summary

The FAQ's compatibility answers stated "PHP 8.3+" / "Symfony 7.4+" flatly, without saying those constraints only gate installing the **bundle** into a host application — leaving users on older stacks to conclude the tool can't help them, when the standalone binary (bundled PHP runtime, never executes the audited code) audits any project.

- Scopes the "What PHP versions / What Symfony versions are supported?" answers to the bundle, and notes the standalone binary imposes neither on the audited project.
- Adds **"Can I audit a project on an older Symfony or PHP version?"**: yes, via the standalone binary or the GitHub Action — with the honest caveat that the deterministic mapping parsers target attribute-era Symfony (`#[Route]`, `#[IsGranted]`, `security.yaml`), so annotation-based apps may see less complete route/access-control mapping even though the LLM still reads the annotations in context.

Docs only. Complements #208 (badges scoped to the bundle install step).

## Type of change

- [x] Documentation

## Checklist

- [x] All checks pass: `bin/castor lint` — runs on CI; locally verified with `prettier@3.6.2 --check "**/*.md"` and `markdownlint-cli2 docs/faq.md`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)