### PR TITLE
chore: release 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.17.0] — 2026-07-23 — Preflight
+
+A release about the standalone binary looking after itself. The binary now tells
+you when a newer release is available (throttled, interactive-only,
+stderr-only), a single `curl … | SSA_INIT=1 sh` installs _and_ configures it,
+`init` is fully scriptable (`--provider`/`--model`/`--env-var`/`--force`) with
+its inputs validated before anything is written, and the new `doctor` command
+preflights the whole environment — including actually booting the audit with the
+installed provider bridge — before a run. A pre-release bug hunt hardened the
+same surface: `v`-prefixed tags can no longer disable update detection, metadata
+lookups are tightly bounded, and non-UTF-8 input is rejected instead of
+crashing.
+
 ### Added
 
 - **The standalone binary now tells you when a newer release is available.**
@@ -2722,6 +2735,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.17.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.17.0
 [1.16.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.16.0
 [1.15.0]:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   (or, non-interactively, to its default: `anthropic`, `claude-opus-4-8`, and a
   `<PROVIDER>_API_KEY` variable derived from the resolved provider). This lets a
   single command configure any provider — e.g.
-  `init --provider=openai --model=gpt-5.4 --no-interaction`. The standalone
-  installer's `SSA_INIT` no-terminal fallback and the GitHub Action run plain
+  `init --provider=openai --model=gpt-5.4 --no-interaction`. Inputs are
+  validated before anything happens: a blank provider or model, or an
+  `--env-var` value that is not a valid environment variable name (which would
+  produce an unresolvable `%env(...)%` placeholder), aborts with exit code `2`
+  and leaves both the configuration and the bridge untouched. The bridge is
+  installed **before** the configuration file is written, so a failed bridge
+  download (offline, `composer` missing) leaves the previous, working
+  configuration in place instead of a half-switched setup whose config names one
+  provider while the installed bridge serves another. The standalone installer's
+  `SSA_INIT` no-terminal fallback and the GitHub Action run plain
   `init --no-interaction` (the Anthropic defaults); pass the options yourself to
   script a different provider. Documented in
   [`docs/configuration.md`](docs/configuration.md#standalone-configuration).
@@ -67,14 +75,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   line each: **Configuration** (`config.yaml` resolves, a `platform:` block is
   present, and any `%env(...)%` API-key variable it references is set),
   **Provider bridge** (the `symfony/ai-*` bridge autoloader is installed under
-  the data directory), and **Composer** (a runnable `composer` is reachable). A
-  missing `composer` is a warning — auditing still works — while a
-  missing/invalid configuration or an uninstalled bridge is a failure. The
-  command exits `0` when every check passes or only warns and `1` when any check
-  fails, so it drops into a CI preflight step
+  the data directory _and the audit actually boots with it_ — the probe runs the
+  exact configuration-load → container-build → command-instantiation path
+  `audit` uses at startup, so a leftover bridge from a previously configured
+  provider is reported as a failure instead of green-lighting an audit that
+  would abort at boot), and **Composer** (a runnable `composer` is reachable,
+  resolved the way a shell resolves it — including the `composer.bat`/`.cmd`
+  shims on Windows, which `Process` alone does not find). A missing `composer`
+  is a warning — auditing still works — while a missing/invalid configuration or
+  an uninstalled/unbootable bridge is a failure. The boot probe is skipped while
+  the configuration check fails, so a config problem is reported once, by the
+  check that owns it. The command exits `0` when every check passes or only
+  warns and `1` when any check fails, so it drops into a CI preflight step
   (`symfony-security-auditor doctor && symfony-security-auditor audit`). The
   command exists only in the standalone binary. Implemented by `DoctorCommand`
-  delegating to `EnvironmentDoctor` (`src/Command/`), wired into the standalone
+  delegating to `EnvironmentDoctor` (`src/Command/`), with the boot probe behind
+  `AuditPreflightInterface` (`src/Command/`) implemented by
+  `StandaloneAuditPreflight` (`src/Standalone/`), wired into the standalone
   application by `StandaloneApplicationFactory`.
 
 ### Changed
@@ -95,6 +112,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **A `v`-prefixed release tag can no longer silently disable update
+  detection.** `SelfUpdater` compared GitHub's `tag_name` verbatim, and PHP's
+  `version_compare()` ranks any `v`-prefixed string _below_ every plain version
+  — `version_compare('v1.18.0', '1.16.0', '>')` is `false` — so if a release
+  were ever tagged `v1.18.0` instead of `1.18.0`, `self-update` would report
+  "Already up to date" and the update notice would stay silent, with no error
+  anywhere. The tag is now compared and displayed with any leading `v`/`V`
+  stripped, while download URLs keep the tag verbatim (that is the path the
+  release assets publish under).
+- **The update check can no longer stall an interactive command on a black-holed
+  network.** `ProcessReleaseClient` gave every request the binary-download
+  budget — `--connect-timeout 30` and `--max-time 600` — so a firewall that
+  silently drops packets could hold the after-command update notice (and
+  `self-update`'s metadata lookups) for up to 30 seconds on connect and minutes
+  on a stalled transfer. Release-metadata `get()` requests are now bounded to
+  `--connect-timeout 10` / `--max-time 20`; binary `download()` transfers keep
+  the generous 600-second window they need on slow links.
 - **`self-update`'s macOS fallbacks accept only executable regular files, so a
   same-named stray file or directory is never replaced instead of the running
   binary.** Without `/proc/self/exe`, `RunningBinaryLocator` `realpath()`ed the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,14 +79,13 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   exact configuration-load → container-build → command-instantiation path
   `audit` uses at startup, so a leftover bridge from a previously configured
   provider is reported as a failure instead of green-lighting an audit that
-  would abort at boot), and **Composer** (a runnable `composer` is reachable,
-  resolved the way a shell resolves it — including the `composer.bat`/`.cmd`
-  shims on Windows, which `Process` alone does not find). A missing `composer`
-  is a warning — auditing still works — while a missing/invalid configuration or
-  an uninstalled/unbootable bridge is a failure. The boot probe is skipped while
-  the configuration check fails, so a config problem is reported once, by the
-  check that owns it. The command exits `0` when every check passes or only
-  warns and `1` when any check fails, so it drops into a CI preflight step
+  would abort at boot), and **Composer** (a runnable `composer` is reachable). A
+  missing `composer` is a warning — auditing still works — while a
+  missing/invalid configuration or an uninstalled/unbootable bridge is a
+  failure. The boot probe is skipped while the configuration check fails, so a
+  config problem is reported once, by the check that owns it. The command exits
+  `0` when every check passes or only warns and `1` when any check fails, so it
+  drops into a CI preflight step
   (`symfony-security-auditor doctor && symfony-security-auditor audit`). The
   command exists only in the standalone binary. Implemented by `DoctorCommand`
   delegating to `EnvironmentDoctor` (`src/Command/`), with the boot probe behind

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ bin/console audit:run --dry-run
   report and exit code so only new findings fail CI.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.16.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.17.0`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **DDD architecture** — strict layering and a sole `LLMClientInterface` seam

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.16.0
+        uses: vinceamstoutz/symfony-security-auditor@1.17.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -206,7 +206,7 @@ Outputs: `exit-code`, `report-path`, and — only when `format: json` —
 ```yaml
       - name: Symfony Security Audit
         id: audit
-        uses: vinceamstoutz/symfony-security-auditor@1.16.0
+        uses: vinceamstoutz/symfony-security-auditor@1.17.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -237,7 +237,7 @@ tradeoffs.
 
 ```yaml
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.16.0
+        uses: vinceamstoutz/symfony-security-auditor@1.17.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -471,13 +471,17 @@ model: claude-opus-4-8
 `init` is also scriptable: pass `--provider`, `--model`, and `--env-var` to skip
 the matching prompt. Any option left out falls back to its interactive prompt
 (or, under `--no-interaction`, to its default — `anthropic`, `claude-opus-4-8`,
-and `<PROVIDER>_API_KEY` respectively). When a configuration already exists,
-`init` asks before overwriting it — and declines by default under
-`--no-interaction` — so scripted reconfiguration needs `--force` to replace the
-existing file without asking. The `SSA_INIT` installer flag's no-terminal
-fallback and the GitHub Action run plain `init --no-interaction`, which keeps
-those Anthropic defaults — pass the options yourself to script any other
-provider:
+and `<PROVIDER>_API_KEY` respectively). A blank provider or model, or an
+`--env-var` that is not a valid environment variable name, is rejected with exit
+code `2` before anything is written. The provider bridge is downloaded
+**before** the configuration file is replaced, so a failed download (offline,
+`composer` missing) leaves the previous, working configuration untouched. When a
+configuration already exists, `init` asks before overwriting it — and declines
+by default under `--no-interaction` — so scripted reconfiguration needs
+`--force` to replace the existing file without asking. The `SSA_INIT` installer
+flag's no-terminal fallback and the GitHub Action run plain
+`init --no-interaction`, which keeps those Anthropic defaults — pass the options
+yourself to script any other provider:
 
 ```bash
 symfony-security-auditor init --provider=openai --model=gpt-5.4 --no-interaction
@@ -776,11 +780,11 @@ symfony-security-auditor doctor
 
 It runs three checks and prints one line for each:
 
-| Check           | What it verifies                                                                                                   |
-| --------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Configuration   | `config.yaml` resolves, a `platform:` block is present, and any `%env(...)%` API-key variable it references is set |
-| Provider bridge | the `symfony/ai-*` bridge autoloader is installed under the data directory (`init` downloads it)                   |
-| Composer        | a runnable `composer` is reachable — needed only to run `init` or switch providers, not to audit                   |
+| Check           | What it verifies                                                                                                                                                                                               |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Configuration   | `config.yaml` resolves, a `platform:` block is present, and any `%env(...)%` API-key variable it references is set                                                                                             |
+| Provider bridge | the `symfony/ai-*` bridge autoloader is installed under the data directory (`init` downloads it) **and the audit actually boots with it** — a leftover bridge from a previously configured provider fails here |
+| Composer        | a runnable `composer` is reachable — needed only to run `init` or switch providers, not to audit                                                                                                               |
 
 A missing `composer` is reported as a **warning** (auditing still works); a
 missing/invalid configuration or an uninstalled bridge is a **failure**. The

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -787,9 +787,9 @@ It runs three checks and prints one line for each:
 | Composer        | a runnable `composer` is reachable — needed only to run `init` or switch providers, not to audit                                                                                                               |
 
 A missing `composer` is reported as a **warning** (auditing still works); a
-missing/invalid configuration or an uninstalled bridge is a **failure**. The
-command exits `0` when every check passes or only warns, and `1` when any check
-fails, so it drops into a CI preflight step:
+missing/invalid configuration or an uninstalled — or unbootable — bridge is a
+**failure**. The command exits `0` when every check passes or only warns, and
+`1` when any check fails, so it drops into a CI preflight step:
 
 ```bash
 symfony-security-auditor doctor && symfony-security-auditor audit path/to/app

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -162,7 +162,7 @@ deprecated by the other.
   inputs/outputs may be added in a `MINOR`; renaming or removing one is a
   `MAJOR`. The Marketplace `name` (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.16.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.17.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.16.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.17.0/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",

--- a/src/Audit/Infrastructure/SelfUpdate/ProcessReleaseClient.php
+++ b/src/Audit/Infrastructure/SelfUpdate/ProcessReleaseClient.php
@@ -22,7 +22,10 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Excepti
 /**
  * Fetches release metadata and assets with `curl` through Symfony `Process` —
  * the same subprocess-only convention `ComposerBridgeInstaller` uses — so the
- * binary needs no bundled HTTP client.
+ * binary needs no bundled HTTP client. Metadata lookups (`get()`) run behind
+ * the after-command update notice, so they are bounded tightly; only binary
+ * downloads (`download()`) keep a transfer window sized for a large asset on
+ * a slow link.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -30,9 +33,11 @@ final readonly class ProcessReleaseClient implements ReleaseClientInterface
 {
     private const string USER_AGENT = 'symfony-security-auditor-self-update';
 
-    private const string CONNECT_TIMEOUT_SECONDS = '30';
+    private const string CONNECT_TIMEOUT_SECONDS = '10';
 
-    private const string MAX_TRANSFER_SECONDS = '600';
+    private const string METADATA_MAX_TRANSFER_SECONDS = '20';
+
+    private const string DOWNLOAD_MAX_TRANSFER_SECONDS = '600';
 
     private const float PROCESS_TIMEOUT_SECONDS = 660.0;
 
@@ -57,8 +62,6 @@ final readonly class ProcessReleaseClient implements ReleaseClientInterface
                     '-fsSL',
                     '--connect-timeout',
                     self::CONNECT_TIMEOUT_SECONDS,
-                    '--max-time',
-                    self::MAX_TRANSFER_SECONDS,
                     '-H',
                     \sprintf('User-Agent: %s', self::USER_AGENT),
                     ...$arguments,
@@ -76,7 +79,7 @@ final readonly class ProcessReleaseClient implements ReleaseClientInterface
     #[Override]
     public function get(string $url): string
     {
-        return $this->run([$url], $url)->getOutput();
+        return $this->run(['--max-time', self::METADATA_MAX_TRANSFER_SECONDS, $url], $url)->getOutput();
     }
 
     /**
@@ -85,7 +88,7 @@ final readonly class ProcessReleaseClient implements ReleaseClientInterface
     #[Override]
     public function download(string $url, string $destination): void
     {
-        $this->run(['--output', $destination, $url], $url);
+        $this->run(['--max-time', self::DOWNLOAD_MAX_TRANSFER_SECONDS, '--output', $destination, $url], $url);
     }
 
     /**

--- a/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
+++ b/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
@@ -20,7 +20,17 @@ use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\SelfUpdateFailedException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Exception\UnsupportedSelfUpdatePlatformException;
 
-/** @internal not part of the BC promise — see docs/versioning.md */
+use function Symfony\Component\String\u;
+
+/**
+ * The GitHub release tag is compared and reported with any leading `v`/`V`
+ * stripped — `version_compare()` ranks a raw `v1.2.3` *below* every plain
+ * `1.2.3`, which would silently disable update detection if a release were
+ * ever tagged with the prefix — while asset URLs keep the tag verbatim, since
+ * that is the path the release publishes under.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
 final readonly class SelfUpdater implements SelfUpdaterInterface
 {
     private const string LATEST_RELEASE_API_URL = 'https://api.github.com/repos/vinceAmstoutz/symfony-security-auditor/releases/latest';
@@ -41,7 +51,8 @@ final readonly class SelfUpdater implements SelfUpdaterInterface
     {
         $this->gitHubBinaryAssetResolver->assertSupportedPlatform();
 
-        $latestVersion = $this->latestVersion();
+        $latestTag = $this->latestTag();
+        $latestVersion = u($latestTag)->trimPrefix(['v', 'V'])->toString();
 
         if (!version_compare($latestVersion, $currentVersion, '>')) {
             return new SelfUpdateResult(SelfUpdateStatus::AlreadyUpToDate, $currentVersion, $latestVersion);
@@ -51,7 +62,7 @@ final readonly class SelfUpdater implements SelfUpdaterInterface
             return new SelfUpdateResult(SelfUpdateStatus::UpdateAvailable, $currentVersion, $latestVersion);
         }
 
-        $this->replaceBinary($this->gitHubBinaryAssetResolver->resolve($latestVersion));
+        $this->replaceBinary($this->gitHubBinaryAssetResolver->resolve($latestTag));
 
         return new SelfUpdateResult(SelfUpdateStatus::Updated, $currentVersion, $latestVersion);
     }
@@ -59,7 +70,7 @@ final readonly class SelfUpdater implements SelfUpdaterInterface
     /**
      * @throws SelfUpdateFailedException
      */
-    private function latestVersion(): string
+    private function latestTag(): string
     {
         $payload = $this->releaseClient->get(self::LATEST_RELEASE_API_URL);
 

--- a/src/Command/AuditPreflightInterface.php
+++ b/src/Command/AuditPreflightInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
+
+/**
+ * Attempts to assemble the audit command exactly the way `audit` does at
+ * startup, without running it, so a preflight can report why an audit would
+ * fail to boot before one is attempted.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+interface AuditPreflightInterface
+{
+    public function failureReason(): ?string;
+}

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -21,7 +21,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\U
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 
-use function Symfony\Component\String\u;
+use function Symfony\Component\String\b;
 
 /**
  * Preflight for the standalone binary: confirms the configuration resolves
@@ -101,9 +101,14 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
             : new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, $this->bootFailureDetail($failureReason));
     }
 
+    /**
+     * The reason is an arbitrary `Throwable` message from the boot probe and
+     * may contain non-UTF-8 bytes (paths, quoted file contents), so it is
+     * handled byte-safely — `u()` would throw on it and mask the diagnosis.
+     */
     private function bootFailureDetail(string $failureReason): string
     {
-        $reason = u($failureReason)->trim()->toString();
+        $reason = b($failureReason)->trim()->toString();
 
         return '' === $reason
             ? 'Installed, but the audit cannot start with it (the boot failed without an error message).'

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -24,8 +24,12 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPa
 /**
  * Preflight for the standalone binary: confirms the configuration resolves
  * (file present, valid, provider selected, API-key variable set), the provider
- * bridge is installed, and `composer` is reachable — the prerequisites for a
- * successful audit run.
+ * bridge is installed *and actually boots the audit for the configured
+ * provider* (a leftover bridge from a previously configured provider passes a
+ * file-existence check but not a boot), and `composer` is reachable — the
+ * prerequisites for a successful audit run. The boot probe is skipped while
+ * the configuration check fails, so a config problem is reported once, by the
+ * check that owns it.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -37,6 +41,7 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
         private StandaloneConfigLoader $standaloneConfigLoader,
         private XdgConfigPathResolver $xdgConfigPathResolver,
         private ComposerAvailabilityCheckerInterface $composerAvailabilityChecker,
+        private AuditPreflightInterface $auditPreflight,
     ) {}
 
     /**
@@ -45,9 +50,11 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
     #[Override]
     public function diagnose(): array
     {
+        $doctorCheckResult = $this->configurationCheck();
+
         return [
-            $this->configurationCheck(),
-            $this->bridgeCheck(),
+            $doctorCheckResult,
+            $this->bridgeCheck(DoctorCheckStatus::Ok === $doctorCheckResult->status),
             $this->composerCheck(),
         ];
     }
@@ -69,7 +76,7 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
         return new DoctorCheckResult('Configuration', DoctorCheckStatus::Ok, 'Config resolves and the API-key variable is set.');
     }
 
-    private function bridgeCheck(): DoctorCheckResult
+    private function bridgeCheck(bool $configurationResolves): DoctorCheckResult
     {
         try {
             $bridgeAutoloadFile = \sprintf('%s/%s', $this->xdgConfigPathResolver->dataDir(), self::BRIDGE_AUTOLOAD_RELATIVE_PATH);
@@ -77,9 +84,19 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
             return new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, $unresolvableConfigPathException->getMessage());
         }
 
-        return is_file($bridgeAutoloadFile)
-            ? new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed.')
-            : new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, 'Not installed — run "init" to download it.');
+        if (!is_file($bridgeAutoloadFile)) {
+            return new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, 'Not installed — run "init" to download it.');
+        }
+
+        if (!$configurationResolves) {
+            return new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed.');
+        }
+
+        $failureReason = $this->auditPreflight->failureReason();
+
+        return null === $failureReason
+            ? new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed and the audit boots with it.')
+            : new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, \sprintf('Installed, but the audit cannot start with it: %s', $failureReason));
     }
 
     private function composerCheck(): DoctorCheckResult

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -21,6 +21,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\U
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 
+use function Symfony\Component\String\u;
+
 /**
  * Preflight for the standalone binary: confirms the configuration resolves
  * (file present, valid, provider selected, API-key variable set), the provider
@@ -96,7 +98,16 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
 
         return null === $failureReason
             ? new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed and the audit boots with it.')
-            : new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, \sprintf('Installed, but the audit cannot start with it: %s', $failureReason));
+            : new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, $this->bootFailureDetail($failureReason));
+    }
+
+    private function bootFailureDetail(string $failureReason): string
+    {
+        $reason = u($failureReason)->trim()->toString();
+
+        return '' === $reason
+            ? 'Installed, but the audit cannot start with it (the boot failed without an error message).'
+            : \sprintf('Installed, but the audit cannot start with it: %s', $reason);
     }
 
     private function composerCheck(): DoctorCheckResult

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -26,6 +26,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneC
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigWriterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 
+use function Symfony\Component\String\b;
 use function Symfony\Component\String\u;
 
 /** @internal not part of the BC promise — the command *name* (`init`) is public, but the PHP class itself is for internal use only. */
@@ -70,14 +71,21 @@ final readonly class InitCommand
             return Command::SUCCESS;
         }
 
-        $provider ??= $this->ask($symfonyStyle, 'Which AI provider do you want to use? (any symfony/ai platform — e.g. anthropic, openai, gemini, mistral, ollama)', 'anthropic');
-        $provider = $this->providerKeyNormalizer->normalize($provider);
-        $model = u($model ?? $this->ask($symfonyStyle, 'Which model should the auditor use?', 'claude-opus-4-8'))->trim()->toString();
-        $envVar = u($envVar ?? $this->ask($symfonyStyle, 'Which environment variable holds the API key?', $this->defaultApiKeyVariable($provider)))->trim()->toString();
+        $provider = b($provider ?? $this->ask($symfonyStyle, 'Which AI provider do you want to use? (any symfony/ai platform — e.g. anthropic, openai, gemini, mistral, ollama)', 'anthropic'))->trim()->toString();
+        $model = b($model ?? $this->ask($symfonyStyle, 'Which model should the auditor use?', 'claude-opus-4-8'))->trim()->toString();
 
-        $violation = $this->inputViolation($provider, $model, $envVar);
+        $violation = $this->identityViolation($provider, $model);
         if (null !== $violation) {
             $symfonyStyle->error($violation);
+
+            return Command::INVALID;
+        }
+
+        $provider = $this->providerKeyNormalizer->normalize($provider);
+        $envVar = b($envVar ?? $this->ask($symfonyStyle, 'Which environment variable holds the API key?', $this->defaultApiKeyVariable($provider)))->trim()->toString();
+
+        if (1 !== preg_match(self::ENV_VAR_NAME_PATTERN, $envVar)) {
+            $symfonyStyle->error(\sprintf('"%s" is not a valid environment variable name (letters, digits, and underscores only; must not start with a digit).', $envVar));
 
             return Command::INVALID;
         }
@@ -90,21 +98,20 @@ final readonly class InitCommand
         return Command::SUCCESS;
     }
 
-    private function inputViolation(string $provider, string $model, string $envVar): ?string
+    /**
+     * Checked on the raw bytes, before `ProviderKeyNormalizer` — its `u()`
+     * call throws on non-UTF-8 input, which must reject with exit code 2
+     * instead of crashing.
+     */
+    private function identityViolation(string $provider, string $model): ?string
     {
-        if ('' === $provider) {
-            return 'The provider must not be empty.';
-        }
-
-        if ('' === $model) {
-            return 'The model must not be empty.';
-        }
-
-        if (1 !== preg_match(self::ENV_VAR_NAME_PATTERN, $envVar)) {
-            return \sprintf('"%s" is not a valid environment variable name (letters, digits, and underscores only; must not start with a digit).', $envVar);
-        }
-
-        return null;
+        return match (true) {
+            1 !== preg_match('//u', $provider) => 'The provider must be valid UTF-8 text.',
+            '' === $provider => 'The provider must not be empty.',
+            1 !== preg_match('//u', $model) => 'The model must be valid UTF-8 text.',
+            '' === $model => 'The model must not be empty.',
+            default => null,
+        };
     }
 
     private function isOverwriteDeclined(SymfonyStyle $symfonyStyle, string $configFile): bool

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -36,6 +36,8 @@ final readonly class InitCommand
 
     public const string DESCRIPTION = 'Create the standalone configuration and download the selected provider bridge';
 
+    private const string ENV_VAR_NAME_PATTERN = '/^[A-Za-z_]\w*$/';
+
     public function __construct(
         private XdgConfigPathResolver $xdgConfigPathResolver,
         private StandaloneConfigFactoryInterface $standaloneConfigFactory,
@@ -70,15 +72,39 @@ final readonly class InitCommand
 
         $provider ??= $this->ask($symfonyStyle, 'Which AI provider do you want to use? (any symfony/ai platform — e.g. anthropic, openai, gemini, mistral, ollama)', 'anthropic');
         $provider = $this->providerKeyNormalizer->normalize($provider);
-        $model ??= $this->ask($symfonyStyle, 'Which model should the auditor use?', 'claude-opus-4-8');
-        $envVar ??= $this->ask($symfonyStyle, 'Which environment variable holds the API key?', $this->defaultApiKeyVariable($provider));
+        $model = u($model ?? $this->ask($symfonyStyle, 'Which model should the auditor use?', 'claude-opus-4-8'))->trim()->toString();
+        $envVar = u($envVar ?? $this->ask($symfonyStyle, 'Which environment variable holds the API key?', $this->defaultApiKeyVariable($provider)))->trim()->toString();
 
-        $this->standaloneConfigWriter->write($configFile, $this->standaloneConfigFactory->create($provider, $model, $envVar));
+        $violation = $this->inputViolation($provider, $model, $envVar);
+        if (null !== $violation) {
+            $symfonyStyle->error($violation);
+
+            return Command::INVALID;
+        }
+
         $this->bridgeInstaller->install($provider, $this->xdgConfigPathResolver->dataDir());
+        $this->standaloneConfigWriter->write($configFile, $this->standaloneConfigFactory->create($provider, $model, $envVar));
 
         $symfonyStyle->success(\sprintf('Configuration written to %s. Export %s, then run "audit <path>".', $configFile, $envVar));
 
         return Command::SUCCESS;
+    }
+
+    private function inputViolation(string $provider, string $model, string $envVar): ?string
+    {
+        if ('' === $provider) {
+            return 'The provider must not be empty.';
+        }
+
+        if ('' === $model) {
+            return 'The model must not be empty.';
+        }
+
+        if (1 !== preg_match(self::ENV_VAR_NAME_PATTERN, $envVar)) {
+            return \sprintf('"%s" is not a valid environment variable name (letters, digits, and underscores only; must not start with a digit).', $envVar);
+        }
+
+        return null;
     }
 
     private function isOverwriteDeclined(SymfonyStyle $symfonyStyle, string $configFile): bool

--- a/src/Command/ProcessComposerAvailabilityChecker.php
+++ b/src/Command/ProcessComposerAvailabilityChecker.php
@@ -16,16 +16,15 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 use Closure;
 use Override;
 use Symfony\Component\Process\Exception\ExceptionInterface;
-use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
  * Probes for a runnable `composer` by executing `composer --version` through
  * Symfony `Process` — the same subprocess-only convention the rest of the tool
- * uses (no raw shell, no argument-interpolation surface). The executable is
- * resolved through `ExecutableFinder` first: `Process` does not consult
- * `PATHEXT`, so a bare `composer` misses the `composer.bat`/`composer.cmd`
- * shims a Windows shell would find.
+ * uses (no raw shell, no argument-interpolation surface). A bare `composer`
+ * argv[0] is sufficient on every platform: `Process` resolves it through its
+ * own `ExecutableFinder`, which consults `PATHEXT` on Windows and so finds the
+ * `composer.bat`/`composer.cmd` shims too.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -46,8 +45,7 @@ final readonly class ProcessComposerAvailabilityChecker implements ComposerAvail
     public static function defaultProcessBuilder(): Closure
     {
         return static function (): Process {
-            $composer = (new ExecutableFinder())->find('composer') ?? 'composer';
-            $process = new Process([$composer, '--version']);
+            $process = new Process(['composer', '--version']);
             $process->setTimeout(self::PROCESS_TIMEOUT_SECONDS);
 
             return $process;

--- a/src/Command/ProcessComposerAvailabilityChecker.php
+++ b/src/Command/ProcessComposerAvailabilityChecker.php
@@ -16,12 +16,16 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 use Closure;
 use Override;
 use Symfony\Component\Process\Exception\ExceptionInterface;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
  * Probes for a runnable `composer` by executing `composer --version` through
  * Symfony `Process` — the same subprocess-only convention the rest of the tool
- * uses (no raw shell, no argument-interpolation surface).
+ * uses (no raw shell, no argument-interpolation surface). The executable is
+ * resolved through `ExecutableFinder` first: `Process` does not consult
+ * `PATHEXT`, so a bare `composer` misses the `composer.bat`/`composer.cmd`
+ * shims a Windows shell would find.
  *
  * @internal not part of the BC promise — see docs/versioning.md
  */
@@ -42,7 +46,8 @@ final readonly class ProcessComposerAvailabilityChecker implements ComposerAvail
     public static function defaultProcessBuilder(): Closure
     {
         return static function (): Process {
-            $process = new Process(['composer', '--version']);
+            $composer = (new ExecutableFinder())->find('composer') ?? 'composer';
+            $process = new Process([$composer, '--version']);
             $process->setTimeout(self::PROCESS_TIMEOUT_SECONDS);
 
             return $process;

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -223,6 +223,12 @@ final readonly class StandaloneApplicationFactory
                 $this->standaloneConfigLoader,
                 $this->xdgConfigPathResolver,
                 new ProcessComposerAvailabilityChecker(ProcessComposerAvailabilityChecker::defaultProcessBuilder()),
+                new StandaloneAuditPreflight(
+                    $this->standaloneConfigLoader,
+                    $this->xdgConfigPathResolver,
+                    $this->standaloneContainerFactory,
+                    $this->standaloneConsoleCommandFactory,
+                ),
             ),
         );
     }

--- a/src/Standalone/StandaloneAuditPreflight.php
+++ b/src/Standalone/StandaloneAuditPreflight.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Standalone;
+
+use Override;
+use Throwable;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditPreflightInterface;
+
+/**
+ * Boots the audit command through the exact same factories `audit` uses at
+ * startup — configuration load, container build and compile, command
+ * instantiation — so its verdict matches what an actual audit run would hit.
+ * Every failure is reported as a reason string rather than thrown: the caller
+ * is a diagnostic, and whatever aborts the boot is precisely its finding.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class StandaloneAuditPreflight implements AuditPreflightInterface
+{
+    public function __construct(
+        private StandaloneConfigLoader $standaloneConfigLoader,
+        private XdgConfigPathResolver $xdgConfigPathResolver,
+        private StandaloneContainerFactory $standaloneContainerFactory = new StandaloneContainerFactory(),
+        private StandaloneConsoleCommandFactory $standaloneConsoleCommandFactory = new StandaloneConsoleCommandFactory(),
+    ) {}
+
+    #[Override]
+    public function failureReason(): ?string
+    {
+        try {
+            $this->standaloneConsoleCommandFactory->create(
+                $this->standaloneContainerFactory->create(
+                    $this->standaloneConfigLoader->load(),
+                    $this->xdgConfigPathResolver->cacheDir(),
+                ),
+            );
+        } catch (Throwable $throwable) {
+            return $throwable->getMessage();
+        }
+
+        return null;
+    }
+}

--- a/tests/Phpunit/EndToEnd/StandaloneDoctorEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/StandaloneDoctorEndToEndTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\EndToEnd;
 
+use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
 use Override;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -47,11 +49,13 @@ final class StandaloneDoctorEndToEndTest extends TestCase
         $this->filesystem->remove([$this->configHome, $this->cacheHome, $this->dataHome]);
     }
 
+    #[RunInSeparateProcess]
+    #[MaximumDuration(4000)]
     public function test_the_standalone_doctor_reports_a_ready_environment_end_to_end(): void
     {
         $this->filesystem->dumpFile(
             $this->configHome.'/symfony-security-auditor/config.yaml',
-            "platform:\n    openai:\n        api_key: 'sk-e2e'\nmodel: 'gpt-4'\n",
+            "platform:\n    generic:\n        default:\n            base_url: 'http://localhost'\nmodel: 'gpt-4'\n",
         );
         $this->filesystem->dumpFile($this->dataHome.'/symfony-security-auditor/vendor/autoload.php', "<?php\n");
 
@@ -63,6 +67,24 @@ final class StandaloneDoctorEndToEndTest extends TestCase
         $display = $commandTester->getDisplay();
         self::assertStringContainsString('[OK] Configuration:', $display);
         self::assertStringContainsString('[OK] Provider bridge:', $display);
+    }
+
+    #[RunInSeparateProcess]
+    #[MaximumDuration(4000)]
+    public function test_the_standalone_doctor_fails_end_to_end_when_the_installed_bridge_does_not_match_the_provider(): void
+    {
+        $this->filesystem->dumpFile(
+            $this->configHome.'/symfony-security-auditor/config.yaml',
+            "provider: openai\nplatform:\n    openai:\n        api_key: 'sk-e2e'\nmodel: 'gpt-4'\n",
+        );
+        $this->filesystem->dumpFile($this->dataHome.'/symfony-security-auditor/vendor/autoload.php', "<?php\n");
+
+        $commandTester = $this->doctorCommandTester();
+
+        $exitCode = $commandTester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Installed, but the audit cannot start with it', $commandTester->getDisplay());
     }
 
     public function test_the_standalone_doctor_fails_end_to_end_when_the_environment_is_not_configured(): void

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -21,6 +21,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\U
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfigResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditPreflightInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ComposerAvailabilityCheckerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCheckResult;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCheckStatus;
@@ -58,9 +59,35 @@ final class EnvironmentDoctorTest extends TestCase
 
         self::assertEquals([
             new DoctorCheckResult('Configuration', DoctorCheckStatus::Ok, 'Config resolves and the API-key variable is set.'),
-            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed.'),
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed and the audit boots with it.'),
             new DoctorCheckResult('Composer', DoctorCheckStatus::Ok, 'Available.'),
         ], $results);
+    }
+
+    public function test_it_fails_the_bridge_check_when_the_installed_bridge_cannot_boot_the_audit(): void
+    {
+        $this->writeConfig("provider: openai\nplatform:\n    openai:\n        api_key: 'sk-test'\n");
+        $this->installBridge();
+
+        $results = $this->doctorWith($this->resolver(), [], true, 'The "openai" platform is not registered.')->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, 'Installed, but the audit cannot start with it: The "openai" platform is not registered.'),
+            $results[1],
+        );
+    }
+
+    public function test_it_reports_the_bridge_installed_without_a_boot_probe_when_the_configuration_check_fails(): void
+    {
+        $this->writeConfig("model: 'gpt-4'\n");
+        $this->installBridge();
+
+        $results = $this->doctorWith($this->resolver(), [], true, 'would only repeat the configuration failure')->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed.'),
+            $results[1],
+        );
     }
 
     public function test_it_fails_the_configuration_check_when_no_provider_is_configured(): void
@@ -137,15 +164,19 @@ final class EnvironmentDoctorTest extends TestCase
     /**
      * @param array<string, string> $environment
      */
-    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable): EnvironmentDoctor
+    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable, ?string $preflightFailure = null): EnvironmentDoctor
     {
         $composerAvailabilityChecker = self::createStub(ComposerAvailabilityCheckerInterface::class);
         $composerAvailabilityChecker->method('isAvailable')->willReturn($composerAvailable);
+
+        $auditPreflight = self::createStub(AuditPreflightInterface::class);
+        $auditPreflight->method('failureReason')->willReturn($preflightFailure);
 
         return new EnvironmentDoctor(
             new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver($environment)),
             $xdgConfigPathResolver,
             $composerAvailabilityChecker,
+            $auditPreflight,
         );
     }
 

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -77,6 +77,19 @@ final class EnvironmentDoctorTest extends TestCase
         );
     }
 
+    public function test_it_reports_a_boot_failure_whose_message_is_not_valid_utf8(): void
+    {
+        $this->writeConfig("provider: openai\nplatform:\n    openai:\n        api_key: 'sk-test'\n");
+        $this->installBridge();
+
+        $results = $this->doctorWith($this->resolver(), [], true, "boom in \xAF\xFE dir")->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, "Installed, but the audit cannot start with it: boom in \xAF\xFE dir"),
+            $results[1],
+        );
+    }
+
     public function test_it_reports_a_boot_failure_without_a_message_in_plain_words(): void
     {
         $this->writeConfig("provider: openai\nplatform:\n    openai:\n        api_key: 'sk-test'\n");

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -77,6 +77,19 @@ final class EnvironmentDoctorTest extends TestCase
         );
     }
 
+    public function test_it_reports_a_boot_failure_without_a_message_in_plain_words(): void
+    {
+        $this->writeConfig("provider: openai\nplatform:\n    openai:\n        api_key: 'sk-test'\n");
+        $this->installBridge();
+
+        $results = $this->doctorWith($this->resolver(), [], true, '   ')->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Failure, 'Installed, but the audit cannot start with it (the boot failed without an error message).'),
+            $results[1],
+        );
+    }
+
     public function test_it_reports_the_bridge_installed_without_a_boot_probe_when_the_configuration_check_fails(): void
     {
         $this->writeConfig("model: 'gpt-4'\n");

--- a/tests/Phpunit/Integration/Command/Fixture/FailingBridgeInstaller.php
+++ b/tests/Phpunit/Integration/Command/Fixture/FailingBridgeInstaller.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Fixture;
+
+use Override;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\BridgeInstallerInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\Exception\BridgeInstallationFailedException;
+
+/**
+ * Test fake — fails every bridge installation, the way a network or composer
+ * outage would.
+ *
+ * @internal scoped to InitCommandTest
+ */
+final class FailingBridgeInstaller implements BridgeInstallerInterface
+{
+    /**
+     * @throws BridgeInstallationFailedException
+     */
+    #[Override]
+    public function install(string $provider, string $targetDirectory): void
+    {
+        throw BridgeInstallationFailedException::forFailedProcess($provider, 'simulated outage');
+    }
+}

--- a/tests/Phpunit/Integration/Command/InitCommandTest.php
+++ b/tests/Phpunit/Integration/Command/InitCommandTest.php
@@ -14,15 +14,18 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command;
 
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\Exception\BridgeInstallationFailedException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\YamlStandaloneConfigWriter;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\InitCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Fixture\FailingBridgeInstaller;
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Fixture\RecordingBridgeInstaller;
 
 final class InitCommandTest extends TestCase
@@ -255,6 +258,86 @@ final class InitCommandTest extends TestCase
         $commandTester->setInputs(['openai', 'gpt-5.4', 'OPENAI_API_KEY']);
 
         self::assertSame(Command::SUCCESS, $commandTester->execute([]));
+    }
+
+    /**
+     * @param array<string, string> $options
+     */
+    #[DataProvider('blankOrInvalidInputs')]
+    public function test_it_rejects_a_blank_or_invalid_input_without_writing_configuration(array $options): void
+    {
+        $commandTester = $this->commandTester();
+
+        $exitCode = $commandTester->execute($options, ['interactive' => false]);
+
+        self::assertSame(Command::INVALID, $exitCode);
+        self::assertFileDoesNotExist($this->configFile());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>}>
+     */
+    public static function blankOrInvalidInputs(): iterable
+    {
+        yield 'empty provider' => [['--provider' => '', '--model' => 'gpt-5.4']];
+        yield 'whitespace provider' => [['--provider' => '   ', '--model' => 'gpt-5.4']];
+        yield 'blank model' => [['--provider' => 'openai', '--model' => '   ']];
+        yield 'env var with a space' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => 'MY KEY']];
+        yield 'env var starting with a digit' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => '1KEY']];
+        yield 'env var with a parenthesis' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => 'KEY)']];
+        yield 'empty env var' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => '']];
+    }
+
+    public function test_it_does_not_install_a_bridge_for_a_blank_provider(): void
+    {
+        $commandTester = $this->commandTester();
+
+        $commandTester->execute(['--provider' => '', '--model' => 'gpt-5.4'], ['interactive' => false]);
+
+        self::assertSame([], $this->recordingBridgeInstaller->installations);
+    }
+
+    public function test_it_explains_why_an_invalid_env_var_name_was_rejected(): void
+    {
+        $commandTester = $this->commandTester();
+
+        $commandTester->execute(['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => 'MY KEY'], ['interactive' => false]);
+
+        self::assertStringContainsString('not a valid environment variable name', $commandTester->getDisplay());
+    }
+
+    public function test_it_trims_surrounding_whitespace_from_the_model_and_env_var_options(): void
+    {
+        $commandTester = $this->commandTester();
+
+        $commandTester->execute(
+            ['--provider' => 'openai', '--model' => ' gpt-5.4 ', '--env-var' => ' MY_KEY '],
+            ['interactive' => false],
+        );
+
+        self::assertSame(
+            ['provider' => 'openai', 'platform' => ['openai' => ['api_key' => '%env(MY_KEY)%']], 'model' => 'gpt-5.4'],
+            Yaml::parseFile($this->configFile()),
+        );
+    }
+
+    public function test_it_leaves_the_configuration_unwritten_when_the_bridge_install_fails(): void
+    {
+        $initCommand = new InitCommand(
+            new XdgConfigPathResolver($this->configHome, null, null, $this->dataHome),
+            new StandaloneConfigFactory(),
+            new YamlStandaloneConfigWriter(),
+            new FailingBridgeInstaller(),
+        );
+        $commandTester = new CommandTester($initCommand);
+
+        try {
+            $this->expectException(BridgeInstallationFailedException::class);
+
+            $commandTester->execute(['--provider' => 'openai', '--model' => 'gpt-5.4'], ['interactive' => false]);
+        } finally {
+            self::assertFileDoesNotExist($this->configFile());
+        }
     }
 
     public function test_it_confirms_where_the_configuration_was_written(): void

--- a/tests/Phpunit/Integration/Command/InitCommandTest.php
+++ b/tests/Phpunit/Integration/Command/InitCommandTest.php
@@ -286,6 +286,9 @@ final class InitCommandTest extends TestCase
         yield 'env var starting with a digit' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => '1KEY']];
         yield 'env var with a parenthesis' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => 'KEY)']];
         yield 'empty env var' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => '']];
+        yield 'provider with invalid utf-8 bytes' => [['--provider' => "caf\xE9", '--model' => 'gpt-5.4']];
+        yield 'model with invalid utf-8 bytes' => [['--provider' => 'openai', '--model' => "caf\xE9"]];
+        yield 'env var with invalid utf-8 bytes' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => "\xE9KEY"]];
     }
 
     public function test_it_does_not_install_a_bridge_for_a_blank_provider(): void
@@ -297,13 +300,29 @@ final class InitCommandTest extends TestCase
         self::assertSame([], $this->recordingBridgeInstaller->installations);
     }
 
-    public function test_it_explains_why_an_invalid_env_var_name_was_rejected(): void
+    /**
+     * @param array<string, string> $options
+     */
+    #[DataProvider('violationMessages')]
+    public function test_it_explains_why_an_input_was_rejected(array $options, string $expectedMessage): void
     {
         $commandTester = $this->commandTester();
 
-        $commandTester->execute(['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => 'MY KEY'], ['interactive' => false]);
+        $commandTester->execute($options, ['interactive' => false]);
 
-        self::assertStringContainsString('not a valid environment variable name', $commandTester->getDisplay());
+        self::assertStringContainsString($expectedMessage, $commandTester->getDisplay());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>, string}>
+     */
+    public static function violationMessages(): iterable
+    {
+        yield 'empty provider' => [['--provider' => '', '--model' => 'gpt-5.4'], 'The provider must not be empty.'];
+        yield 'invalid utf-8 provider' => [['--provider' => "caf\xE9", '--model' => 'gpt-5.4'], 'The provider must be valid UTF-8 text.'];
+        yield 'blank model' => [['--provider' => 'openai', '--model' => ' '], 'The model must not be empty.'];
+        yield 'invalid utf-8 model' => [['--provider' => 'openai', '--model' => "caf\xE9"], 'The model must be valid UTF-8 text.'];
+        yield 'invalid env var name' => [['--provider' => 'openai', '--model' => 'gpt-5.4', '--env-var' => 'MY KEY'], 'not a valid environment variable name'];
     }
 
     public function test_it_trims_surrounding_whitespace_from_the_model_and_env_var_options(): void

--- a/tests/Phpunit/Integration/Command/ProcessComposerAvailabilityCheckerTest.php
+++ b/tests/Phpunit/Integration/Command/ProcessComposerAvailabilityCheckerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ProcessComposerAvailabilityChecker;
 
@@ -47,48 +46,8 @@ final class ProcessComposerAvailabilityCheckerTest extends TestCase
         $process = (ProcessComposerAvailabilityChecker::defaultProcessBuilder())();
 
         $commandLine = $process->getCommandLine();
-        self::assertStringContainsString('composer', $commandLine);
+        self::assertStringContainsString("'composer'", $commandLine);
         self::assertStringContainsString("'--version'", $commandLine);
         self::assertSame(30.0, $process->getTimeout());
-    }
-
-    public function test_default_process_builder_resolves_composer_through_the_path(): void
-    {
-        $binDir = sys_get_temp_dir().'/ssa-composer-bin-'.bin2hex(random_bytes(4));
-        $filesystem = new Filesystem();
-        $filesystem->dumpFile($binDir.'/composer', "#!/bin/sh\n");
-        $filesystem->chmod($binDir.'/composer', 0o755);
-
-        $process = $this->withPath($binDir, static fn (): Process => (ProcessComposerAvailabilityChecker::defaultProcessBuilder())());
-        $filesystem->remove($binDir);
-
-        self::assertStringContainsString(\sprintf("'%s/composer'", $binDir), $process->getCommandLine());
-    }
-
-    public function test_default_process_builder_falls_back_to_the_bare_composer_name(): void
-    {
-        $emptyDir = sys_get_temp_dir().'/ssa-composer-empty-'.bin2hex(random_bytes(4));
-        $filesystem = new Filesystem();
-        $filesystem->mkdir($emptyDir);
-
-        $process = $this->withPath($emptyDir, static fn (): Process => (ProcessComposerAvailabilityChecker::defaultProcessBuilder())());
-        $filesystem->remove($emptyDir);
-
-        self::assertStringContainsString("'composer' '--version'", $process->getCommandLine());
-    }
-
-    /**
-     * @param callable(): Process $build
-     */
-    private function withPath(string $path, callable $build): Process
-    {
-        $originalPath = getenv('PATH');
-        putenv('PATH='.$path);
-
-        try {
-            return $build();
-        } finally {
-            putenv(false === $originalPath ? 'PATH' : 'PATH='.$originalPath);
-        }
     }
 }

--- a/tests/Phpunit/Integration/Command/ProcessComposerAvailabilityCheckerTest.php
+++ b/tests/Phpunit/Integration/Command/ProcessComposerAvailabilityCheckerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ProcessComposerAvailabilityChecker;
 
@@ -49,5 +50,45 @@ final class ProcessComposerAvailabilityCheckerTest extends TestCase
         self::assertStringContainsString('composer', $commandLine);
         self::assertStringContainsString("'--version'", $commandLine);
         self::assertSame(30.0, $process->getTimeout());
+    }
+
+    public function test_default_process_builder_resolves_composer_through_the_path(): void
+    {
+        $binDir = sys_get_temp_dir().'/ssa-composer-bin-'.bin2hex(random_bytes(4));
+        $filesystem = new Filesystem();
+        $filesystem->dumpFile($binDir.'/composer', "#!/bin/sh\n");
+        $filesystem->chmod($binDir.'/composer', 0o755);
+
+        $process = $this->withPath($binDir, static fn (): Process => (ProcessComposerAvailabilityChecker::defaultProcessBuilder())());
+        $filesystem->remove($binDir);
+
+        self::assertStringContainsString(\sprintf("'%s/composer'", $binDir), $process->getCommandLine());
+    }
+
+    public function test_default_process_builder_falls_back_to_the_bare_composer_name(): void
+    {
+        $emptyDir = sys_get_temp_dir().'/ssa-composer-empty-'.bin2hex(random_bytes(4));
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($emptyDir);
+
+        $process = $this->withPath($emptyDir, static fn (): Process => (ProcessComposerAvailabilityChecker::defaultProcessBuilder())());
+        $filesystem->remove($emptyDir);
+
+        self::assertStringContainsString("'composer' '--version'", $process->getCommandLine());
+    }
+
+    /**
+     * @param callable(): Process $build
+     */
+    private function withPath(string $path, callable $build): Process
+    {
+        $originalPath = getenv('PATH');
+        putenv('PATH='.$path);
+
+        try {
+            return $build();
+        } finally {
+            putenv(false === $originalPath ? 'PATH' : 'PATH='.$originalPath);
+        }
     }
 }

--- a/tests/Phpunit/Integration/Command/ProcessComposerAvailabilityCheckerTest.php
+++ b/tests/Phpunit/Integration/Command/ProcessComposerAvailabilityCheckerTest.php
@@ -46,7 +46,7 @@ final class ProcessComposerAvailabilityCheckerTest extends TestCase
         $process = (ProcessComposerAvailabilityChecker::defaultProcessBuilder())();
 
         $commandLine = $process->getCommandLine();
-        self::assertStringContainsString("'composer'", $commandLine);
+        self::assertStringContainsString('composer', $commandLine);
         self::assertStringContainsString("'--version'", $commandLine);
         self::assertSame(30.0, $process->getTimeout());
     }

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/ProcessReleaseClientTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/ProcessReleaseClientTest.php
@@ -50,11 +50,36 @@ final class ProcessReleaseClientTest extends TestCase
     /**
      * @throws SelfUpdateFailedException
      */
-    public function test_get_passes_the_requested_url_to_the_process(): void
+    public function test_get_bounds_the_transfer_tightly_and_passes_the_url(): void
     {
-        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => Process::fromShellCommandline(\sprintf('printf %%s %s', escapeshellarg(implode(' ', $arguments)))));
+        $captured = [];
+        $processReleaseClient = new ProcessReleaseClient(static function (array $arguments) use (&$captured): Process {
+            $captured = $arguments;
 
-        self::assertSame('https://example.test/resource', $processReleaseClient->get('https://example.test/resource'));
+            return Process::fromShellCommandline('printf %s BODY');
+        });
+
+        $processReleaseClient->get('https://example.test/resource');
+
+        self::assertSame(['--max-time', '20', 'https://example.test/resource'], $captured);
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     */
+    public function test_download_keeps_a_generous_transfer_bound_and_targets_the_destination(): void
+    {
+        $captured = [];
+        $destination = $this->workingDirectory.'/asset';
+        $processReleaseClient = new ProcessReleaseClient(static function (array $arguments) use (&$captured): Process {
+            $captured = $arguments;
+
+            return Process::fromShellCommandline('true');
+        });
+
+        $processReleaseClient->download('https://example.test/asset', $destination);
+
+        self::assertSame(['--max-time', '600', '--output', $destination, 'https://example.test/asset'], $captured);
     }
 
     /**
@@ -75,7 +100,7 @@ final class ProcessReleaseClientTest extends TestCase
     public function test_download_writes_the_response_to_the_destination(): void
     {
         $destination = $this->workingDirectory.'/asset';
-        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => Process::fromShellCommandline(\sprintf('printf CONTENT > %s', escapeshellarg($arguments[1]))));
+        $processReleaseClient = new ProcessReleaseClient(static fn (array $arguments): Process => Process::fromShellCommandline(\sprintf('printf CONTENT > %s', escapeshellarg($arguments[3]))));
 
         $processReleaseClient->download('https://example.test/asset', $destination);
 
@@ -109,12 +134,12 @@ final class ProcessReleaseClientTest extends TestCase
 
     public function test_default_process_builder_uses_authenticated_curl(): void
     {
-        $process = (ProcessReleaseClient::defaultProcessBuilder())(['--output', '/tmp/asset', 'https://example.test/asset']);
+        $process = (ProcessReleaseClient::defaultProcessBuilder())(['--max-time', '600', '--output', '/tmp/asset', 'https://example.test/asset']);
 
         $commandLine = $process->getCommandLine();
         self::assertStringContainsString("'curl'", $commandLine);
         self::assertStringContainsString("'-fsSL'", $commandLine);
-        self::assertStringContainsString("'--connect-timeout' '30'", $commandLine);
+        self::assertStringContainsString("'--connect-timeout' '10'", $commandLine);
         self::assertStringContainsString("'--max-time' '600'", $commandLine);
         self::assertStringContainsString("'User-Agent: symfony-security-auditor-self-update'", $commandLine);
         self::assertStringContainsString("'https://example.test/asset'", $commandLine);

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
@@ -81,6 +81,29 @@ final class SelfUpdaterTest extends TestCase
      * @throws SelfUpdateFailedException
      * @throws UnsupportedSelfUpdatePlatformException
      */
+    #[DataProvider('vPrefixedTags')]
+    public function test_it_updates_from_a_v_prefixed_release_tag(string $tagName): void
+    {
+        $payload = 'NEW-BINARY';
+        $selfUpdateResult = $this->selfUpdater($this->clientFor($tagName, $payload, hash('sha256', $payload)))->run('1.0.0', false);
+
+        self::assertSame('9.9.9', $selfUpdateResult->latestVersion);
+        self::assertStringEqualsFile($this->binaryPath, $payload);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function vPrefixedTags(): iterable
+    {
+        yield 'lowercase v' => ['v9.9.9'];
+        yield 'uppercase V' => ['V9.9.9'];
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
     public function test_it_reports_already_up_to_date_without_touching_the_binary(): void
     {
         $selfUpdateResult = $this->selfUpdater($this->clientFor('1.0.0', 'IGNORED', hash('sha256', 'IGNORED')))->run('1.0.0', false);

--- a/tests/Phpunit/Integration/Standalone/StandaloneAuditPreflightTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneAuditPreflightTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Standalone;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
+use Override;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfigResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Standalone\StandaloneAuditPreflight;
+
+final class StandaloneAuditPreflightTest extends TestCase
+{
+    private string $configHome;
+
+    private string $cacheHome;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(6));
+        $this->configHome = sys_get_temp_dir().'/ssa-preflight-config-'.$suffix;
+        $this->cacheHome = sys_get_temp_dir().'/ssa-preflight-cache-'.$suffix;
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove([$this->configHome, $this->cacheHome]);
+    }
+
+    #[RunInSeparateProcess]
+    #[MaximumDuration(4000)]
+    public function test_it_reports_no_failure_for_a_bootable_configuration(): void
+    {
+        $this->writeConfig("platform:\n    generic:\n        default:\n            base_url: 'http://localhost'\nmodel: 'gpt-4'\n");
+
+        self::assertNull($this->preflight()->failureReason());
+    }
+
+    #[RunInSeparateProcess]
+    #[MaximumDuration(4000)]
+    public function test_it_reports_why_a_configured_provider_without_its_bridge_cannot_boot(): void
+    {
+        $this->writeConfig("provider: openai\nplatform:\n    openai:\n        api_key: 'sk-test'\nmodel: 'gpt-4'\n");
+
+        self::assertStringContainsString('symfony/ai-open-ai-platform', (string) $this->preflight()->failureReason());
+    }
+
+    public function test_it_reports_a_configuration_that_cannot_load(): void
+    {
+        $this->writeConfig("platform: [a, b\n");
+
+        self::assertStringContainsString('is not valid YAML', (string) $this->preflight()->failureReason());
+    }
+
+    private function preflight(): StandaloneAuditPreflight
+    {
+        $xdgConfigPathResolver = new XdgConfigPathResolver($this->configHome, $this->cacheHome, null);
+
+        return new StandaloneAuditPreflight(
+            new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver()),
+            $xdgConfigPathResolver,
+        );
+    }
+
+    private function writeConfig(string $yaml): void
+    {
+        (new Filesystem())->dumpFile($this->configHome.'/symfony-security-auditor/config.yaml', $yaml);
+    }
+}


### PR DESCRIPTION
## Summary

Pre-release bug-hunt fixes for 1.17.0, double-reviewed, followed by the 1.17.0 release cut (codename **Preflight**). A review of the full `1.16.0..HEAD` diff surfaced one medium finding (a `doctor` false green) and several smaller ones; this PR fixes them:

- **`doctor`'s bridge check now boots the audit** through the exact factories `audit` uses at startup (`AuditPreflightInterface` / `StandaloneAuditPreflight`), so a leftover bridge from a previously configured provider fails the preflight instead of green-lighting an audit that would abort at boot. The boot probe is skipped while the configuration check fails (one problem, one report), and a boot-failure reason is rendered byte-safely — including message-less and non-UTF-8 exception messages.
- **`init` validates its inputs before any side effect** — a blank or non-UTF-8 provider/model, or an invalid `--env-var` name, exits with code 2 and leaves everything untouched — and **installs the bridge before overwriting the configuration**, so a failed download keeps the previous working setup instead of a half-switched one.
- **`self-update` strips a leading `v`/`V` from release tags** before comparing/displaying (PHP's `version_compare('v1.18.0', '1.16.0', '>')` is `false`, which would have silently disabled update detection for a `v`-prefixed tag); asset URLs keep the tag verbatim.
- **Release-metadata lookups are tightly bounded** (`--connect-timeout 10`, `--max-time 20`) so the after-command update notice can no longer stall an interactive command on a black-holed network; binary downloads keep the 600 s transfer window.

Two independent review passes ran over the diff. Pass 1 caught an unpinned fix and a dangling-output edge; pass 2 caught the two non-UTF-8 crash paths and disproved a planned `ExecutableFinder` change for the composer probe (`symfony/process` ≥ 7.1.7 already resolves Windows `composer.bat`/`.cmd` shims itself, so that change was dropped rather than shipped with a false rationale). Known accepted trade-offs: a config *write* failure after a successful bridge install can still leave a mismatched pair (much rarer than the download-failure case, and now diagnosed by `doctor`), and boot failures rooted in configuration that only surface at container build are reported under the "Provider bridge" line (correct exit code, imperfect label).

The final commit is the **1.17.0 release cut**: the `[1.17.0] — 2026-07-23 — Preflight` changelog section with intro, the `[1.17.0]` link reference, and all six version pins (schema `$id`, GitHub Action `uses:` examples in `README.md`, `docs/ci.md`, `docs/versioning.md`) bumped per the release checklist. After merge, tagging `1.17.0` will trigger the Release Guard pin check.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — including an E2E test pinning the `doctor` wrong-bridge failure
- [x] All checks pass: PHP CS Fixer, Rector, PHPStan (max), Deptrac, Swiss Knife, Prettier (3.6.2), markdownlint, composer-normalize, and the full PHPUnit suite were run locally; Infection and the coverage gate need a coverage driver not present in this environment and are validated by CI
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)