### PR TITLE
refactor(standalone): drop the empty-path guard

### DIFF
--- a/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocator.php
+++ b/src/Audit/Infrastructure/SelfUpdate/RunningBinaryLocator.php
@@ -71,10 +71,6 @@ final readonly class RunningBinaryLocator implements RunningBinaryLocatorInterfa
 
     private function resolvedEntryPath(): ?string
     {
-        if ('' === $this->invokedScriptPath) {
-            return null;
-        }
-
         $resolved = $this->executableFile(realpath($this->invokedScriptPath));
         if (null !== $resolved) {
             return $resolved;


### PR DESCRIPTION
## Summary

Fixes the escaped `ReturnRemoval` mutant Infection reported on `main` (run for #205's merge, MSI 99% vs the 100% gate): the early `return null;` for an empty `invokedScriptPath` in `RunningBinaryLocator::resolvedEntryPath()`.

The mutant is **behaviorally equivalent**, so no test can ever kill it: with the guard removed, `realpath('')` resolves to the working directory and every PATH-derived candidate for an empty name resolves to a directory — and `executableFile()` only accepts an executable *regular file* (`is_file()`), so both flows still return `null` for an empty entry path (verified empirically on PHP 8.4). Per the project's "never silence quality gates" rule, the redundant branch is removed instead of the mutant being ignored. The existing tests (`test_it_does_not_mistake_a_path_directory_for_the_binary_when_the_invoked_name_is_empty`, the PATH-lookup and failure cases) keep pinning the surrounding behavior, and the remaining mutants in the method fall through to the PATH scan, which those tests observe.

No behavior change; changelog exempt (internal quality-gate fix).

## Type of change

- [x] Refactor / internal improvement

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — existing tests already pin the behavior; all self-update suites pass (77 tests)
- [x] All checks pass: PHP CS Fixer, Rector, PHPStan (max), Deptrac run locally; Infection needs a coverage driver not present in this environment and is validated by CI (the escaped mutant's line no longer exists)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)