### PR TITLE
test(standalone): kill the coalesce swap

### DIFF
--- a/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/SelfUpdate/RunningBinaryLocatorTest.php
@@ -60,7 +60,7 @@ final class RunningBinaryLocatorTest extends TestCase
         $procSelfExe = $this->workingDirectory.'/proc-self-exe';
         symlink($kernelTarget, $procSelfExe);
         $invokedScript = $this->workingDirectory.'/invoked-binary';
-        (new Filesystem())->touch($invokedScript);
+        $this->createExecutableBinary($invokedScript);
 
         self::assertSame($kernelTarget, (new RunningBinaryLocator($procSelfExe, $invokedScript, 'micro'))->path());
     }


### PR DESCRIPTION
## Summary

Kills the remaining escaped mutant on `main` (Infection run for #211's merge): the `Coalesce` operand swap in `RunningBinaryLocator::path()` (`kernelReportedPath() ?? resolvedEntryPath()` → swapped order).

Root cause of the escape: `test_it_prefers_the_kernel_reported_executable_over_the_invoked_script` created its invoked script with `touch()` — a plain, non-executable file. Since the executable-only fallbacks landed (#205), `resolvedEntryPath()` returns `null` for it, so both operand orders produce the same answer and the swap goes unnoticed. The invoked script is now a real executable binary (the file's existing `createExecutableBinary()` helper), so the swapped order returns the wrong path and fails the assertion.

Verified by applying the exact mutant diff locally: 1 test failure with the mutant, 13/13 green without it.

## Type of change

- [x] Tests only

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHP CS Fixer and PHPStan (max) run locally; Infection needs a coverage driver not present in this environment and is validated by CI (the exact mutant was applied and killed locally)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)