### PR TITLE
feat: offline-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `ExecutiveSummaryReportRenderer` (`src/Audit/Infrastructure/Report/`);
   LLM-sourced file paths are control-character- and bidi-stripped through
   `TerminalTextSanitizer` exactly as the console report does.
+- **New `privacy.offline_only` refuses every network call the auditor owns.**
+  With `privacy.offline_only: true`, the advisory feed is replaced by
+  `InMemoryAdvisoryDatabase`, so `composer audit` is never executed and
+  `lookup_advisory` always answers "no advisories". In standalone mode
+  `OfflineOnlyPlatformGuard` (`src/Audit/Infrastructure/Config/`) additionally
+  checks the configured platforms before the container boots, parsing each
+  endpoint with PHP 8.5's RFC 3986 URI API (`Uri\Rfc3986\Uri`, backported to
+  8.3/8.4 by `league/uri-polyfill`) rather than `parse_url()`: every provider
+  must carry at least one endpoint and every endpoint must be loopback,
+  link-local or private-range, so a hosted provider (an `api_key` and nothing
+  else) or a cloud `base_url` aborts the run with
+  `NonLocalPlatformEndpointException` naming the provider instead of shipping
+  source code off the machine. In bundle mode the platform lives in the
+  application's own `ai.yaml`, which the auditor cannot inspect, so that half
+  stays the operator's responsibility — documented, not silently implied. Model
+  pricing was already network-free (read from the `symfony/models-dev` catalog
+  in `vendor/`). `docs/faq.md` gains a `tcpdump` recipe for verifying the claim
+  rather than trusting it.
 
 ## [1.17.0] — 2026-07-23 — Preflight
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Commit messages are validated separately in CI via
 src/
   Audit/
     Domain/          # Pure PHP — no framework, no I/O
-      Configuration/ # Typed config VOs (BundleConfiguration, AuditProfile, LLMConfiguration, CustomAttackerSkill, …)
+      Configuration/ # Typed config VOs (BundleConfiguration, AuditProfile, LLMConfiguration, PrivacyConfiguration, CustomAttackerSkill, …)
       Model/         # Value objects and enums (Vulnerability [+ `of()` factory + CodeLocation/VulnerabilityClassification/VulnerabilityNarrative], SymfonyMapping [+ `of()` + ProjectFileInventory/AccessControlMap], AuditReport [+ ReportIdentity], ExecutiveSummary (stakeholder view: risk level + severity/type/file distributions), ProjectFile, ProjectFileType, ProjectFileTypeClassifier, CvssEstimate (heuristic CVSS v4.0 per finding), RouteAccessControl, VoterCapability, FormBinding, TokenUsageSnapshot, VulnerabilityHydrationResult, VulnerabilityDropReason, ReviewerFeedback/AcceptedFindingFeedback, …) — public factories use `of()`; the wide `create()` is `@deprecated`
       Exception/     # Domain exceptions (LLMProviderException, GitChangedFilesUnavailableException, InvalidCodeLocationException, InvalidVulnerabilityClassificationException)
       Pipeline/      # PipelineInterface, StageInterface, CoverageRecorderInterface (ports)

--- a/README.md
+++ b/README.md
@@ -360,7 +360,12 @@ The auditor is conservative about what leaves your machine:
 - **You choose where the code goes.** Source is sent only to the provider you
   wire in `ai.yaml`. For zero third-party exposure, run fully offline with
   [Ollama](docs/configuration.md#supported-platforms) — nothing leaves your
-  network.
+  network. Set
+  [`privacy.offline_only: true`](docs/configuration.md#privacy--data-egress) to
+  have that enforced rather than assumed: the advisory feed is dropped (no
+  `composer audit`) and the standalone CLI refuses to boot against a platform
+  endpoint that is not loopback or private-range. `docs/faq.md` carries a
+  `tcpdump` recipe for verifying it yourself.
 - **Reports are sensitive — they list your weak spots.** On public repos, prefer
   SARIF → GitHub Code Scanning (collaborator-only) over downloadable CI
   artifacts. See

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
     },
     "require": {
         "php": ">=8.3",
+        "ext-uri": "*",
         "composer-runtime-api": "^2.0",
+        "league/uri-polyfill": "^7.8",
         "mcp/sdk": "^0.7.0",
         "nikic/php-parser": "^5.3",
         "psr/clock": "^1.0",

--- a/config/services.php
+++ b/config/services.php
@@ -77,6 +77,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\VoterCapabilityParser
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditRunnerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\DeferredAdvisoryDatabase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\InMemoryAdvisoryDatabase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\LockfileHashedAdvisoryCache;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\SymfonyProcessComposerAuditRunner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\FilesystemAttackerCache;
@@ -561,6 +562,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ]);
 
     $defaultsConfigurator->set(SymfonyProcessComposerAuditRunner::class);
+
+    $defaultsConfigurator->set(InMemoryAdvisoryDatabase::class);
 
     $defaultsConfigurator->set(LockfileHashedAdvisoryCache::class)
         ->args([

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ bundle registration, bundle-level configuration, platform wiring via
   - [`scan.*` — file discovery](#scan--file-discovery)
   - [`audit.*` — orchestrator knobs](#audit--orchestrator-knobs)
   - [`cache.*` — caching layers](#cache--caching-layers)
+- [`privacy.*` — data egress](#privacy--data-egress)
   - [Simple mode](#simple-mode--one-model-for-both-roles)
   - [Split mode](#split-mode--separate-models-per-role)
   - [Full example](#full-configuration-example)
@@ -219,6 +220,20 @@ own rates). Models with no published cache rate fall back to the base input
 rate. So the budget tracker and the `estimated_cost_usd` in the report reflect
 the real discounted spend rather than charging every input token at the full
 rate.
+
+### `privacy.*` — data egress
+
+| Key                    | Type   | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `privacy.offline_only` | `bool` | `false` | Refuse every network call the auditor itself owns. The advisory feed is replaced by an empty in-memory database, so `composer audit` never runs and `lookup_advisory` always answers "no advisories". In **standalone** mode the configured platform endpoints are also checked before the audit boots: every provider must carry at least one endpoint and every endpoint must be loopback, link-local or private-range (Ollama, LM Studio, a LAN inference box), otherwise the run aborts naming the offending provider. In **bundle** mode the platform lives in your own `ai.yaml`, which the auditor cannot inspect, so pointing it at a local platform stays your responsibility. Model pricing needs no network in either mode (it is read from the `symfony/models-dev` catalog in `vendor/`). The standalone update-availability check is separate — set `SSA_NO_UPDATE_CHECK=1` to silence it. See [How do I verify that nothing leaves my machine?](faq.md#how-do-i-verify-that-nothing-leaves-my-machine) |
+
+```yaml
+# config/packages/symfony_security_auditor.yaml
+symfony_security_auditor:
+    model: 'llama3.2'
+    privacy:
+        offline_only: true
+```
 
 ### Simple mode — one model for both roles
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -252,7 +252,39 @@ symfony_security_auditor:
     model: 'llama3.3'  # or any model from `ollama pull`
 ```
 
-No data leaves your machine.
+No data leaves your machine. Add
+[`privacy.offline_only: true`](configuration.md#privacy--data-egress) to have
+the auditor enforce that rather than rely on it: it drops the advisory feed (no
+`composer audit`) and, in standalone mode, aborts before the audit boots if a
+configured platform endpoint is not loopback or private-range.
+
+### How do I verify that nothing leaves my machine?
+
+Do not take the claim on trust — watch the wire. Set
+[`privacy.offline_only: true`](configuration.md#privacy--data-egress) so the
+auditor refuses its own network calls (and, in standalone mode, refuses to boot
+against a non-local platform endpoint), export `SSA_NO_UPDATE_CHECK=1` to
+silence the standalone release check, then capture traffic while an audit runs:
+
+```bash
+# Terminal 1 — capture everything that is not loopback and not your local LLM
+sudo tcpdump -n -i any 'not host 127.0.0.1 and not port 11434'
+
+# Terminal 2 — run the audit
+SSA_NO_UPDATE_CHECK=1 symfony-security-auditor audit /path/to/project
+```
+
+Expect the capture to stay empty for the whole run. Two notes on reading it:
+
+- `composer install` and your editor make their own connections — run the audit
+  in an otherwise idle shell so anything captured is attributable.
+- With `privacy.offline_only` off, an audit legitimately talks to your LLM
+  provider and (through `composer audit`) to the Packagist advisory feed, so a
+  non-empty capture there is expected, not a leak.
+
+For a stricter guarantee, run the audit in a network namespace or container that
+has no route off the host at all except to the Ollama socket — if the auditor
+still completes, nothing it needs is remote.
 
 ### Does it log my source code anywhere?
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -62,6 +62,7 @@ Every key under `symfony_security_auditor:` documented in
 - `cache.enabled`, `cache.dir`, `cache.prompt_caching` (the last is **deprecated
   since 1.7** — see [Deprecation policy](#deprecation-policy) — still accepted
   but ignored)
+- `privacy.offline_only`
 
 Default values for these keys are also part of the contract. Changing a default
 is a `MAJOR` change.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -387,6 +387,17 @@
               "description": "Deprecated since 1.7 and ignored. Configure prompt caching on the AI platform in ai.yaml instead."
             }
           }
+        },
+        "privacy": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Data-egress controls.",
+          "properties": {
+            "offline_only": {
+              "type": "boolean",
+              "description": "Refuse every network call the auditor owns: the advisory feed becomes an empty in-memory database (composer audit is never run) and, in standalone mode, the audit aborts unless every configured platform endpoint is loopback or private-range. Default: false."
+            }
+          }
         }
       }
     }

--- a/src/Audit/Domain/Configuration/BundleConfiguration.php
+++ b/src/Audit/Domain/Configuration/BundleConfiguration.php
@@ -40,6 +40,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskLevel;
  *     scan: array{included_paths: list<string>, respect_gitignore: bool, max_file_size_kb: int, import_sarif?: list<string>, custom_risk_patterns: array<string, array<string, array{regex: string, description: string}>>, secret_scrubbing: array{enabled: bool, additional_patterns: list<string>}},
  *     audit: array{max_iterations: int|null, min_confidence: float, reviewer_batch_size: int, tools_enabled: bool, structured_collection?: bool, reviewer_structured_collection?: bool, stable_system_prompt?: bool, max_tool_iterations: int, reviewer_tools_enabled: bool, reviewer_max_tool_iterations: int, baseline?: string|null, triage_memory?: bool, fail_on?: string, since_closure?: string|null, excluded_types?: list<string>, included_types?: list<string>, custom_skills?: array<string, array{file_type: string, instructions: string, priority: int}>, reviewer_max_concurrent: int|null, attacker_max_concurrent: int|null, static_prescan: array{enabled: bool, lean_mode: bool|null}, chunking: array{strategy: string}, poc_synthesis: array{enabled: bool|null, severity_floor: string}, fix_synthesis: array{enabled: bool, severity_floor: string}, code_slicing: array{enabled: bool|null, min_lines_before_slicing: int}, escalation: array{enabled: bool, cheap_model: string|null}, budget: array{max_tokens: int|null, max_cost_usd: float|null}, retry: array{max_attempts: int, initial_delay_ms: int, backoff_multiplier: float, jitter_ratio: float}, rate_limit: array{requests_per_minute: int|null, input_tokens_per_minute: int|null, output_tokens_per_minute: int|null}},
  *     cache: array{enabled: bool, dir: string, prompt_caching: bool},
+ *     privacy?: array{offline_only: bool},
  * }
  */
 final readonly class BundleConfiguration
@@ -52,6 +53,7 @@ final readonly class BundleConfiguration
         public BudgetConfiguration $budget,
         public CacheConfiguration $cache,
         public RateLimitConfiguration $rateLimit,
+        public PrivacyConfiguration $privacy = new PrivacyConfiguration(),
     ) {}
 
     /**
@@ -134,6 +136,9 @@ final readonly class BundleConfiguration
                 requestsPerMinute: $config['audit']['rate_limit']['requests_per_minute'],
                 inputTokensPerMinute: $config['audit']['rate_limit']['input_tokens_per_minute'],
                 outputTokensPerMinute: $config['audit']['rate_limit']['output_tokens_per_minute'],
+            ),
+            privacy: new PrivacyConfiguration(
+                offlineOnly: $config['privacy']['offline_only'] ?? false,
             ),
         );
     }

--- a/src/Audit/Domain/Configuration/PrivacyConfiguration.php
+++ b/src/Audit/Domain/Configuration/PrivacyConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Configuration;
+
+/**
+ * Typed representation of `symfony_security_auditor.privacy`.
+ */
+final readonly class PrivacyConfiguration
+{
+    public function __construct(
+        public bool $offlineOnly = false,
+    ) {}
+}

--- a/src/Audit/Infrastructure/Config/AuditConfigurationDefinition.php
+++ b/src/Audit/Infrastructure/Config/AuditConfigurationDefinition.php
@@ -33,6 +33,7 @@ final readonly class AuditConfigurationDefinition
         $this->defineScanNode($nodeBuilder);
         $this->defineAuditNode($nodeBuilder);
         $this->defineCacheNode($nodeBuilder);
+        $this->definePrivacyNode($nodeBuilder);
     }
 
     private function defineModelNodes(NodeBuilder $nodeBuilder): void
@@ -398,6 +399,21 @@ final readonly class AuditConfigurationDefinition
                                     ->info('Maximum output tokens per minute. `null` (default) disables this dimension. Counted post-hoc from `record()` so the next `acquire()` defers until the window resets when the bucket is full.')
                                 ->end()
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+        ;
+    }
+
+    private function definePrivacyNode(NodeBuilder $nodeBuilder): void
+    {
+        $nodeBuilder
+                ->arrayNode('privacy')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('offline_only')
+                            ->defaultFalse()
+                            ->info('Refuse to make any network call the auditor owns. The advisory feed is replaced by an empty in-memory database, so `composer audit` is never run and the `lookup_advisory` tool always answers "no advisories". In standalone mode the configured platform endpoints are also checked before the audit boots: every provider must expose a loopback/private-range endpoint (Ollama, LM Studio, …) or the run aborts. In bundle mode the platform lives in your own `ai.yaml`, which the auditor cannot inspect, so pointing it at a local platform stays your responsibility. Default false.')
                         ->end()
                     ->end()
                 ->end()

--- a/src/Audit/Infrastructure/Config/Exception/NonLocalPlatformEndpointException.php
+++ b/src/Audit/Infrastructure/Config/Exception/NonLocalPlatformEndpointException.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception;
+
+use RuntimeException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final class NonLocalPlatformEndpointException extends RuntimeException
+{
+    public static function forProvider(string $provider, string $endpoint): self
+    {
+        return new self(\sprintf(
+            'privacy.offline_only is enabled, but the "%s" platform would send your source code to "%s", which is not a loopback or private-range address. Point it at a local platform (e.g. Ollama on http://localhost:11434) or disable privacy.offline_only.',
+            $provider,
+            $endpoint,
+        ));
+    }
+
+    public static function forProviderWithoutEndpoint(string $provider): self
+    {
+        return new self(\sprintf(
+            'privacy.offline_only is enabled, but the "%s" platform is a hosted provider with no local endpoint configured, so every prompt would leave this machine. Configure a local platform (e.g. Ollama on http://localhost:11434) or disable privacy.offline_only.',
+            $provider,
+        ));
+    }
+}

--- a/src/Audit/Infrastructure/Config/OfflineOnlyPlatformGuard.php
+++ b/src/Audit/Infrastructure/Config/OfflineOnlyPlatformGuard.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config;
+
+use Uri\Rfc3986\Uri;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\NonLocalPlatformEndpointException;
+
+/**
+ * Fails a `privacy.offline_only` run before it boots unless every configured
+ * platform talks to this machine (or its private network). A provider is
+ * accepted only when it carries at least one URL and every URL it carries
+ * resolves to a loopback, link-local or private-range host — so a hosted
+ * provider (an `api_key` and nothing else) and a cloud endpoint
+ * (`base_url: https://…azure.com`) are both rejected.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class OfflineOnlyPlatformGuard
+{
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function assertEveryPlatformIsLocal(StandalonePlatformConfig $standalonePlatformConfig): void
+    {
+        foreach ($standalonePlatformConfig->platform as $provider => $providerConfig) {
+            $this->assertProviderIsLocal((string) $provider, \is_array($providerConfig) ? $providerConfig : []);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $providerConfig
+     *
+     * @throws NonLocalPlatformEndpointException
+     */
+    private function assertProviderIsLocal(string $provider, array $providerConfig): void
+    {
+        $urls = $this->urlsIn($providerConfig);
+
+        if ([] === $urls) {
+            throw NonLocalPlatformEndpointException::forProviderWithoutEndpoint($provider);
+        }
+
+        foreach ($urls as $url) {
+            if (!$this->isLocal($url)) {
+                throw NonLocalPlatformEndpointException::forProvider($provider, $url);
+            }
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $providerConfig
+     *
+     * @return list<string>
+     */
+    private function urlsIn(array $providerConfig): array
+    {
+        $urls = [];
+        foreach ($providerConfig as $value) {
+            if (\is_array($value)) {
+                $urls = [...$urls, ...$this->urlsIn($value)];
+
+                continue;
+            }
+
+            if (\is_string($value) && $this->isEndpoint($value)) {
+                $urls[] = $value;
+            }
+        }
+
+        return $urls;
+    }
+
+    private function isEndpoint(string $value): bool
+    {
+        return null !== Uri::parse($value)?->getScheme();
+    }
+
+    private function isLocal(string $url): bool
+    {
+        $host = Uri::parse($url)?->getHost();
+        if (null === $host || '' === $host) {
+            return false;
+        }
+
+        $host = trim($host, '[]');
+
+        if ('localhost' === $host || str_ends_with($host, '.localhost') || str_ends_with($host, '.local')) {
+            return true;
+        }
+
+        if (false === filter_var($host, \FILTER_VALIDATE_IP)) {
+            return false;
+        }
+
+        return false === filter_var($host, \FILTER_VALIDATE_IP, \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE);
+    }
+}

--- a/src/Audit/Infrastructure/Config/StandaloneConfig.php
+++ b/src/Audit/Infrastructure/Config/StandaloneConfig.php
@@ -25,4 +25,11 @@ final readonly class StandaloneConfig
         public array $auditConfig,
         public StandalonePlatformConfig $platform,
     ) {}
+
+    public function offlineOnly(): bool
+    {
+        $privacy = $this->auditConfig['privacy'] ?? null;
+
+        return \is_array($privacy) && true === ($privacy['offline_only'] ?? false);
+    }
 }

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -27,6 +27,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Bridge\ComposerBri
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MalformedProjectConfigException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingPlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\NonLocalPlatformEndpointException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
@@ -253,6 +254,7 @@ final readonly class StandaloneApplicationFactory
      * @throws AmbiguousPlatformException
      * @throws UnresolvableAuditCommandException
      * @throws MalformedProjectConfigException
+     * @throws NonLocalPlatformEndpointException
      */
     private function loadAuditCommand(): Command
     {
@@ -267,6 +269,7 @@ final readonly class StandaloneApplicationFactory
      * @throws UnknownPlatformProviderException
      * @throws AmbiguousPlatformException
      * @throws MalformedProjectConfigException
+     * @throws NonLocalPlatformEndpointException
      */
     private function buildContainer(): ContainerBuilder
     {

--- a/src/Standalone/StandaloneContainerFactory.php
+++ b/src/Standalone/StandaloneContainerFactory.php
@@ -21,6 +21,8 @@ use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\NonLocalPlatformEndpointException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\OfflineOnlyPlatformGuard;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfig;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfig;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
@@ -40,15 +42,21 @@ final readonly class StandaloneContainerFactory
 
     public function __construct(
         private BundleExtensionLoader $bundleExtensionLoader = new BundleExtensionLoader(),
+        private OfflineOnlyPlatformGuard $offlineOnlyPlatformGuard = new OfflineOnlyPlatformGuard(),
     ) {}
 
     /**
      * @throws MissingBundleExtensionException
      * @throws UnknownPlatformProviderException
      * @throws AmbiguousPlatformException
+     * @throws NonLocalPlatformEndpointException
      */
     public function create(StandaloneConfig $standaloneConfig, string $cacheDir): ContainerBuilder
     {
+        if ($standaloneConfig->offlineOnly()) {
+            $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal($standaloneConfig->platform);
+        }
+
         $workingDirectory = getcwd();
 
         $containerBuilder = new ContainerBuilder(new ParameterBag([

--- a/src/SymfonySecurityAuditorBundle.php
+++ b/src/SymfonySecurityAuditorBundle.php
@@ -52,6 +52,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\TriageMemoryRecorderI
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditRunnerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\DeferredAdvisoryDatabase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\InMemoryAdvisoryDatabase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\LockfileHashedAdvisoryCache;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\SymfonyProcessComposerAuditRunner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\FilesystemAttackerCache;
@@ -235,7 +236,9 @@ final class SymfonySecurityAuditorBundle extends AbstractBundle
             ? RegexSecretScrubber::class
             : NullSecretScrubber::class);
 
-        $servicesConfigurator->alias(AdvisoryDatabaseInterface::class, DeferredAdvisoryDatabase::class);
+        $servicesConfigurator->alias(AdvisoryDatabaseInterface::class, $bundleConfiguration->privacy->offlineOnly
+            ? InMemoryAdvisoryDatabase::class
+            : DeferredAdvisoryDatabase::class);
 
         $servicesConfigurator->alias(ComposerAuditRunnerInterface::class, $bundleConfiguration->cache->enabled
             ? LockfileHashedAdvisoryCache::class

--- a/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
+++ b/tests/Phpunit/Integration/Bundle/SymfonySecurityAuditorBundleTest.php
@@ -65,6 +65,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\TriageMemoryRecorderI
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\ComposerAuditRunnerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\DeferredAdvisoryDatabase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\InMemoryAdvisoryDatabase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\LockfileHashedAdvisoryCache;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\SymfonyProcessComposerAuditRunner;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Cache\FilesystemAttackerCache;
@@ -237,6 +238,13 @@ final class SymfonySecurityAuditorBundleTest extends TestCase
         $pathArgument = $definition->getArgument(1);
         self::assertInstanceOf(Reference::class, $pathArgument);
         self::assertSame(AuditedProjectPathHolder::class, (string) $pathArgument);
+    }
+
+    public function test_offline_only_replaces_the_advisory_feed_with_an_empty_local_one(): void
+    {
+        $containerBuilder = $this->loadParameters(['model' => 'gpt-4o', 'privacy' => ['offline_only' => true]]);
+
+        self::assertSame(InMemoryAdvisoryDatabase::class, (string) $containerBuilder->getAlias(AdvisoryDatabaseInterface::class));
     }
 
     public function test_bundle_does_not_register_escalation_services_by_default(): void

--- a/tests/Phpunit/Integration/Standalone/StandaloneConsoleCommandFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneConsoleCommandFactoryTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\NonLocalPlatformEndpointException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfig;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfig;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
@@ -51,6 +52,7 @@ final class StandaloneConsoleCommandFactoryTest extends TestCase
      * @throws MissingBundleExtensionException
      * @throws UnknownPlatformProviderException
      * @throws UnresolvableAuditCommandException
+     * @throws NonLocalPlatformEndpointException
      */
     #[RunInSeparateProcess]
     #[MaximumDuration(4000)]

--- a/tests/Phpunit/Integration/Standalone/StandaloneContainerFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneContainerFactoryTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\AI\Platform\PlatformInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\NonLocalPlatformEndpointException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfig;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfig;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditCommand;
@@ -48,6 +49,7 @@ final class StandaloneContainerFactoryTest extends TestCase
      * @throws AmbiguousPlatformException
      * @throws MissingBundleExtensionException
      * @throws UnknownPlatformProviderException
+     * @throws NonLocalPlatformEndpointException
      */
     #[RunInSeparateProcess]
     #[MaximumDuration(4000)]
@@ -65,6 +67,48 @@ final class StandaloneContainerFactoryTest extends TestCase
      * @throws AmbiguousPlatformException
      * @throws MissingBundleExtensionException
      * @throws UnknownPlatformProviderException
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_offline_only_refuses_to_boot_against_a_remote_platform(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('"anthropic"');
+
+        (new StandaloneContainerFactory())->create(
+            new StandaloneConfig(
+                ['privacy' => ['offline_only' => true]],
+                new StandalonePlatformConfig(['anthropic' => ['api_key' => 'sk-secret']]),
+            ),
+            $this->cacheDir,
+        );
+    }
+
+    /**
+     * @throws AmbiguousPlatformException
+     * @throws MissingBundleExtensionException
+     * @throws UnknownPlatformProviderException
+     * @throws NonLocalPlatformEndpointException
+     */
+    #[RunInSeparateProcess]
+    #[MaximumDuration(4000)]
+    public function test_offline_only_boots_against_a_local_platform(): void
+    {
+        $containerBuilder = (new StandaloneContainerFactory())->create(
+            new StandaloneConfig(
+                ['privacy' => ['offline_only' => true]],
+                new StandalonePlatformConfig(['generic' => ['default' => ['base_url' => 'http://localhost']]]),
+            ),
+            $this->cacheDir,
+        );
+
+        self::assertInstanceOf(AuditCommand::class, $containerBuilder->get(AuditCommand::class));
+    }
+
+    /**
+     * @throws AmbiguousPlatformException
+     * @throws MissingBundleExtensionException
+     * @throws UnknownPlatformProviderException
+     * @throws NonLocalPlatformEndpointException
      */
     #[RunInSeparateProcess]
     #[MaximumDuration(4000)]
@@ -84,6 +128,7 @@ final class StandaloneContainerFactoryTest extends TestCase
      * @throws AmbiguousPlatformException
      * @throws MissingBundleExtensionException
      * @throws UnknownPlatformProviderException
+     * @throws NonLocalPlatformEndpointException
      */
     #[RunInSeparateProcess]
     #[MaximumDuration(4000)]
@@ -107,6 +152,7 @@ final class StandaloneContainerFactoryTest extends TestCase
      * @throws AmbiguousPlatformException
      * @throws MissingBundleExtensionException
      * @throws UnknownPlatformProviderException
+     * @throws NonLocalPlatformEndpointException
      */
     #[RunInSeparateProcess]
     public function test_it_rejects_a_selector_absent_from_the_platform_block(): void
@@ -123,6 +169,7 @@ final class StandaloneContainerFactoryTest extends TestCase
      * @throws AmbiguousPlatformException
      * @throws MissingBundleExtensionException
      * @throws UnknownPlatformProviderException
+     * @throws NonLocalPlatformEndpointException
      */
     #[RunInSeparateProcess]
     public function test_it_rejects_several_platforms_without_a_selector(): void

--- a/tests/Phpunit/Unit/Domain/Configuration/BundleConfigurationTest.php
+++ b/tests/Phpunit/Unit/Domain/Configuration/BundleConfigurationTest.php
@@ -89,6 +89,35 @@ final class BundleConfigurationTest extends TestCase
      * @throws InvalidAuditExecutionConfigurationException
      * @throws InvalidRateLimitConfigurationException
      */
+    /**
+     * @throws InvalidAuditExecutionConfigurationException
+     * @throws InvalidRateLimitConfigurationException
+     */
+    public function test_offline_only_is_off_unless_configured(): void
+    {
+        $bundleConfiguration = BundleConfiguration::fromArray($this->treeBuilderOutput());
+
+        self::assertFalse($bundleConfiguration->privacy->offlineOnly);
+    }
+
+    /**
+     * @throws InvalidAuditExecutionConfigurationException
+     * @throws InvalidRateLimitConfigurationException
+     */
+    public function test_from_array_maps_offline_only(): void
+    {
+        $config = $this->treeBuilderOutput();
+        $config['privacy'] = ['offline_only' => true];
+
+        $bundleConfiguration = BundleConfiguration::fromArray($config);
+
+        self::assertTrue($bundleConfiguration->privacy->offlineOnly);
+    }
+
+    /**
+     * @throws InvalidAuditExecutionConfigurationException
+     * @throws InvalidRateLimitConfigurationException
+     */
     public function test_from_array_passes_scan_import_sarif_paths_through(): void
     {
         $config = $this->treeBuilderOutput();

--- a/tests/Phpunit/Unit/Domain/Configuration/PrivacyConfigurationTest.php
+++ b/tests/Phpunit/Unit/Domain/Configuration/PrivacyConfigurationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Configuration\PrivacyConfiguration;
+
+final class PrivacyConfigurationTest extends TestCase
+{
+    public function test_offline_only_is_opt_in(): void
+    {
+        self::assertFalse((new PrivacyConfiguration())->offlineOnly);
+    }
+
+    public function test_offline_only_can_be_turned_on(): void
+    {
+        self::assertTrue((new PrivacyConfiguration(offlineOnly: true))->offlineOnly);
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Config/OfflineOnlyPlatformGuardTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Config/OfflineOnlyPlatformGuardTest.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Config;
+
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\NonLocalPlatformEndpointException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\OfflineOnlyPlatformGuard;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfig;
+
+final class OfflineOnlyPlatformGuardTest extends TestCase
+{
+    private OfflineOnlyPlatformGuard $offlineOnlyPlatformGuard;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->offlineOnlyPlatformGuard = new OfflineOnlyPlatformGuard();
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    #[DataProvider('localEndpointCases')]
+    public function test_it_accepts_a_platform_that_stays_on_this_machine(string $endpoint): void
+    {
+        $standalonePlatformConfig = new StandalonePlatformConfig(['ollama' => ['endpoint' => $endpoint]]);
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal($standalonePlatformConfig);
+
+        self::assertSame(['ollama' => ['endpoint' => $endpoint]], $standalonePlatformConfig->platform);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function localEndpointCases(): iterable
+    {
+        yield 'loopback name' => ['http://localhost:11434'];
+        yield 'loopback ipv4' => ['http://127.0.0.1:11434'];
+        yield 'loopback ipv6' => ['http://[::1]:11434'];
+        yield 'private class a' => ['http://10.1.2.3:8080'];
+        yield 'private class b' => ['http://172.16.4.5:8080'];
+        yield 'private class c' => ['http://192.168.1.20:1234'];
+        yield 'link local' => ['http://169.254.10.10:1234'];
+        yield 'mdns host' => ['http://workstation.local:11434'];
+        yield 'localhost subdomain' => ['http://models.localhost:11434'];
+        yield 'uppercase host' => ['http://LOCALHOST:11434'];
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    #[DataProvider('remoteEndpointCases')]
+    public function test_it_refuses_a_platform_that_would_leave_this_machine(string $endpoint): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage($endpoint);
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig(['azure' => ['base_url' => $endpoint]]),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function remoteEndpointCases(): iterable
+    {
+        yield 'public host name' => ['https://my-deployment.openai.azure.com'];
+        yield 'public ipv4' => ['https://8.8.8.8:443'];
+        yield 'public ipv6' => ['https://[2001:4860:4860::8888]:443'];
+        yield 'scheme without host' => ['file:///etc/passwd'];
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_it_refuses_a_hosted_provider_that_carries_no_endpoint_at_all(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('the "anthropic" platform is a hosted provider with no local endpoint configured');
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig(['anthropic' => ['api_key' => 'sk-secret']]),
+        );
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_it_refuses_a_provider_whose_configuration_is_not_a_map(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('"bedrock"');
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig(['bedrock' => null]),
+        );
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_it_inspects_endpoints_nested_below_the_provider_key(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('https://api.example.com');
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig(['generic' => ['default' => ['base_url' => 'https://api.example.com']]]),
+        );
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_it_refuses_as_soon_as_one_of_several_platforms_is_remote(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('"openai"');
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig([
+                'ollama' => ['endpoint' => 'http://localhost:11434'],
+                'openai' => ['api_key' => 'sk-secret'],
+            ]),
+        );
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_a_non_url_setting_is_not_mistaken_for_an_endpoint(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('no local endpoint configured');
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig(['ollama' => ['model' => 'llama3.2', 'region' => 'eu-west-3']]),
+        );
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_every_endpoint_of_a_provider_must_be_local_not_just_the_first(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('https://fallback.example.com');
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig(['generic' => [
+                'primary' => ['base_url' => 'http://127.0.0.1:1234'],
+                'fallback' => ['base_url' => 'https://fallback.example.com'],
+            ]]),
+        );
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_an_endpoint_found_before_a_nested_block_is_still_checked(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('https://remote.example.com');
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig(['generic' => [
+                'base_url' => 'https://remote.example.com',
+                'fallback' => ['base_url' => 'http://127.0.0.1:1234'],
+            ]]),
+        );
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_every_endpoint_inside_one_nested_block_is_checked(): void
+    {
+        $this->expectException(NonLocalPlatformEndpointException::class);
+        $this->expectExceptionMessage('https://remote.example.com');
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal(
+            new StandalonePlatformConfig(['generic' => ['default' => [
+                'base_url' => 'http://127.0.0.1:1234',
+                'fallback_url' => 'https://remote.example.com',
+            ]]]),
+        );
+    }
+
+    /**
+     * @throws NonLocalPlatformEndpointException
+     */
+    public function test_an_empty_platform_map_has_nothing_to_refuse(): void
+    {
+        $standalonePlatformConfig = new StandalonePlatformConfig([]);
+
+        $this->offlineOnlyPlatformGuard->assertEveryPlatformIsLocal($standalonePlatformConfig);
+
+        self::assertSame([], $standalonePlatformConfig->platform);
+    }
+}

--- a/tests/Phpunit/Unit/Infrastructure/Config/StandaloneConfigTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Config/StandaloneConfigTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Config;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfig;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfig;
+
+final class StandaloneConfigTest extends TestCase
+{
+    public function test_offline_only_is_on_when_the_audit_config_asks_for_it(): void
+    {
+        self::assertTrue($this->config(['privacy' => ['offline_only' => true]])->offlineOnly());
+    }
+
+    /**
+     * @param array<array-key, mixed> $auditConfig
+     */
+    #[DataProvider('nonOfflineConfigCases')]
+    public function test_offline_only_is_off_otherwise(array $auditConfig): void
+    {
+        self::assertFalse($this->config($auditConfig)->offlineOnly());
+    }
+
+    /**
+     * @return iterable<string, array{array<array-key, mixed>}>
+     */
+    public static function nonOfflineConfigCases(): iterable
+    {
+        yield 'no privacy section' => [[]];
+        yield 'explicitly disabled' => [['privacy' => ['offline_only' => false]]];
+        yield 'empty privacy section' => [['privacy' => []]];
+        yield 'privacy is not a map' => [['privacy' => 'yes']];
+        yield 'truthy but not true' => [['privacy' => ['offline_only' => 1]]];
+    }
+
+    /**
+     * @param array<array-key, mixed> $auditConfig
+     */
+    private function config(array $auditConfig): StandaloneConfig
+    {
+        return new StandaloneConfig($auditConfig, new StandalonePlatformConfig([]));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `privacy.offline_only`: drops the advisory feed (no `composer audit`) and, in
standalone mode, refuses to boot unless every configured platform endpoint is
loopback or private-range. Bundle mode can't see your `ai.yaml`, so that half stays
yours — stated in the docs. FAQ gains a `tcpdump` recipe to verify it.

Endpoints are parsed with PHP 8.5's RFC 3986 URI API (`Uri\Rfc3986\Uri`), with
[`league/uri-polyfill`](https://uri.thephpleague.com/polyfill/7.0/) backporting it to
8.3/8.4 (it `provides ext-uri`, so 8.5 uses the native extension). That also drops the
hand-rolled scheme regex and the manual host lowercasing — the parser does both.

## Type of change

- [x] New feature

## Checklist

- [x] Tests added (`OfflineOnlyPlatformGuardTest`, `PrivacyConfigurationTest`,
      `StandaloneConfigTest`, plus bundle-wiring and standalone-boot cases)
- [x] Run locally: PHPUnit 4188 tests green, coverage 100.00% (8905/8905),
      Infection 56/56 mutants killed (MSI 100%) on the changed files, PHPStan max,
      PHP CS Fixer and `composer normalize` clean
- [x] New config key in `docs/versioning.md` + `resources/schema.json`
