### PR TITLE
fix: chart label column too narrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   the reader's light/dark preference. A report with no findings renders no
   charts.
 
+### Fixed
+
+- **Long vulnerability-type names no longer collide with their bar in the HTML
+  report's distribution charts.** `DistributionBarChart` reserved 170px for the
+  label column, but a type value such as `insecure_direct_object_reference`
+  renders wider than that at the chart's font size, so its tail ran underneath
+  the bar. The label column is now 250px wide and the bars 290px, which fits the
+  longest `VulnerabilityType` value with margin and keeps the count label inside
+  the 600px viewBox.
+
 ## [1.17.0] — 2026-07-23 — Preflight
 
 A release about the standalone binary looking after itself. The binary now tells

--- a/src/Audit/Infrastructure/Report/DistributionBarChart.php
+++ b/src/Audit/Infrastructure/Report/DistributionBarChart.php
@@ -28,9 +28,9 @@ final readonly class DistributionBarChart
 
     private const int BAR_HEIGHT = 14;
 
-    private const int BAR_LEFT_X = 170;
+    private const int BAR_LEFT_X = 250;
 
-    private const int BAR_MAX_WIDTH = 360;
+    private const int BAR_MAX_WIDTH = 290;
 
     private const int BAR_TOP_OFFSET = 5;
 

--- a/tests/Phpunit/Unit/Infrastructure/Report/DistributionBarChartTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/DistributionBarChartTest.php
@@ -56,7 +56,7 @@ final class DistributionBarChartTest extends TestCase
     {
         $output = $this->distributionBarChart->render('Findings by severity', [new ChartBar('High', 3, 'high')]);
 
-        self::assertStringContainsString('width="360.0"', $output);
+        self::assertStringContainsString('width="290.0"', $output);
     }
 
     public function test_bar_width_is_proportional_to_the_largest_count(): void
@@ -66,7 +66,7 @@ final class DistributionBarChartTest extends TestCase
             new ChartBar('Low', 1, 'low'),
         ]);
 
-        self::assertStringContainsString('width="90.0"', $output);
+        self::assertStringContainsString('width="72.5"', $output);
     }
 
     public function test_each_bar_carries_its_severity_modifier_class(): void
@@ -80,7 +80,7 @@ final class DistributionBarChartTest extends TestCase
     {
         $output = $this->distributionBarChart->render('Findings by severity', [new ChartBar('High', 7, 'high')]);
 
-        self::assertStringContainsString('<text class="bar-count" x="538.0" y="16">7</text>', $output);
+        self::assertStringContainsString('<text class="bar-count" x="548.0" y="16">7</text>', $output);
     }
 
     public function test_chart_height_grows_with_the_number_of_bars(): void
@@ -100,8 +100,8 @@ final class DistributionBarChartTest extends TestCase
             new ChartBar('second', 1, 'type'),
         ]);
 
-        self::assertStringContainsString('x="170" y="5" width="360.0" height="14"', $output);
-        self::assertStringContainsString('x="170" y="29" width="360.0" height="14"', $output);
+        self::assertStringContainsString('x="250" y="5" width="290.0" height="14"', $output);
+        self::assertStringContainsString('x="250" y="29" width="290.0" height="14"', $output);
     }
 
     public function test_rows_are_stacked_one_below_the_other(): void


### PR DESCRIPTION
## Summary

The HTML report's type chart reserved 170px for labels, so a long value like
`insecure_direct_object_reference` ran underneath its bar. Label column is now
250px, bars 290px — fits the longest `VulnerabilityType` with margin, count label
still inside the 600px viewBox.

Found by rendering a sample report in a headless browser while preparing doc
examples, not by reading the markup.

## Type of change

- [x] Bug fix

## Checklist

- [x] Existing chart geometry assertions updated to the new coordinates
- [x] Run locally: PHPUnit 4208 tests green, coverage 100.00% (8958/8958),
      Infection 19/19 mutants killed on `DistributionBarChart`, PHPStan max and
      PHP CS Fixer clean