### PR TITLE
refactor: drop duplicated severity summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   the reader's light/dark preference. A report with no findings renders no
   charts.
 
+### Changed
+
+- **The HTML report no longer repeats the severity counts.** The "Summary by
+  severity" table and the Distribution section's by-severity chart printed the
+  same numbers, one above the other; `HtmlReportRenderer` now emits the chart
+  only (each bar carries its own count as text, so nothing is lost), and the
+  `table.summary` styles are gone from the report template. A report with no
+  findings still shows the "No validated vulnerabilities found." message.
+
 ### Fixed
 
 - **Long vulnerability-type names no longer collide with their bar in the HTML

--- a/src/Audit/Infrastructure/Report/HtmlReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/HtmlReportRenderer.php
@@ -104,24 +104,9 @@ final readonly class HtmlReportRenderer implements ReportRendererInterface
 
     private function summary(AuditReport $auditReport): string
     {
-        if (0 === $auditReport->totalVulnerabilities()) {
-            return '<p class="safe">No validated vulnerabilities found.</p>';
-        }
-
-        $rows = [];
-        foreach (VulnerabilitySeverity::cases() as $severity) {
-            $count = \count($auditReport->vulnerabilitiesBySeverity($severity));
-            if ($count > 0) {
-                $rows[] = \sprintf(
-                    '<tr class="severity-%s"><th>%s</th><td>%d</td></tr>',
-                    $this->escape($severity->value),
-                    $this->escape($severity->label()),
-                    $count,
-                );
-            }
-        }
-
-        return \sprintf('<table class="summary"><caption>Summary by severity</caption>%s</table>', implode('', $rows));
+        return 0 === $auditReport->totalVulnerabilities()
+            ? '<p class="safe">No validated vulnerabilities found.</p>'
+            : '';
     }
 
     private function body(AuditReport $auditReport): string

--- a/src/Audit/Infrastructure/Report/Template/report.html
+++ b/src/Audit/Infrastructure/Report/Template/report.html
@@ -52,31 +52,6 @@
       dl.meta dd {
         margin: 0;
       }
-      table.summary {
-        border-collapse: collapse;
-        margin: 1rem 0;
-      }
-      table.summary th,
-      table.summary td {
-        border: 1px solid #8884;
-        padding: 0.25rem 0.75rem;
-        text-align: left;
-      }
-      table.summary tr.severity-critical th {
-        border-left: 0.4rem solid #7f1d1d;
-      }
-      table.summary tr.severity-high th {
-        border-left: 0.4rem solid #b91c1c;
-      }
-      table.summary tr.severity-medium th {
-        border-left: 0.4rem solid #b45309;
-      }
-      table.summary tr.severity-low th {
-        border-left: 0.4rem solid #2563eb;
-      }
-      table.summary tr.severity-info th {
-        border-left: 0.4rem solid #6b7280;
-      }
       .safe {
         color: #15803d;
         font-weight: 600;

--- a/tests/Phpunit/Unit/Infrastructure/Report/HtmlReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/HtmlReportRendererTest.php
@@ -66,6 +66,23 @@ final class HtmlReportRendererTest extends AbstractReportRendererTestCase
     }
 
     /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_render_states_severity_counts_once_in_the_chart_not_twice(): void
+    {
+        $output = $this->renderer->render($this->makeReport(
+            $this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::HIGH),
+        ));
+
+        self::assertStringNotContainsString('<table class="summary"', $output);
+        self::assertStringNotContainsString('Summary by severity', $output);
+        self::assertStringContainsString('aria-label="Findings by severity"', $output);
+    }
+
+    /**
      * @throws InvalidAuditContextException
      */
     public function test_render_shows_safe_message_when_no_vulnerabilities(): void
@@ -121,36 +138,6 @@ final class HtmlReportRendererTest extends AbstractReportRendererTestCase
         self::assertStringContainsString('<h2>Vulnerabilities (1 total)</h2>', $output);
         self::assertStringContainsString('src/Admin/UserController.php', $output);
         self::assertStringContainsString('class="finding severity-high"', $output);
-    }
-
-    /**
-     * @throws InvalidCodeLocationException
-     * @throws InvalidVulnerabilityClassificationException
-     * @throws InvalidAuditContextException
-     * @throws InvalidVulnerabilityNarrativeException
-     */
-    public function test_render_summary_counts_only_present_severities(): void
-    {
-        $output = $this->renderer->render($this->makeReport($this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::HIGH)));
-
-        self::assertStringContainsString('<tr class="severity-high">', $output);
-        self::assertStringContainsString('<td>1</td></tr>', $output);
-        self::assertStringNotContainsString('<tr class="severity-critical">', $output);
-    }
-
-    /**
-     * @throws InvalidCodeLocationException
-     * @throws InvalidVulnerabilityClassificationException
-     * @throws InvalidAuditContextException
-     * @throws InvalidVulnerabilityNarrativeException
-     */
-    public function test_render_styles_every_summary_row_severity_class(): void
-    {
-        $output = $this->renderer->render($this->makeReport($this->makeValidatedVuln()));
-
-        foreach (VulnerabilitySeverity::cases() as $severity) {
-            self::assertStringContainsString('table.summary tr.severity-'.$severity->value, $output);
-        }
     }
 
     /**
@@ -370,25 +357,6 @@ final class HtmlReportRendererTest extends AbstractReportRendererTestCase
 
         self::assertStringContainsString('<dt>CWE</dt>', $output);
         self::assertStringContainsString('<dd>'.VulnerabilityType::SQL_INJECTION->cwe()->label().'</dd>', $output);
-    }
-
-    /**
-     * @throws InvalidCodeLocationException
-     * @throws InvalidVulnerabilityClassificationException
-     * @throws InvalidAuditContextException
-     * @throws InvalidVulnerabilityNarrativeException
-     */
-    public function test_render_summary_table_renders_exactly_one_row_per_present_severity(): void
-    {
-        $output = $this->renderer->render($this->makeReport(
-            $this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::HIGH),
-        ));
-
-        $expectedTable = '<table class="summary"><caption>Summary by severity</caption>'
-            .'<tr class="severity-high"><th>'.VulnerabilitySeverity::HIGH->label().'</th><td>1</td></tr>'
-            .'</table>';
-
-        self::assertStringContainsString($expectedTable, $output);
     }
 
     /**


### PR DESCRIPTION
## Summary

The HTML report printed the severity counts twice: the "Summary by severity" table
and, two lines below, the Distribution section's by-severity chart. The chart labels
every bar with its count, so the table carried nothing new.

`HtmlReportRenderer::summary()` now emits only the empty-state message, and the
`table.summary` rules are gone from the template. A report with no findings is
unchanged.

## Type of change

- [x] Refactor / internal improvement

## Checklist

- [x] Three table-specific tests replaced by one asserting the counts appear only
      in the chart
- [x] Run locally: PHPUnit 4206 tests green, coverage 100.00% (8948/8948),
      Infection 60/60 mutants killed on `HtmlReportRenderer`, PHPStan max and PHP CS Fixer clean