### PR TITLE
docs: improve output formats reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ codes). Progress is suppressed for `--format=json/sarif` to stdout and for
 
 The full report renders the same way in console, JSON, SARIF, HTML, and Markdown
 — see [CLI reference](docs/configuration.md#cli-reference) and
-[output formats](docs/ci.md#output-formats-reference).
+[output formats](docs/configuration.md#output-formats-reference).
 
 ## Getting Started
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,7 +12,7 @@ GitHub Code Scanning or the GitLab Security Dashboard.
   - [Reusable GitHub Action](#reusable-github-action)
   - [Sticky PR comment with the audit summary](#sticky-pr-comment-with-the-audit-summary)
 - [GitLab CI](#gitlab-ci)
-- [Output Formats Reference](#output-formats-reference)
+- [Output Formats in CI](#output-formats-in-ci)
 
 > See also: [Configuration](configuration.md) · [FAQ](faq.md) ·
 > [Troubleshooting](troubleshooting.md)
@@ -508,7 +508,7 @@ symfony-security-audit:
     expire_in: 30 days
 ```
 
-## Output Formats Reference
+## Output Formats in CI
 
 ```bash
 # Console (default — useful for workflow logs)
@@ -527,5 +527,5 @@ php bin/console audit:run /path/to/project --format sarif --output report.sarif
 php bin/console audit:run /path/to/project --format html --output report.html
 ```
 
-See what the
-[`executive` summary and the HTML distribution charts look like](configuration.md#output-examples).
+Every format, its options and sample output live in the
+[Output Formats Reference](configuration.md#output-formats-reference).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ bundle registration, bundle-level configuration, platform wiring via
 - [Split-Model Setup](#split-model-setup)
 - [Standalone Configuration](#standalone-configuration)
 - [CLI Reference](#cli-reference)
-  - [Output examples](#output-examples)
+  - [Output Formats Reference](#output-formats-reference)
   - [`audit:diff`](#auditdiff--comparing-two-reports)
   - [`audit:trend`](#audittrend--tracking-findings-across-reports)
   - [`audit:baseline`](#auditbaseline--maintaining-the-accepted-finding-baseline)
@@ -604,7 +604,10 @@ bin/console audit:run --generate-baseline=.security-baseline.json
 bin/console audit:run --baseline=.security-baseline.json
 ```
 
-### Output examples
+### Output Formats Reference
+
+What each format produces. For ready-to-paste pipeline snippets, see
+[Output Formats in CI](ci.md#output-formats-in-ci).
 
 #### `executive`
 


### PR DESCRIPTION
## Summary

The output-format links pointed at `docs/ci.md#output-formats-reference`, which
after the examples moved holds only pipeline snippets — the formats themselves are
documented in `docs/configuration.md`.

- `docs/configuration.md`: "Output examples" → **Output Formats Reference**
  (canonical), with a lead-in linking to the CI snippets
- `docs/ci.md`: section → "Output Formats in CI", linking back to the reference
- `README.md`: points at `configuration.md#output-formats-reference`

The two sections now cross-link, so a reader landing on either finds the other.

Verified every internal anchor across `README`, `CLAUDE.md`, `CONTRIBUTING`,
`SECURITY`, `CHANGELOG`, `examples/` and `docs/` resolves. One unrelated broken link
remains, not touched here: `CONTRIBUTING.md` →
`docs/architecture.md#vulnerabilitytype--backed-enum-with-owasp-references`, whose
heading now reads "`VulnerabilityType` — backed enum with OWASP **and CWE**
references" (the anchor needs `-and-cwe-`). Happy to fix in its own PR.

## Type of change

- [x] Documentation

## Checklist

- [x] Prettier + markdownlint clean
- [x] No code change, so no tests or changelog entry
