### PR TITLE
fix: executive summary contradicts itself on low-only reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   longest `VulnerabilityType` value with margin and keeps the count label inside
   the 600px viewBox.
 
+- **The executive summary no longer claims "No validated findings" when it is
+  listing findings.** `ExecutiveSummaryReportRenderer::businessImpact()` mapped
+  `RiskLevel::Safe` to the prose "No validated findings … no business exposure",
+  but Safe is derived as `riskScore < 5`, so a report whose only validated
+  findings are low-impact (a single LOW scores 2, and INFO scores 0) is Safe
+  while `totalVulnerabilities() > 0`. The report then printed that "nothing
+  found" sentence directly above the finding count and severity/type/hotspot
+  breakdown — a self-contradiction. The Safe wording now depends on the finding
+  count: with findings it reads "Negligible business exposure: the validated
+  findings are low-impact …", and only a genuinely empty report keeps the
+  original sentence.
+
 ### Security
 
 - **`privacy.offline_only` no longer treats an IPv4-mapped IPv6 endpoint as

--- a/src/Audit/Infrastructure/Report/ExecutiveSummaryReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/ExecutiveSummaryReportRenderer.php
@@ -59,20 +59,29 @@ final readonly class ExecutiveSummaryReportRenderer implements ReportRendererInt
             '{{auditId}}' => $auditReport->auditId(),
             '{{riskLevel}}' => $auditReport->riskLevel(),
             '{{riskScore}}' => $executiveSummary->riskScore,
-            '{{businessImpact}}' => $this->wrapped($this->businessImpact($executiveSummary->riskLevel)),
+            '{{businessImpact}}' => $this->wrapped($this->businessImpact($executiveSummary)),
             '{{body}}' => $this->body($executiveSummary),
         ]);
     }
 
-    private function businessImpact(RiskLevel $riskLevel): string
+    private function businessImpact(ExecutiveSummary $executiveSummary): string
     {
-        return match ($riskLevel) {
+        return match ($executiveSummary->riskLevel) {
             RiskLevel::Critical => 'Immediate action required: findings at this level let an attacker read or alter data they should never reach, or take over a privileged account.',
             RiskLevel::High => 'Action required this sprint: findings at this level are exploitable by a motivated attacker and put user data or business logic at risk.',
             RiskLevel::Medium => 'Plan remediation: no single finding is decisive, but together they weaken defence in depth and shorten the path to a breach.',
             RiskLevel::Low => 'Low business exposure: fold the fixes into routine maintenance.',
-            RiskLevel::Safe => 'No validated findings: this audit identified no business exposure in the scanned surface.',
+            RiskLevel::Safe => $this->safeBusinessImpact($executiveSummary->totalFindings),
         };
+    }
+
+    private function safeBusinessImpact(int $totalFindings): string
+    {
+        if (0 === $totalFindings) {
+            return 'No validated findings: this audit identified no business exposure in the scanned surface.';
+        }
+
+        return 'Negligible business exposure: the validated findings are low-impact — fold the fixes into routine maintenance.';
     }
 
     private function wrapped(string $prose): string

--- a/tests/Phpunit/Unit/Infrastructure/Report/ExecutiveSummaryReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ExecutiveSummaryReportRendererTest.php
@@ -72,6 +72,26 @@ final class ExecutiveSummaryReportRendererTest extends AbstractReportRendererTes
     }
 
     /**
+     * A single LOW finding scores 2, below the Safe threshold (< 5), so the
+     * risk level is Safe while the report still carries a validated finding —
+     * the business-impact prose must not claim there were none.
+     *
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_a_safe_report_that_still_has_findings_does_not_claim_none_were_found(): void
+    {
+        $output = $this->renderer->render($this->makeReport(
+            $this->makeValidatedVuln(vulnerabilitySeverity: VulnerabilitySeverity::LOW),
+        ));
+
+        self::assertStringNotContainsString('No validated findings', $output);
+        self::assertStringContainsString('Negligible business exposure', $output);
+    }
+
+    /**
      * @throws InvalidCodeLocationException
      * @throws InvalidVulnerabilityClassificationException
      * @throws InvalidAuditContextException


### PR DESCRIPTION
## Summary

Pre-1.18.0 bug hunt over the `1.17.0..HEAD` diff (five reviewers, each finding adversarially reproduce-or-rejected). One real bug survived; fixed here.

`ExecutiveSummaryReportRenderer::businessImpact()` mapped `RiskLevel::Safe` to the prose _"No validated findings … no business exposure"_. But Safe is derived as `riskScore < 5`, and a LOW finding scores 2 / INFO scores 0 — so a report whose only validated findings are low-impact is Safe while `totalVulnerabilities() > 0`. The renderer then printed that "nothing found" sentence directly above `"1 validated finding(s) across 1 file(s)"` and the severity/type/hotspot breakdown — a self-contradiction reproduced with a single LOW finding.

The Safe wording now depends on the finding count: _"Negligible business exposure: the validated findings are low-impact …"_ when findings exist, and the original sentence only for a genuinely empty report.

The other candidates were rejected under verification (e.g. a chart division-by-zero unreachable because the count builders only emit count>0 entries).

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (reproduced as a failing renderer test first, then fixed)
- [x] All checks pass: PHP CS Fixer, Rector, PHPStan (max), Deptrac, Swiss Knife, Prettier, markdownlint, and the full PHPUnit suite run locally (4227 tests, coverage 100%)
- [x] 100% MSI maintained: Infection re-verified the changed renderer at 100%
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)