### PR TITLE
fix: concurrent analysis drops files after a batch error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **Concurrent attacker analysis no longer drops every file after a batch
+  error.** When `completeBatchWithTools()` threw anything other than a budget or
+  provider failure (e.g. `InvalidTokenUsageException` from a hostile
+  provider-response token count), `ConcurrentChunkAnalyzer::dispatchInWindows()`
+  `return`ed from inside its window loop, so every window after the failing one
+  was marked `errored` without ever being sent to the LLM — a single odd runtime
+  error silently dropped all later files from the audit and reported them as
+  covered, a false-negative that only affected concurrent mode (the `fast`
+  profile's `attacker_max_concurrent > 1`); sequential mode already isolated the
+  failure to the one chunk and continued. The generic-error branch now fails
+  only the window that threw and continues with the rest, mirroring the
+  sequential analyzer's per-chunk recovery.
+
 - **Long vulnerability-type names no longer collide with their bar in the HTML
   report's distribution charts.** `DistributionBarChart` reserved 170px for the
   label column, but a type value such as `insecure_direct_object_reference`

--- a/src/Audit/Application/Agent/Chunk/ConcurrentChunkAnalyzer.php
+++ b/src/Audit/Application/Agent/Chunk/ConcurrentChunkAnalyzer.php
@@ -214,11 +214,11 @@ final readonly class ConcurrentChunkAnalyzer
             try {
                 $results += $this->dispatchWindow($window, $coverageRecorder);
             } catch (BudgetExceededException $budgetExceededException) {
-                $this->failRemainingWindows($windows, $windowNumber, 'aborted', $coverageRecorder);
+                $this->recordRemainingWindows($windows, $windowNumber, 'aborted', $coverageRecorder);
 
                 throw $budgetExceededException;
             } catch (LLMProviderException $llmProviderException) {
-                $this->failRemainingWindows($windows, $windowNumber, 'errored', $coverageRecorder);
+                $this->recordRemainingWindows($windows, $windowNumber, 'errored', $coverageRecorder);
 
                 throw $llmProviderException;
             } catch (Throwable $throwable) {
@@ -226,7 +226,7 @@ final readonly class ConcurrentChunkAnalyzer
                     'error' => $throwable->getMessage(),
                 ]);
 
-                return $results + $this->failRemainingWindows($windows, $windowNumber, 'errored', $coverageRecorder);
+                $results += $this->failWindow($window, 'errored', $coverageRecorder);
             }
         }
 
@@ -281,27 +281,41 @@ final readonly class ConcurrentChunkAnalyzer
     }
 
     /**
-     * Marks every window from `$fromWindowNumber` onward — the one that just
-     * failed plus any not yet attempted — as failed, without touching windows
-     * that already finalized successfully.
+     * On a fatal budget/provider abort, records every window from
+     * `$fromWindowNumber` onward — the one that just failed plus any not yet
+     * attempted — as failed, without touching windows that already finalized.
+     * Side effects only: the caller rethrows, so no hydration result is
+     * returned or consumed.
      *
      * @param list<array<int, array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}>> $windows
-     *
-     * @return array<int, VulnerabilityHydrationResult>
      */
-    private function failRemainingWindows(array $windows, int $fromWindowNumber, string $status, CoverageRecorderInterface $coverageRecorder): array
+    private function recordRemainingWindows(array $windows, int $fromWindowNumber, string $status, CoverageRecorderInterface $coverageRecorder): void
     {
-        $results = [];
         foreach ($windows as $windowNumber => $window) {
             if ($windowNumber < $fromWindowNumber) {
                 continue;
             }
 
-            foreach ($window as $index => $entry) {
-                ChunkCoverageRecorder::record($entry['chunk'], $status, $coverageRecorder);
-                $this->recordDrainedFindings($entry['session'], $coverageRecorder);
-                $results[$index] = $this->vulnerabilityFactory->fromList([]);
-            }
+            $this->failWindow($window, $status, $coverageRecorder);
+        }
+    }
+
+    /**
+     * Marks one window's chunks with `$status`, draining any findings the LLM
+     * recorded before the batch aborted. Used both to fail the window that
+     * threw and — for a fatal budget/provider abort — every window after it.
+     *
+     * @param array<int, array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}> $window
+     *
+     * @return array<int, VulnerabilityHydrationResult>
+     */
+    private function failWindow(array $window, string $status, CoverageRecorderInterface $coverageRecorder): array
+    {
+        $results = [];
+        foreach ($window as $index => $entry) {
+            ChunkCoverageRecorder::record($entry['chunk'], $status, $coverageRecorder);
+            $this->recordDrainedFindings($entry['session'], $coverageRecorder);
+            $results[$index] = $this->vulnerabilityFactory->fromList([]);
         }
 
         return $results;

--- a/tests/Phpunit/Unit/Application/Agent/Chunk/ConcurrentChunkAnalyzerTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/Chunk/ConcurrentChunkAnalyzerTest.php
@@ -19,6 +19,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use Symfony\Component\Validator\Validation;
+use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAnalysisRequest;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerContextPromptRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunk\AttackerChunkCache;
@@ -143,6 +144,110 @@ final class ConcurrentChunkAnalyzerTest extends TestCase
     }
 
     /**
+     * A generic batch failure must be isolated to its own window: the windows
+     * after it still have to be dispatched, exactly as the sequential analyzer
+     * keeps analysing chunks after one errors. Otherwise a single odd runtime
+     * error silently drops every later file from the audit — a false-negative
+     * SAFE for a security tool.
+     *
+     * @throws InvalidProjectFileException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     * @throws InvalidToolRegistryException
+     */
+    public function test_a_generic_failure_in_a_middle_window_still_dispatches_the_windows_after_it(): void
+    {
+        $callCount = 0;
+        $llmClient = $this->createMock(ToolBatchCapableLLMClientInterface::class);
+        $llmClient
+            ->expects(self::exactly(3))
+            ->method('completeBatchWithTools')
+            ->willReturnCallback(static function (array $requests) use (&$callCount): array {
+                ++$callCount;
+                if (2 === $callCount) {
+                    throw new RuntimeException('middle window tore');
+                }
+
+                foreach ($requests as $request) {
+                    self::registryOf($request)->execute('record_vulnerability', self::recordedFinding('window-'.$callCount));
+                }
+
+                return array_fill(0, \count($requests), LLMResponse::of('', 'm', 'end_turn', TokenUsageSnapshot::of(1, 1)));
+            });
+
+        $concurrentChunkAnalyzer = $this->makeAnalyzer($llmClient, 2);
+
+        [$vulnerabilities] = $concurrentChunkAnalyzer->analyze(
+            [
+                [$this->makeFile('src/A.php')], [$this->makeFile('src/B.php')],
+                [$this->makeFile('src/C.php')], [$this->makeFile('src/D.php')],
+                [$this->makeFile('src/E.php')], [$this->makeFile('src/F.php')],
+            ],
+            $this->request(),
+            new RecordingCoverageRecorder(),
+            new RiskMarkerIndex([]),
+        );
+
+        self::assertCount(4, $vulnerabilities);
+    }
+
+    /**
+     * A budget abort is fatal: the window that hit the cap and every window
+     * after it are recorded `aborted` (windows already finalized keep their
+     * `analyzed` status) and the exception propagates.
+     *
+     * @throws InvalidProjectFileException
+     * @throws LLMProviderException
+     * @throws InvalidToolRegistryException
+     */
+    public function test_a_budget_abort_in_a_later_window_records_the_remaining_windows_as_aborted(): void
+    {
+        $recordingCoverageRecorder = new RecordingCoverageRecorder();
+        $caught = null;
+
+        try {
+            $this->makeAnalyzer($this->clientFailingOnSecondWindowWith(BudgetExceededException::forTokens(150, 100)), 2)->analyze(
+                [[$this->makeFile('src/A.php')], [$this->makeFile('src/B.php')], [$this->makeFile('src/C.php')], [$this->makeFile('src/D.php')]],
+                $this->request(),
+                $recordingCoverageRecorder,
+                new RiskMarkerIndex([]),
+            );
+        } catch (BudgetExceededException $budgetExceededException) {
+            $caught = $budgetExceededException;
+        }
+
+        self::assertInstanceOf(BudgetExceededException::class, $caught);
+        self::assertSame(['aborted' => 2, 'analyzed' => 2], $this->statusCounts($recordingCoverageRecorder));
+    }
+
+    /**
+     * A provider failure is fatal in the same way, recorded as `errored`.
+     *
+     * @throws InvalidProjectFileException
+     * @throws BudgetExceededException
+     * @throws InvalidToolRegistryException
+     */
+    public function test_a_provider_abort_in_a_later_window_records_the_remaining_windows_as_errored(): void
+    {
+        $recordingCoverageRecorder = new RecordingCoverageRecorder();
+        $caught = null;
+
+        try {
+            $this->makeAnalyzer($this->clientFailingOnSecondWindowWith(new LLMProviderException('provider down')), 2)->analyze(
+                [[$this->makeFile('src/A.php')], [$this->makeFile('src/B.php')], [$this->makeFile('src/C.php')], [$this->makeFile('src/D.php')]],
+                $this->request(),
+                $recordingCoverageRecorder,
+                new RiskMarkerIndex([]),
+            );
+        } catch (LLMProviderException $llmProviderException) {
+            $caught = $llmProviderException;
+        }
+
+        self::assertInstanceOf(LLMProviderException::class, $caught);
+        self::assertSame(['analyzed' => 2, 'errored' => 2], $this->statusCounts($recordingCoverageRecorder));
+    }
+
+    /**
      * @throws InvalidProjectFileException
      * @throws BudgetExceededException
      * @throws LLMProviderException
@@ -203,6 +308,44 @@ final class ConcurrentChunkAnalyzerTest extends TestCase
             ['Finalizing an attacker chunk result failed; the chunk is recorded as errored and its siblings in the same window are preserved.', ['error' => 'coverage sink unavailable']],
             $warnings,
         );
+    }
+
+    /**
+     * A client whose first window succeeds (recording a finding per chunk) and
+     * whose second window throws `$failure`, so a later-window abort is
+     * reached with an earlier window already finalized.
+     */
+    private function clientFailingOnSecondWindowWith(Throwable $throwable): ToolBatchCapableLLMClientInterface
+    {
+        $callCount = 0;
+        $llmClient = $this->createMock(ToolBatchCapableLLMClientInterface::class);
+        $llmClient
+            ->expects(self::exactly(2))
+            ->method('completeBatchWithTools')
+            ->willReturnCallback(static function (array $requests) use (&$callCount, $throwable): array {
+                if (2 === ++$callCount) {
+                    throw $throwable;
+                }
+
+                foreach ($requests as $request) {
+                    self::registryOf($request)->execute('record_vulnerability', self::recordedFinding('first-window'));
+                }
+
+                return array_fill(0, \count($requests), LLMResponse::of('', 'm', 'end_turn', TokenUsageSnapshot::of(1, 1)));
+            });
+
+        return $llmClient;
+    }
+
+    /**
+     * @return array<string, int> coverage status => count, sorted by status
+     */
+    private function statusCounts(RecordingCoverageRecorder $recordingCoverageRecorder): array
+    {
+        $counts = array_count_values(array_column($recordingCoverageRecorder->coverage, 'status'));
+        ksort($counts);
+
+        return $counts;
     }
 
     private function makeAnalyzer(ToolBatchCapableLLMClientInterface $toolBatchCapableLLMClient, int $maxConcurrent, ?AttackerCacheInterface $attackerCache = null, ?LoggerInterface $logger = null): ConcurrentChunkAnalyzer


### PR DESCRIPTION
## Summary

Core audit-loop bug hunt (five deep finders over orchestrator / chunkers / reviewer verdict path / collectors / pipeline, each candidate adversarially reproduce-or-rejected). One real bug survived; fixed here.

`ConcurrentChunkAnalyzer::dispatchInWindows()` `return`ed from inside its window loop when `completeBatchWithTools()` threw anything other than a budget or provider failure. Every window after the failing one was then marked `errored` without ever being sent to the LLM — so a single odd runtime error (e.g. `InvalidTokenUsageException` from a hostile provider token count, a declared `@throws` of that call) silently dropped all later files from the audit and reported them as covered: a **false-negative SAFE**, confined to concurrent mode (the `fast` profile's `attacker_max_concurrent > 1`). Sequential mode already isolated such a failure to the one chunk and continued; the log line even claimed "the audit continues" while it didn't.

The generic-error branch now fails only the window that threw and continues the loop, mirroring the sequential analyzer's per-chunk recovery. `failWindow()` is extracted so the fatal budget/provider abort paths and this recovery path share one implementation. Reproduced first as a failing 3-window test (middle window throws; the window after it must still be dispatched and its findings survive) — the existing test only failed the *last* window, so abandonment was never exercised.

The other core-loop candidates were rejected under verification.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated (reproduced as a failing analyzer test first, then fixed)
- [x] All checks pass: PHP CS Fixer, Rector, PHPStan (max), Deptrac, Swiss Knife, Prettier, markdownlint, and the full PHPUnit suite run locally (4228 tests, coverage 100%)
- [x] 100% MSI maintained: Infection re-verified the changed analyzer at 100%
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)