### PR TITLE
chore: release 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.18.0] — 2026-07-26 — Airgap
+
+A release about auditing on your own terms — privately, and legibly. The new
+`privacy.offline_only` mode lets the auditor run fully air-gapped: it refuses
+every network call it owns, and in standalone mode aborts before the container
+boots if any configured platform endpoint would leave the machine. The new
+`executive` format distils a run into a one-screen, stakeholder-facing summary
+with no per-finding detail, and the HTML report now draws its severity and type
+distributions as self-contained inline-SVG charts that follow the reader's
+light/dark theme. A pre-release bug hunt rounds it out — hardening the offline
+guard against IPv4-mapped IPv6 endpoints, stopping the executive summary
+contradicting itself on low-severity reports, and fixing concurrent analysis
+silently dropping files after a batch error.
+
 ### Added
 
 - **A new `executive` output format summarizes an audit for stakeholders.**
@@ -2834,6 +2848,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.18.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.18.0
 [1.17.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.17.0
 [1.16.0]:

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ bin/console audit:run --dry-run
   fingerprint, `audit:trend` tracks counts across a series of them.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.17.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.18.0`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **Extensible** — strict DDD layering and a sole `LLMClientInterface` seam let

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.17.0
+        uses: vinceamstoutz/symfony-security-auditor@1.18.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -207,7 +207,7 @@ Outputs: `exit-code`, `report-path`, and — only when `format: json` —
 ```yaml
       - name: Symfony Security Audit
         id: audit
-        uses: vinceamstoutz/symfony-security-auditor@1.17.0
+        uses: vinceamstoutz/symfony-security-auditor@1.18.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -238,7 +238,7 @@ tradeoffs.
 
 ```yaml
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.17.0
+        uses: vinceamstoutz/symfony-security-auditor@1.18.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -163,7 +163,7 @@ deprecated by the other.
   inputs/outputs may be added in a `MINOR`; renaming or removing one is a
   `MAJOR`. The Marketplace `name` (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.17.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.18.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.17.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.18.0/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",


### PR DESCRIPTION
## Summary

Cuts the **1.18.0** release (codename **Airgap**). Docs/pins only — no code change.

- Promotes the `[Unreleased]` changelog to `## [1.18.0] — 2026-07-26 — Airgap` with a release intro, and recreates an empty `[Unreleased]`.
- Adds the `[1.18.0]` release link reference.
- Bumps every version pin to `1.18.0` via `bin/castor release:bump 1.18.0` — the schema `$id` in `resources/schema.json` and the GitHub Action `uses:` examples in `README.md`, `docs/ci.md` (×3), `docs/versioning.md`. (The `# $schema:` modelines in `examples/` track `main` and need no per-release bump.)

### What 1.18.0 ships

- **`privacy.offline_only`** — fully air-gapped auditing: refuses every network call the auditor owns, and in standalone mode aborts before boot if any configured platform endpoint would leave the machine.
- **`--format=executive`** — a one-screen, stakeholder-facing summary (risk level, business-impact framing, severity/type/file distributions) with no per-finding detail.
- **HTML distribution charts** — self-contained inline-SVG severity/type charts that follow the reader's light/dark theme.
- **Pre-release fixes** — offline guard hardened against IPv4-mapped IPv6 endpoints (Security); executive summary no longer contradicts itself on low-severity reports; concurrent analysis no longer drops files after a batch error.

## Post-merge

Tagging `1.18.0` triggers the `Release Guard` workflow, which re-checks the pins against the tag.

## Type of change

- [x] Release / documentation

## Checklist

- [x] Changelog promoted per `.claude/rules/changelog.md` (header + intro, empty `[Unreleased]` recreated, link reference added)
- [x] Version pins bumped via `bin/castor release:bump 1.18.0` (schema `$id` + Action `uses:` examples); no `1.17.0` pin remains
- [x] `resources/schema.json` is valid JSON; Prettier and markdownlint clean
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)