### PR TITLE
fix(standalone): drop polyfilled ext-uri from the static build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,9 +165,15 @@ jobs:
           # PHP core extensions (date, …) that `spc download`/`build` reject as
           # non-buildable packages; drop them, then append zlib for the
           # GZ-compressed PHAR wrapper (box.json `compression: GZ`).
+          # `uri` is unbuildable for the mirror-image reason: the root `ext-uri`
+          # requirement is satisfied by league/uri-polyfill's `provide`, which
+          # spc does not read, and the 8.3 target has no uri extension to
+          # compile — so it must be dropped too. Unpinning spc past 2.8.5 makes
+          # this entry redundant, not wrong: `uri` is an internal extension on
+          # spc main.
           raw="$(./spc dump-extensions . --format=text)"
           filtered="$(printf '%s' "$raw" | tr ',' '\n' \
-            | grep -vxE 'core|standard|date|hash|json|pcre|spl|reflection|random|zlib' \
+            | grep -vxE 'core|standard|date|hash|json|pcre|spl|reflection|random|uri|zlib' \
             | paste -sd, -)"
           echo "list=${filtered},zlib" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Fixed
+
+- **The standalone binaries are published with releases again.** 1.18.0 added
+  `"ext-uri": "*"` to `composer.json` — satisfied on PHP 8.3/8.4 by
+  `league/uri-polyfill`, which declares `provide: {"ext-uri": "*"}` — and
+  `spc dump-extensions`, which collects every `ext-*` requirement in
+  `composer.json`/`composer.lock` and never reads `provide`, emitted `uri` into
+  the list handed to `spc download --for-extensions`. `static-php-cli` 2.8.5 has
+  no `uri` package to build (PHP only gained the extension in 8.5; the release
+  targets 8.3), so all five legs of the binary matrix aborted within a second of
+  starting the build with "`Extension [uri] not exist !`" and the 1.18.0 release
+  carried no binaries at all. `.github/workflows/release.yaml` now drops `uri`
+  alongside the always-compiled core extensions before the list reaches spc; the
+  polyfill shipped inside the PHAR supplies `Uri\Rfc3986\Uri` at runtime,
+  exactly as it already does for the PHP 8.3/8.4 test matrix.
+
 ## [1.18.0] — 2026-07-26 — Airgap
 
 A release about auditing on your own terms — privately, and legibly. The new


### PR DESCRIPTION
## Summary

The Release job for 1.18.0 failed on all five binary legs, so the release published no binaries at all ([run 30201860793](https://github.com/vinceAmstoutz/symfony-security-auditor/actions/runs/30201860793), release assets are empty). This drops `uri` from the extension list handed to `static-php-cli` so the binaries build again.

### Root cause

1.18.0 added `"ext-uri": "*"` to `composer.json` (offline-only mode, #215), satisfied on PHP 8.3/8.4 by `league/uri-polyfill`, which declares `provide: {"ext-uri": "*"}` since 7.8.1. Composer resolves it; `spc dump-extensions` does not — it collects every `ext-*` key from `composer.json`/`composer.lock` (`extractFromComposerLock()` reads the lock's `platform` block) and never reads `provide`. So `uri` entered `spc download --for-extensions`, and `static-php-cli` 2.8.5 has no `uri` package to build: PHP only gained the extension in 8.5, and the release targets 8.3.

## Type of change

- [x] Bug fix


## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)