### PR TITLE
docs: use last models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Minimal:
 
 ```yaml
 symfony_security_auditor:
-    model: 'claude-opus-4-8'
+    model: 'claude-opus-5'
 ```
 
 One-knob preset (`fast` | `balanced` | `thorough`; explicit keys always win):
@@ -175,7 +175,7 @@ Split-model (larger attacker, faster reviewer):
 
 ```yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-8'
+    attacker_model: 'claude-opus-5'
     reviewer_model: 'claude-haiku-4-5-20251001'
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The Flex recipe already created this file — pick your model:
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    model: 'claude-opus-4-8'
+    model: 'claude-opus-5'
 ```
 
 Optionally pick a one-knob preset — `fast`, `balanced` (default), or `thorough`:

--- a/composer.json
+++ b/composer.json
@@ -80,16 +80,16 @@
         "tomasvotruba/cognitive-complexity": "^1.0"
     },
     "suggest": {
-        "symfony/ai-anthropic-platform": "Anthropic (Claude) platform bridge — claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5-20251001",
-        "symfony/ai-azure-platform": "Azure OpenAI platform bridge — enterprise GPT-5.4, o4-mini",
+        "symfony/ai-anthropic-platform": "Anthropic (Claude) platform bridge — claude-opus-5, claude-sonnet-5, claude-haiku-4-5-20251001",
+        "symfony/ai-azure-platform": "Azure OpenAI platform bridge — enterprise GPT-5.6, o4-mini",
         "symfony/ai-bedrock-platform": "AWS Bedrock platform bridge — Claude, Nova, Llama on AWS",
         "symfony/ai-deep-seek-platform": "DeepSeek platform bridge — deepseek-chat, deepseek-reasoner",
-        "symfony/ai-gemini-platform": "Google Gemini platform bridge — gemini-3.1-pro-preview, gemini-3.5-flash",
-        "symfony/ai-meta-platform": "Meta (Llama) platform bridge — Llama-4-Scout, Llama-3.3",
-        "symfony/ai-mini-max-platform": "MiniMax platform bridge — MiniMax-M2, MiniMax-M3",
-        "symfony/ai-mistral-platform": "Mistral platform bridge — mistral-large, codestral",
+        "symfony/ai-gemini-platform": "Google Gemini platform bridge — gemini-3.1-pro-preview, gemini-3.6-flash",
+        "symfony/ai-meta-platform": "Meta (Llama) platform bridge — llama-4-scout-17b-16e-instruct-fp8, llama-3.3-70b-instruct",
+        "symfony/ai-mini-max-platform": "MiniMax platform bridge — MiniMax-M3, MiniMax-M2.7",
+        "symfony/ai-mistral-platform": "Mistral platform bridge — mistral-large-latest, codestral-latest",
         "symfony/ai-ollama-platform": "Ollama local inference bridge — llama3.3, deepseek-r1, qwen3, phi4 (no API key)",
-        "symfony/ai-open-ai-platform": "OpenAI platform bridge — gpt-5.4, gpt-4.1, o4-mini",
+        "symfony/ai-open-ai-platform": "OpenAI platform bridge — gpt-5.6, gpt-4.1, o4-mini",
         "symfony/ai-open-responses-platform": "OpenAI Responses API platform bridge",
         "symfony/ai-vertex-ai-platform": "Google Vertex AI platform bridge — Gemini + Claude on GCP"
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -757,14 +757,14 @@ Minimal configuration:
 
 ```yaml
 symfony_security_auditor:
-    model: 'claude-opus-4-8'
+    model: 'claude-opus-5'
 ```
 
 Split-model configuration (larger model for attacking, faster for reviewing):
 
 ```yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-8'
+    attacker_model: 'claude-opus-5'
     reviewer_model: 'claude-haiku-4-5-20251001'
 ```
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -41,7 +41,7 @@ Use a powerful model for discovery and a cheap/fast model for validation:
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-8'   # deep reasoning for vulnerability discovery
+    attacker_model: 'claude-opus-5'   # deep reasoning for vulnerability discovery
     reviewer_model: 'claude-haiku-4-5-20251001'  # ~20× cheaper for false-positive filtering
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -505,7 +505,7 @@ flag's no-terminal fallback and the GitHub Action run plain
 yourself to script any other provider:
 
 ```bash
-symfony-security-auditor init --provider=openai --model=gpt-5.4 --no-interaction
+symfony-security-auditor init --provider=openai --model=gpt-5.6 --no-interaction
 # --env-var omitted → derived as OPENAI_API_KEY
 ```
 
@@ -539,7 +539,7 @@ provider: openai
 platform:
     anthropic: { api_key: '%env(ANTHROPIC_API_KEY)%' }
     openai: { api_key: '%env(OPENAI_API_KEY)%' }
-model: gpt-5.4
+model: gpt-5.6
 ```
 
 ## CLI Reference

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,7 @@ following keys:
 > # $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
 >
 > symfony_security_auditor:
->     model: "claude-opus-4-8"
+>     model: "claude-opus-5"
 > ```
 >
 > This gives key completion, type checking, and inline docs as you edit. The
@@ -241,7 +241,7 @@ symfony_security_auditor:
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    model: 'claude-opus-4-8'
+    model: 'claude-opus-5'
 ```
 
 ### Split mode — separate models per role
@@ -249,7 +249,7 @@ symfony_security_auditor:
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-8'   # powerful model for discovery
+    attacker_model: 'claude-opus-5'   # powerful model for discovery
     reviewer_model: 'claude-haiku-4-5-20251001'  # faster model for validation
 ```
 
@@ -258,7 +258,7 @@ symfony_security_auditor:
 ```yaml
 # config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-8'
+    attacker_model: 'claude-opus-5'
     reviewer_model: 'claude-haiku-4-5-20251001'
     scan:
         included_paths:
@@ -390,8 +390,13 @@ supports:
 
 ```yaml
 symfony_security_auditor:
-    model: 'claude-opus-4-8?temperature=0.2'
+    model: 'claude-haiku-4-5-20251001?temperature=0.2'
 ```
+
+> Sampling parameters are model-specific: the current Claude generation (Opus
+> 4.7/4.8, Opus 5, Sonnet 5, Fable 5) no longer accepts `temperature`, `top_p`,
+> or `top_k`, and rejects such a request outright. Steer those models with
+> `effort` or `thinking` instead.
 
 `max_tokens` set this way overrides the bundle's `max_output_tokens` for that
 role. `symfony/ai-bundle`'s own `ai.yaml` platform config additionally accepts
@@ -420,7 +425,7 @@ ai:
 
 ```yaml
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-8'   # deep reasoning for vuln discovery
+    attacker_model: 'claude-opus-5'   # deep reasoning for vuln discovery
     reviewer_model: 'claude-haiku-4-5-20251001'  # fast + cheap for false-positive filtering
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -143,7 +143,7 @@ No. We recommend the layered approach:
 
 ### How accurate is it?
 
-Accuracy depends on the LLM model. Stronger models (Claude Opus, GPT-5.4, Gemini
+Accuracy depends on the LLM model. Stronger models (Claude Opus, GPT-5.6, Gemini
 3 Pro) produce fewer false positives and catch deeper flaws. The Reviewer agent
 filters Attacker output — only `reviewer_validated` findings appear in the final
 report.
@@ -190,7 +190,7 @@ prompt caching enabled (default):
 | Claude Fable 5 only                 | $6 – $16             |
 | Claude Opus only                    | $3 – $8              |
 | Claude Opus + Haiku (split-model)   | $0.50 – $2           |
-| GPT-5.4 only                        | $3 – $8              |
+| GPT-5.6 only                        | $3 – $8              |
 | DeepSeek / Mistral / Ollama (local) | ~$0 / $0             |
 
 Tips: set `profile: fast` (one attacker iteration, lean pre-scan, code slicing,
@@ -309,7 +309,7 @@ prompt receives the resulting CVE summaries, not your dependency list itself.
 | Highest accuracy  | `attacker_model: claude-opus-5` + `reviewer_model: claude-opus-5`               |
 | Best cost/quality | `attacker_model: claude-opus-5` + `reviewer_model: claude-haiku-4-5-20251001`   |
 | Strong + cheaper  | `attacker_model: claude-sonnet-5` + `reviewer_model: claude-haiku-4-5-20251001` |
-| Cheapest paid     | `model: deepseek-chat` or `mistral-large`                                       |
+| Cheapest paid     | `model: deepseek-chat` or `mistral-large-latest`                                |
 | Offline / free    | `model: llama3.3` via Ollama                                                    |
 | Enterprise        | Azure OpenAI / AWS Bedrock with split-model                                     |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -306,8 +306,9 @@ prompt receives the resulting CVE summaries, not your dependency list itself.
 | Goal              | Recommended setup                                                               |
 | ----------------- | ------------------------------------------------------------------------------- |
 | Most demanding    | `attacker_model: claude-fable-5` + `reviewer_model: claude-haiku-4-5-20251001`  |
-| Highest accuracy  | `attacker_model: claude-opus-4-8` + `reviewer_model: claude-opus-4-8`           |
-| Best cost/quality | `attacker_model: claude-opus-4-8` + `reviewer_model: claude-haiku-4-5-20251001` |
+| Highest accuracy  | `attacker_model: claude-opus-5` + `reviewer_model: claude-opus-5`               |
+| Best cost/quality | `attacker_model: claude-opus-5` + `reviewer_model: claude-haiku-4-5-20251001`   |
+| Strong + cheaper  | `attacker_model: claude-sonnet-5` + `reviewer_model: claude-haiku-4-5-20251001` |
 | Cheapest paid     | `model: deepseek-chat` or `mistral-large`                                       |
 | Offline / free    | `model: llama3.3` via Ollama                                                    |
 | Enterprise        | Azure OpenAI / AWS Bedrock with split-model                                     |
@@ -330,14 +331,14 @@ split-model setup above plus per-agent model options (see
 - **Attacker — favour capability and reasoning depth.** It runs a long-horizon,
   recall-sensitive search across the whole codebase, so it benefits from a more
   capable model and higher reasoning effort. On models that expose an `effort`
-  option (e.g. Claude Opus 4.7+/Fable 5, where `high`/`xhigh` are the sweet spot
-  for this kind of work) or an adaptive `thinking` option, set it on the
-  attacker:
+  option (e.g. Claude Opus 5, Sonnet 5 and Fable 5, where `high`/`xhigh` are the
+  sweet spot for this kind of work) or an adaptive `thinking` option, set it on
+  the attacker:
 
   ```yaml
   symfony_security_auditor:
       attacker_model:
-          name: 'claude-opus-4-8'
+          name: 'claude-opus-5'
           options:
               effort: 'high'
       reviewer_model:
@@ -380,12 +381,12 @@ Other params (e.g. `temperature`) flow through the model name:
 ```yaml
 # Query-string
 symfony_security_auditor:
-    model: 'claude-opus-4-8?temperature=0.1'
+    model: 'claude-haiku-4-5-20251001?temperature=0.1'
 
 # Expanded
 symfony_security_auditor:
     model:
-        name: 'claude-opus-4-8'
+        name: 'claude-haiku-4-5-20251001'
         options:
             temperature: 0.1
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -205,7 +205,7 @@ Diagnostic order:
    `ReviewerAgent` to log all incoming candidates, including non-validated ones.
 3. **Raise `audit.max_iterations`** to `5` — the loop stops early when no new
    findings emerge; a stronger pass can surface more.
-4. **Switch to a stronger model** — Claude Opus and GPT-5.4 consistently
+4. **Switch to a stronger model** — Claude Opus and GPT-5.6 consistently
    outperform small models.
 5. **Check the file actually got scanned** — run with `-vv` to see ingested file
    counts and chunk counts.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -205,7 +205,7 @@ Diagnostic order:
    `ReviewerAgent` to log all incoming candidates, including non-validated ones.
 3. **Raise `audit.max_iterations`** to `5` — the loop stops early when no new
    findings emerge; a stronger pass can surface more.
-4. **Switch to a stronger model** — Claude Opus and GPT-4o consistently
+4. **Switch to a stronger model** — Claude Opus and GPT-5.4 consistently
    outperform small models.
 5. **Check the file actually got scanned** — run with `-vv` to see ingested file
    counts and chunk counts.
@@ -230,13 +230,17 @@ on the model:
 ```yaml
 symfony_security_auditor:
     model:
-        name: 'claude-opus-4-8'
+        name: 'claude-haiku-4-5-20251001'
         options:
             temperature: 0.0
 ```
 
 With `temperature: 0.0` + `cache.enabled: true`, repeated runs on identical code
 become deterministic.
+
+The current Claude generation (Opus 4.7/4.8, Opus 5, Sonnet 5, Fable 5) no
+longer accepts `temperature` and rejects a request that sets it — on those
+models rely on `cache.enabled: true` alone for run-to-run stability.
 
 ## Performance & Cost
 

--- a/examples/configs/ci-optimized.yaml
+++ b/examples/configs/ci-optimized.yaml
@@ -7,7 +7,7 @@
 # Drop in as: config/packages/symfony_security_auditor.yaml
 symfony_security_auditor:
     # Heavyweight model finds the bugs; lightweight model filters false positives.
-    attacker_model: 'claude-opus-4-8'
+    attacker_model: 'claude-opus-5'
     reviewer_model: 'claude-haiku-4-5-20251001'
 
     scan:

--- a/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
+++ b/examples/vulnerable-app/config/packages/symfony_security_auditor.yaml
@@ -1,7 +1,7 @@
 # $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
 
 symfony_security_auditor:
-    attacker_model: 'claude-opus-4-8'
+    attacker_model: 'claude-opus-5'
     reviewer_model: 'claude-haiku-4-5-20251001'
     audit:
         min_confidence: 0.6

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -16,7 +16,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Model id used for both the attacker and reviewer roles, e.g. claude-opus-4-8."
+          "description": "Model id used for both the attacker and reviewer roles, e.g. claude-opus-5."
         },
         "attacker_model": {
           "type": ["string", "null"],


### PR DESCRIPTION
## Summary

Every illustrative config snippet in the docs named `claude-opus-4-8`, which is now the previous-generation Opus. Refresh to the current Claude 5 family, plus a fix for `temperature` examples that were already broken. Every model id below is verified against the models.dev catalog this bundle already prices from — `symfony/models-dev` v116.0 installed and `models-dev.json` read directly, rather than guessed.

### What changed

- **`claude-opus-4-8` → `claude-opus-5`** in the example snippets across `README.md`, `CLAUDE.md`, `docs/architecture.md`, `docs/ci.md`, `docs/configuration.md`, `docs/faq.md`, `docs/troubleshooting.md`, `examples/configs/ci-optimized.yaml`, and `examples/vulnerable-app/config/packages/symfony_security_auditor.yaml`. `claude-opus-5` (2026-07-24) is the newest Anthropic entry in the catalog.
- **Sonnet 5 surfaced** — the model-selection table in `docs/faq.md` gains a `attacker_model: claude-sonnet-5` + `reviewer_model: claude-haiku-4-5-20251001` row (a strong attacker at lower cost). The attacker-effort guidance now reads "Claude Opus 5, Sonnet 5 and Fable 5" instead of "Claude Opus 4.7+/Fable 5".
- **Haiku left alone** — Claude Haiku 4.5 is still current, so every `claude-haiku-4-5-20251001` reviewer example is unchanged. `claude-fable-5` was already correct.
- **`temperature` examples fixed.** These were broken independently of their model version: the current Claude generation rejects `temperature`, `top_p`, and `top_k` outright, so the documented `claude-opus-4-8?temperature=0.2` fails the request — and simply bumping it to `claude-opus-5` would have kept it broken. The three examples (`docs/configuration.md`, `docs/faq.md`, `docs/troubleshooting.md`) now use a model that accepts sampling parameters, with a short note naming the models that don't. In `docs/troubleshooting.md` the note matters most, since setting `temperature` is offered there as the fix for nondeterministic runs.
- **`composer.json` and `resources/schema.json`** — the `suggest` model list and the `model` description that editors show as a tooltip now name Claude 5 too.

### Cross-provider ids corrected against the catalog

- **`gpt-5.4` (2026-03-05) is two generations behind `gpt-5.6` (2026-07-09)** — updated in `docs/configuration.md`, `docs/faq.md`, `docs/troubleshooting.md` (which also said `GPT-4o`), and the OpenAI and Azure `suggest` lines. The FAQ cost band is deliberately unchanged and now fits better rather than worse: `gpt-5.6` is $5/$30 per MTok against Claude Opus 5's $5/$25, where `gpt-5.4` was $2.5/$15 and already shared that row.
- **`mistral-large` and `codestral` are not catalog ids at all** — the real ones are `mistral-large-latest` and `codestral-latest`. Model pricing is looked up by id, so copying the old name out of the FAQ landed on the unpriced-model path.
- **`Llama-4-Scout` / `Llama-3.3` are informal shorthand, not ids** — replaced with `llama-4-scout-17b-16e-instruct-fp8` and `llama-3.3-70b-instruct`.
- **`gemini-3.5-flash` → `gemini-3.6-flash`** (2026-07-21). `gemini-3.1-pro-preview` is still the newest non-image Pro, so it stays.
- **`MiniMax-M2` (2025-10-27) is the oldest entry** — the pair is now `MiniMax-M3` and `MiniMax-M2.7`.
- Unchanged because they still resolve: `deepseek-chat` and `deepseek-reasoner`, plus the Ollama tags (`llama3.3`, `deepseek-r1`, `qwen3`, `phi4`) — those live in Ollama's own namespace and the catalog has no `ollama` provider to check them against.

## Type of change

- [x] Documentation

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — verified with commitlint against `origin/main`

No `CHANGELOG.md` entry: documentation and metadata text only, no behavior change — exempt per `.claude/rules/changelog.md`.
