### PR TITLE
fix(docs): drop the invalid expanded model mapping from examples

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -337,12 +337,8 @@ split-model setup above plus per-agent model options (see
 
   ```yaml
   symfony_security_auditor:
-      attacker_model:
-          name: 'claude-opus-5'
-          options:
-              effort: 'high'
-      reviewer_model:
-          name: 'claude-haiku-4-5-20251001'
+      attacker_model: 'claude-opus-5?effort=high'
+      reviewer_model: 'claude-haiku-4-5-20251001'
   ```
 
 - **Reviewer — favour speed.** It validates one finding against context you
@@ -376,22 +372,18 @@ symfony_security_auditor:
     reviewer_max_output_tokens: 2048
 ```
 
-Other params (e.g. `temperature`) flow through the model name:
+Other params (e.g. `temperature`) flow through the model name, using the
+query-string syntax:
 
 ```yaml
-# Query-string
 symfony_security_auditor:
     model: 'claude-haiku-4-5-20251001?temperature=0.1'
-
-# Expanded
-symfony_security_auditor:
-    model:
-        name: 'claude-haiku-4-5-20251001'
-        options:
-            temperature: 0.1
 ```
 
-See [Configuration → Model Options](configuration.md#model-options).
+> `model`, `attacker_model`, and `reviewer_model` are plain strings, so the
+> expanded `{name, options}` mapping that `symfony/ai-bundle`'s own `ai.yaml`
+> accepts for a model is **not** valid here — only the query-string form above
+> works. See [Configuration → Model Options](configuration.md#model-options).
 
 ## Compatibility
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -229,10 +229,7 @@ on the model:
 
 ```yaml
 symfony_security_auditor:
-    model:
-        name: 'claude-haiku-4-5-20251001'
-        options:
-            temperature: 0.0
+    model: 'claude-haiku-4-5-20251001?temperature=0.0'
 ```
 
 With `temperature: 0.0` + `cache.enabled: true`, repeated runs on identical code


### PR DESCRIPTION
## Summary

Three documented examples showed `model:` / `attacker_model:` as a `{name, options}` mapping. **That config cannot load** — it fails at container compile time. Rewrites all three to the query-string form the bundle actually supports.

```yaml
# documented, but rejected by the Config component
symfony_security_auditor:
    attacker_model:
        name: 'claude-opus-5'
        options:
            effort: 'high'

# what actually works
symfony_security_auditor:
    attacker_model: 'claude-opus-5?effort=high'
```

`model`, `attacker_model`, and `reviewer_model` are all `scalarNode`s (`AuditConfigurationDefinition::defineModelNodes()`, lines 40 / 52 / 60), so an array value is rejected before the container is built. `docs/configuration.md` already said so in as many words — *"this bundle's `model` / `attacker_model` / `reviewer_model` keys do not [accept the expanded mapping]: they are plain strings, so only the query-string form works here"* — so the two documents contradicted each other, and the FAQ was the wrong one.

### Sites fixed

| File | Example |
| --- | --- |
| `docs/faq.md` | per-agent reasoning effort (`attacker_model` + `reviewer_model`) |
| `docs/faq.md` | the `temperature` example's "Expanded" variant |
| `docs/troubleshooting.md` | the determinism / `temperature: 0.0` example |

The FAQ's `# Query-string` / `# Expanded` pair collapses into a single block, and the dangling heading is replaced with a note stating the mapping form is `ai.yaml`-only — so the next reader doesn't reintroduce it.

### Provenance

Two of these three were edited in #230, which corrected the model names inside them without noticing the surrounding shape was invalid. Worth knowing when reading the history: the examples were wrong before that PR too, but #230 touched them and let it through.

### Verification

- `grep` for `^\s*(model|attacker_model|reviewer_model):\s*$` across `docs/`, `README.md`, `CLAUDE.md`, `examples/`, `resources/` — **zero** remaining expanded mappings.
- Prettier 3.6.2 `--check "**/*.md"` clean; `markdownlint-cli2` 0 issues across 24 files.

## Type of change

- [x] Documentation

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

No `CHANGELOG.md` entry: docs-only, exempt per `.claude/rules/changelog.md`.