### PR TITLE
chore: keep main at the released version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,16 @@
 - [ ] Documentation
 - [ ] Tests only
 
+## Target branch
+
+Tick one and open the pull request against it — CI fails if they disagree. The
+default base `main` is almost never right
+([why](docs/versioning.md#branches--maintenance)).
+
+- [ ] `1.x` — anything for the next minor release: bug fixes and new features
+- [ ] `2.x` — breaking changes, for the next major release
+- [ ] `main` — release merges only, nothing else
+
 ## Checklist
 
 - [ ] Tests added or updated (unit + integration where applicable)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "[0-9]+.x"
   pull_request: ~
   workflow_dispatch: ~
 

--- a/.github/workflows/pr-target.yaml
+++ b/.github/workflows/pr-target.yaml
@@ -1,0 +1,58 @@
+name: Pull request target
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions: {}
+
+jobs:
+  target:
+    name: Base branch matches the declared target
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the description follows the template and the base matches
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script: a pull-request body is attacker-controlled text.
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          fail() { echo "::error::$1"; exit 1; }
+
+          for section in '## Summary' '## Type of change' '## Target branch' '## Checklist'; do
+            printf '%s\n' "$PR_BODY" | grep -qF -- "$section" \
+              || fail "The description is missing the '${section}' section from .github/PULL_REQUEST_TEMPLATE.md. Restore the template and fill it in."
+          done
+
+          # Only the "Target branch" section, so a ticked box elsewhere in the
+          # description can never be read as a target.
+          block="$(printf '%s\n' "$PR_BODY" | awk '/^##[[:space:]]*Target branch/ { inside = 1; next } /^##[[:space:]]/ { inside = 0 } inside')"
+          ticked="$(printf '%s\n' "$block" | sed -n 's/^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*`\([^`]*\)`.*/\1/p')"
+          count="$(printf '%s' "$ticked" | grep -c . || true)"
+
+          if [ "$count" -ne 1 ]; then
+            fail "Tick exactly one branch under '## Target branch' (found ${count}), and open the pull request against it."
+          fi
+
+          case "$ticked" in
+            main)
+              [ "$BASE_REF" = 'main' ] \
+                || fail "'main' takes release merges only, but this pull request is based on '${BASE_REF}'."
+              ;;
+            *.x)
+              [ "$BASE_REF" = "$ticked" ] \
+                || fail "You ticked '${ticked}' but opened this pull request against '${BASE_REF}'. Retarget the base to '${ticked}', or tick the branch you actually want."
+              ;;
+            *)
+              fail "'${ticked}' is not one of the targets in .github/PULL_REQUEST_TEMPLATE.md."
+              ;;
+          esac
+
+          echo "Ticked '${ticked}', based on '${BASE_REF}' — consistent."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -241,6 +241,33 @@ jobs:
             ${{ matrix.asset }}
             ${{ matrix.asset }}.sha256
 
+  installers:
+    name: Attach the installers and config schema
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          persist-credentials: false
+
+      - name: Attach the installers and config schema to the release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # zizmor: ignore[superfluous-actions] v3.0.2 -- not a security issue per zizmor's own docs; migrating to `gh release` is a separate follow-up
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          overwrite_files: true
+          # Published so the documented URLs can resolve through
+          # `releases/latest/download/` — which always serves the newest
+          # published release — instead of tracking `main`, where an unreleased
+          # change reaches users before the release that carries it.
+          # `resources/schema.json` uploads under its basename, `schema.json`.
+          files: |
+            install.sh
+            install.ps1
+            resources/schema.json
+
   prune:
     name: Prune stale release assets
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,73 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Added
+
+- **The installers and the config schema are published as release assets.**
+  `README.md` pointed users at
+  `raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh`,
+  and the `# $schema:` modelines in `examples/configs/*.yaml` and
+  `docs/configuration.md` at `main/resources/schema.json` — so every install ran
+  whatever sat on the development branch, and editors autocompleted config keys
+  from it. Because `AuditConfigurationDefinition` does not call
+  `ignoreExtraKeys()`, a key documented before its release makes the audit abort
+  with `InvalidConfigurationException`, and standalone is not spared:
+  `BundleExtensionLoader` loads the same extension the bundle configures.
+  `.github/workflows/release.yaml` gains an `installers` job attaching
+  `install.sh`, `install.ps1` and `resources/schema.json` to each release. The
+  documented URLs still point at `main` for now: `releases/latest/download/`
+  resolves to the newest _published_ release, so it only answers once a release
+  carries these assets. Repointing them is a follow-up, to be done after this
+  job has run — otherwise the documented install command would 404, which is the
+  very breakage this prepares to fix.
+- **A documented branch policy that keeps `main` at the released version.**
+  `docs/versioning.md` defined the BC promise but said nothing about branches,
+  so documentation on the default branch drifted ahead of the newest tag for as
+  long as a release took to prepare — and since `AuditConfigurationDefinition`
+  rejects an unknown key outright, a reader could follow it into
+  `InvalidConfigurationException`. `main` now holds **exactly the latest
+  release**: development happens on `1.x`, breaking work for the next `MAJOR` on
+  `2.x`, and `main` only ever receives a release merge. Everything the default
+  branch documents is therefore installable. `CONTRIBUTING.md` gains the
+  matching branch table and keeps the _Since X.Y_ marking convention so a reader
+  can still tell which release introduced a key.
+- **The pull-request template declares a target, and CI enforces it.** A
+  contributor had no prompt to state a change's impact, and since a pull request
+  opens against the default branch it would land on `main` by default — the one
+  branch that should only receive release merges.
+  `.github/PULL_REQUEST_TEMPLATE.md` gains a `## Target branch` section listing
+  the branches themselves — `1.x`, `2.x`, `main` — rather than SemVer impacts,
+  so there is one question on one axis and no two options that mean the same
+  thing. The new `Pull request target` workflow
+  (`.github/workflows/pr-target.yaml`) fails the build when the template
+  sections are missing, when no box or several are ticked, or when the ticked
+  branch disagrees with the base the pull request was opened against — so a
+  mistargeted branch is caught before review rather than after merge. It matches
+  any `<N>.x` branch, so it needs no edit when a major rolls, and it reads only
+  the event payload, so it needs no checkout, no `uses:` and no permissions.
+
+### Changed
+
+- **CI now runs on version branches.** `.github/workflows/ci.yaml` triggered on
+  pushes to `main` only, so a commit pushed straight to a next-`MAJOR` branch
+  like `2.x` would ship without the test matrix, PHPStan, Deptrac or Infection
+  ever running. The push trigger now also matches `[0-9]+.x`.
+
+### Removed
+
+- **`extra.branch-alias` is gone from `composer.json`.** It declared
+  `{"dev-main": "1.0.x-dev"}` while the project was at 1.18.0 — wrong for
+  eighteen `MINOR` releases, because `bin/castor release:bump` never touched it
+  and nothing else read it. Its only effect was letting a dev version satisfy a
+  numeric constraint such as `^1.19@dev`; requiring a branch directly
+  (`composer require vinceamstoutz/symfony-security-auditor:dev-1.x`) works
+  without it, and nothing depends on this package with a version constraint
+  since it installs as a dev tool. Keeping it would have meant re-pinning it
+  every release to stop it rotting again, for a feature that had already proven
+  unused. `extra` held nothing else, so the whole key is removed. This is not a
+  BC break: `composer.json` metadata is not part of the public API surface in
+  [`docs/versioning.md`](docs/versioning.md).
+
 ### Fixed
 
 - **The standalone binaries are published with releases again.** 1.18.0 added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ the dual-agent loop before you touch code.
 - [Evaluating Detection Quality](#evaluating-detection-quality)
 - [Code Quality](#code-quality)
 - [Writing Tests](#writing-tests)
+- [Which Branch to Target](#which-branch-to-target)
+- [Documenting Additions](#documenting-additions)
 - [Common Tasks](#common-tasks)
 - [Submitting a Pull Request](#submitting-a-pull-request)
 - [Commit Style](#commit-style)
@@ -205,6 +207,47 @@ require a PR-description justification and a linked tracking issue.
 **Domain models** (`src/Audit/Domain/Model/`) are immutable. State changes
 return new instances. See
 [`.claude/rules/domain-models.md`](.claude/rules/domain-models.md).
+
+## Which Branch to Target
+
+`main` holds exactly the latest release, so almost nothing belongs there
+directly. Development happens on version branches:
+
+| Change                                    | Base   |
+| ----------------------------------------- | ------ |
+| Bug fix or new feature for the next minor | `1.x`  |
+| Breaking change, for the next major       | `2.x`  |
+| Release merge                             | `main` |
+
+A pull request opens against `main` by default, so **retarget the base**. Tick
+the same branch under `## Target branch` in the description; the
+`Pull request target` check fails the build when the two disagree. Full
+rationale in [Branches & maintenance](docs/versioning.md#branches--maintenance).
+
+## Documenting Additions
+
+Because `main` tracks the latest release, its documentation matches what users
+can install — but a reader still needs to know which release introduced a key,
+and the config tree rejects an unknown key outright
+(`InvalidConfigurationException` from both the bundle and the standalone binary)
+if they are on an older version.
+
+So when you document a new config key, CLI option or output format, mark it with
+the release that will carry it:
+
+```markdown
+| `audit.new_key` | `bool` | `false` | _Since 1.19._ What it does. |
+```
+
+Use the next unreleased version — the one your `CHANGELOG.md` entry sits under.
+Removals already follow this convention (see `cache.prompt_caching`, marked
+_Deprecated since 1.7_); additions need it for the same reason.
+
+Do not point documentation or examples at a
+`raw.githubusercontent.com/.../main/` URL. User-facing files are published as
+release assets, so reference them through `releases/latest/download/`, which
+always resolves to the newest published release. See
+[Branches & maintenance](docs/versioning.md#branches--maintenance).
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ SAST tools miss. Provider-agnostic via
 
 ![Symfony Security Auditor](assets/banner.webp?raw=true)
 
+> [!NOTE]
+>
+> `main` holds **exactly the latest release**, so everything documented here is
+> in the version you install. Development happens on
+> [version branches](docs/versioning.md#branches--maintenance).
+
 ## Why this auditor?
 
 Traditional PHP static analysis tools (PHPStan, Psalm) catch type errors. Static

--- a/composer.json
+++ b/composer.json
@@ -115,11 +115,6 @@
         },
         "sort-packages": true
     },
-    "extra": {
-        "branch-alias": {
-            "dev-main": "1.0.x-dev"
-        }
-    },
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -324,6 +324,50 @@ to attach one to.
   and emit a runtime deprecation when called. Scheduled for removal in the next
   `MAJOR`.
 
+## Branches & maintenance
+
+`main` holds **exactly the latest release** — nothing lands on it except a
+release merge. Development happens on version branches, so the default branch a
+reader lands on always documents a version they can install.
+
+There is one branch per `MAJOR`, plus `main`:
+
+| Branch | Role         | Takes                                             |
+| ------ | ------------ | ------------------------------------------------- |
+| `main` | released     | Release merges only. Always equals the newest tag |
+| `1.x`  | current      | Fixes and features for the next 1.x release       |
+| `2.x`  | next `MAJOR` | Breaking work for a `MAJOR` not yet released      |
+
+A `<N>.x` branch lives for the whole life of that `MAJOR`. It carries fixes and
+features while the `MAJOR` is current, and once the next one ships it keeps the
+same name and becomes that line's maintenance branch — bug fixes only, then
+security fixes only. There are no per-`MINOR` branches: a fix for 1.19 ships as
+1.20 from `1.x` rather than being backported.
+
+Base a change on the branch matching its nature: ordinary work goes to the
+current `<N>.x`, anything breaking goes to the next `MAJOR`'s. Fixes are merged
+forward — `1.x` into `2.x` — so they are never applied twice and the next
+`MAJOR` never regresses behind the current line.
+
+At any release, the `<N>.x` branch is merged into `main` and tagged there.
+
+Because `main` is the default branch, a pull request opens against it by default
+even though almost nothing should land there directly. **Retarget the base** to
+the development branch — `1.x` for ordinary work, `2.x` for breaking work. The
+[Pull request target](../.github/workflows/pr-target.yaml) check enforces that
+the base branch matches the target declared in the pull-request description.
+
+Additions are still marked _Since X.Y_ (see
+[Documenting Additions](../CONTRIBUTING.md#documenting-additions)) so a reader
+can tell which release introduced a key or option.
+
+> [!IMPORTANT]
+>
+> Documentation on `main` describes the latest release, so everything it
+> documents is available in the version you get from Packagist or the installer.
+> Each addition is marked _Since X.Y_ so you can tell when it appeared; if one
+> carries a version later than the one you have installed, upgrade to get it.
+
 ## LLM model identifiers
 
 Model identifiers passed to `model:`, `attacker_model:`, or `reviewer_model:`


### PR DESCRIPTION
## Summary

Documentation on the default branch drifted ahead of the newest tag, and since `AuditConfigurationDefinition` never calls `ignoreExtraKeys()`, a reader could follow it into `InvalidConfigurationException` — on the standalone binary too, which loads the same extension.

`main` now holds exactly the latest release. Development moves to version branches, the installers and config schema become release assets so their URLs can leave `main`, and CI enforces that a pull request's base matches the branch it declares.

Closes #253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal improvement
- [x] Documentation
- [ ] Tests only

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated — n/a, no PHP source changed
- [x] All checks pass: `bin/castor lint` — run individually, no Docker daemon available
- [ ] 100% MSI
- [x] No `createMock` without a matching `expects()` — n/a
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Branches

One branch per major, plus `main`:

| Branch | Takes |
| --- | --- |
| `main` | Release merges only — always equals the newest tag |
| `1.x` | Fixes and features for the next 1.x release |
| `2.x` | Breaking changes, for the next major |

A `N.x` branch lives for the whole life of that major: it carries fixes and features while the major is current, then keeps the same name and becomes that line's maintenance branch once the next one ships. **No per-minor branches** — a fix for 1.19 ships as 1.20 from `1.x` rather than being backported.