### PR TITLE
fix: restore extra.branch-alias to unbreak CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **CI is green on `1.x` again after `extra.branch-alias` was removed.**
+  Removing it turned every job red — `Lint` on PHPStan, and all nine
+  `Tests + Mutation` legs because Infection runs PHPStan as its static-analysis
+  tool and inherits the same failure. `staabm/phpstan-todo-by`'s
+  `todoBy.sfDeprecation` rule reads the **installed root version** through
+  `Composer\InstalledVersions` and reports every `trigger_deprecation()` whose
+  since-version that root version satisfies; with no alias the root version is
+  the branch name and the three 1.13 deprecations in `SymfonyMapping::create()`,
+  `Vulnerability::create()` and `LLMResponse::create()` were all reported. The
+  alias is restored for both branch keys, and `docs/versioning.md` now records
+  why its value has to stay below the oldest live deprecation so it is not
+  "corrected" into breaking the build again. Removing those three factories is
+  the real fix and belongs to a `MAJOR`.
 - **The standalone binaries are published with releases again.** 1.18.0 added
   `"ext-uri": "*"` to `composer.json` — satisfied on PHP 8.3/8.4 by
   `league/uri-polyfill`, which declares `provide: {"ext-uri": "*"}` — and

--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,12 @@
         },
         "sort-packages": true
     },
+    "extra": {
+        "branch-alias": {
+            "dev-1.x": "1.0.x-dev",
+            "dev-main": "1.0.x-dev"
+        }
+    },
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -304,6 +304,19 @@ alongside it for static analysis and IDE hints. The only deprecations documented
 in the changelog _without_ a runtime trigger are those with no runtime call site
 to attach one to.
 
+> [!WARNING]
+>
+> `extra.branch-alias` in `composer.json` must stay **below the oldest
+> not-yet-removed deprecation**. `staabm/phpstan-todo-by`'s
+> `todoBy.sfDeprecation` rule resolves the installed root version through
+> `Composer\InstalledVersions` and reports every `trigger_deprecation()` whose
+> since-version that version satisfies. Raising the alias to match the release
+> actually in development, or removing it, therefore turns PHPStan red — and
+> with it every `Tests + Mutation` leg, since Infection runs PHPStan too. It is
+> deliberately not rewritten by `bin/castor release:bump` for this reason. The
+> alias can track reality once the deprecations below it are removed in a
+> `MAJOR`.
+
 ### Currently deprecated
 
 - **`cache.prompt_caching`** (since 1.7) — once set `cache_control: ephemeral`


### PR DESCRIPTION
## Summary

Removing `extra.branch-alias` in #254 turned every job on `1.x` red. `Lint` fails on PHPStan; all nine `Tests + Mutation` legs fail because Infection runs PHPStan as its static-analysis tool and inherits the same errors — the mutation run itself completed all 724 mutants, so MSI was never the problem. **One root cause, ten red jobs.**

`staabm/phpstan-todo-by`'s `todoBy.sfDeprecation` resolves the installed root version via `Composer\InstalledVersions` and reports every `trigger_deprecation()` whose since-version that version satisfies. The alias was the only thing supplying a root version, so without it the three 1.13 deprecations were reported as due for removal.

Closes the regression introduced by #254.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal improvement
- [ ] Documentation
- [ ] Tests only

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated — n/a, no PHP source changed
- [x] All checks pass: `bin/castor lint` — run individually, no Docker daemon available
- [x] 100% MSI maintained — Infection needs a full run; PHPStan being green restores it
- [x] No `createMock` without a matching `expects()` — n/a
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Why the value cannot be "kept up to date"

Measured with Composer's own resolver:

| Alias | Normalizes to | Satisfies `>=1.13` | Result |
| --- | --- | --- | --- |
| `1.0.x-dev` | `1.0.9999999.9999999-dev` | false | green |
| `1.19.x-dev` | `1.19.9999999.9999999-dev` | **true** | red |
| *(none)* | branch name | — | red |

So an accurate alias reproduces the failure. Keeping it correct and keeping CI green are mutually exclusive while deprecations from 1.13 remain in the tree — which is why it is **not** wired into `bin/castor release:bump`, and why `docs/versioning.md` now carries a warning so it is not "corrected" into breaking the build again.

Restored under both `dev-1.x` and `dev-main`: Composer falls back to the `dev-main` key when HEAD is on neither branch, which is what CI does on a pull-request merge ref.

## The signal this masks

The gate is right — deprecations from 1.13 with the project at 1.18 are five minors overdue. Because the pin sits below every deprecation added during 1.x, `todoBy.sfDeprecation` has effectively been suppressed project-wide for 18 minors without anyone choosing that. Removing the three `create()` factories is the real fix and is already filed as **#234** for 2.0; once they are gone the alias can track reality and be bump-managed.