### PR TITLE
fix(ci): resolve the root version deterministically

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,16 @@ on:
 permissions:
   contents: read
 
+env:
+  # Pin the root package version instead of letting Composer guess it. The guess
+  # depends on the checked-out branch name and on tags being present, neither of
+  # which holds on a depth-1 detached-HEAD checkout, and
+  # staabm/phpstan-todo-by's todoBy.sfDeprecation reports every
+  # trigger_deprecation() whose since-version the root version satisfies — so a
+  # guess above 1.13 fails PHPStan, and Infection with it. Must stay below the
+  # oldest not-yet-removed deprecation; see docs/versioning.md.
+  COMPOSER_ROOT_VERSION: 1.0.x-dev
+
 jobs:
   prettier:
     name: Prettier Check
@@ -81,6 +91,25 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Assert the resolved root version stays below the oldest deprecation
+        run: |
+          php -r '
+            require "vendor/autoload.php";
+            $package = "vinceamstoutz/symfony-security-auditor";
+            $oldest = "1.13";
+            $ranges = Composer\InstalledVersions::getVersionRanges($package);
+            $satisfies = Composer\InstalledVersions::satisfies(new Composer\Semver\VersionParser(), $package, ">=" . $oldest);
+            printf("root version ranges: %s\n", $ranges);
+            printf("satisfies >=%s: %s\n", $oldest, $satisfies ? "yes" : "no");
+            if ($satisfies) {
+              fwrite(STDERR, sprintf(
+                "::error::The resolved root version (%s) is at or above %s, so todoBy.sfDeprecation will report every trigger_deprecation() introduced in %s. Set COMPOSER_ROOT_VERSION below it, or remove those deprecations. See docs/versioning.md.\n",
+                $ranges, $oldest, $oldest
+              ));
+              exit(1);
+            }
+          '
 
       - name: Cache Rector result cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **CI resolves the root package version deterministically.** Restoring
+  `extra.branch-alias` was not enough: an alias only applies when its key
+  matches the branch Composer manages to infer, and `actions/checkout` produces
+  a depth-1 detached-HEAD checkout with no reachable tags, so the inference —
+  and with it the alias — is unreliable. `todoBy.sfDeprecation` kept reporting
+  the three 1.13 deprecations on `1.x`. `.github/workflows/ci.yaml` now pins
+  `COMPOSER_ROOT_VERSION: 1.0.x-dev` at workflow level, which sets the root
+  version directly and skips inference altogether, and the `Lint` job asserts
+  the resolved version is below the oldest live deprecation before running
+  PHPStan — so a future drift names itself instead of appearing as three
+  unexplained errors.
 - **CI is green on `1.x` again after `extra.branch-alias` was removed.**
   Removing it turned every job red — `Lint` on PHPStan, and all nine
   `Tests + Mutation` legs because Infection runs PHPStan as its static-analysis

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -306,16 +306,25 @@ to attach one to.
 
 > [!WARNING]
 >
-> `extra.branch-alias` in `composer.json` must stay **below the oldest
-> not-yet-removed deprecation**. `staabm/phpstan-todo-by`'s
-> `todoBy.sfDeprecation` rule resolves the installed root version through
-> `Composer\InstalledVersions` and reports every `trigger_deprecation()` whose
-> since-version that version satisfies. Raising the alias to match the release
-> actually in development, or removing it, therefore turns PHPStan red — and
-> with it every `Tests + Mutation` leg, since Infection runs PHPStan too. It is
-> deliberately not rewritten by `bin/castor release:bump` for this reason. The
-> alias can track reality once the deprecations below it are removed in a
-> `MAJOR`.
+> The **resolved root package version** must stay below the oldest
+> not-yet-removed deprecation. `staabm/phpstan-todo-by`'s `todoBy.sfDeprecation`
+> rule reads it through `Composer\InstalledVersions` and reports every
+> `trigger_deprecation()` whose since-version it satisfies, so a root version at
+> or above `1.13` fails PHPStan — and every `Tests + Mutation` leg with it,
+> since Infection runs PHPStan as its static-analysis tool.
+>
+> CI therefore pins `COMPOSER_ROOT_VERSION: 1.0.x-dev` in
+> `.github/workflows/ci.yaml` rather than relying on Composer to guess. The
+> guess depends on the checked-out branch name and on tags being reachable, and
+> holds for neither on a depth-1 detached-HEAD checkout — `extra.branch-alias`
+> alone is not enough, because an alias only applies when its key matches the
+> branch Composer manages to infer. The `Lint` job asserts the resolved version
+> before running PHPStan, so a drift reports itself instead of surfacing as
+> three unexplained deprecation errors.
+>
+> The pin is deliberately not rewritten by `bin/castor release:bump`: raising it
+> to the release actually in development would reintroduce the failure. It can
+> track reality once the deprecations below it are removed in a `MAJOR`.
 
 ### Currently deprecated
 


### PR DESCRIPTION
## Summary

#255 did not unbreak `1.x`. PHPStan still reports the three 1.13 deprecations on `af82f52`, and Infection with it, because **a branch alias only applies when its key matches the branch Composer manages to infer** — and `actions/checkout` produces a depth-1 detached-HEAD checkout with no reachable tags, so that inference is unreliable. `extra.branch-alias` alone cannot fix this.

Pin `COMPOSER_ROOT_VERSION` at workflow level instead: it sets the root version directly and skips inference altogether.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal improvement
- [ ] Documentation
- [ ] Tests only

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated — n/a, no PHP source changed
- [x] All checks pass: `bin/castor lint` — docs/YAML gates run individually; see the honesty note below
- [x] 100% MSI maintained — blocked on PHPStan; this PR is what unblocks it
- [x] No `createMock` without a matching `expects()` — n/a
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Why this is sound

`todoBy.sfDeprecation` errors iff `InstalledVersions::satisfies($package, '>=1.13')` is true (`TodoBySymfonyDeprecationRule.php:106`). Each link measured separately:

| Link | How verified | Result |
| --- | --- | --- |
| `COMPOSER_ROOT_VERSION` → root version | isolated project, real `composer install` | `pretty_version=1.0.x-dev`, `aliases=[]` |
| root version → `getVersionRanges()` | Composer source | `"1.0.x-dev"` |
| that → `satisfies('>=1.13')` | `Semver::satisfies` directly | **false** |

For contrast, the same measurement on the value an accurate pin would use: `1.19.x-dev` normalizes to `1.19.9999999.9999999-dev`, which **does** satisfy `>=1.13`. That is why the pin must not track the release in development, and is not wired into `bin/castor release:bump`.

## Self-reporting instead of silent failure

The `Lint` job now asserts the resolved version before PHPStan runs and fails with the reason:

```
::error::The resolved root version (…) is at or above 1.13, so
todoBy.sfDeprecation will report every trigger_deprecation() introduced in 1.13.
Set COMPOSER_ROOT_VERSION below it, or remove those deprecations.
```

It also prints the resolved ranges on success, so this interaction is inspectable rather than needing rediscovery.

## Honesty note on verification

I could not verify this rule end-to-end locally, and I am not claiming otherwise. `composer install` cannot complete in my environment (the `phpstan/phpstan` dist URL is `api.github.com`, which is egress-blocked), `composer dump-autoload` does **not** refresh root aliases, and patching `installed.php` by hand does not reach the rule — PHPStan loads `InstalledVersions` from its own PHAR context. A control test with `1.18.0` failed to produce the errors it should have, which is how I know that harness is not sensitive.

So the argument above is compositional, from separately measured links, and CI is the real check. The gitignored `composer.lock` is the underlying reason local dependency state diverges from CI's on version-sensitive rules.

## The signal still being masked

The gate is correct: deprecations from 1.13 with the project at 1.18 are five minors overdue, and the pin sits below every deprecation added during 1.x, so `todoBy.sfDeprecation` is effectively suppressed project-wide. Removing the three `create()` factories is the real fix — **#234**, for 2.0. After that the pin can track reality.