### PR TITLE
feat: normalized score and A-F grade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
+- **A report now carries a normalized 0-100 score and an `A`-`F` grade.**
+  `AuditReport::riskScore()` is an unbounded weighted sum, so it grows with
+  every finding and has no ceiling to render against — awkward in a badge, a
+  pull-request comment or a numeric CI gate, all of which need a bounded number.
+  `AuditReport::normalizedScore()` starts at `100` and deducts each finding's
+  `VulnerabilitySeverity::score()` weight, floored at `0`; reusing that one
+  weight table is what keeps the two scales from drifting apart when a severity
+  case changes. `AuditReport::grade()` returns the new
+  `Audit\Domain\Model\SecurityGrade` enum (`A`…`F`), whose boundaries mirror the
+  `riskLevelEnum()` thresholds — `A` is `safe`, `B` is `low`, `C` is `medium`,
+  `D` is `high`, `F` is `critical` — so a report can never read as a healthy
+  grade while its risk level says otherwise. `--format=json` gains the additive
+  root keys `score` and `grade`, and `ExecutiveSummary` carries
+  `normalizedScore` and `grade` beside its existing `riskScore`. `risk_score`
+  and `risk_level` are untouched, so this is purely additive.
 - **The installers and the config schema are published as release assets.**
   `README.md` pointed users at
   `raw.githubusercontent.com/vinceAmstoutz/symfony-security-auditor/main/install.sh`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -674,6 +674,32 @@ follows the reader's light/dark preference.
 
 ![The HTML report: risk badge, run metadata, distribution charts and one card per finding](../assets/html-report.png?raw=true)
 
+### Normalized score and grade
+
+_Since 1.19._ Alongside `risk_score` — an unbounded weighted sum that grows with
+every finding — a report carries a **normalized score** and a **letter grade**,
+both bounded and both meant to be read at a glance in a badge, a pull-request
+comment or a CI gate.
+
+The normalized score starts at `100` and deducts each finding's severity weight
+(`critical` 10, `high` 7, `medium` 5, `low` 2, `info` 0 — the same table
+`risk_score` sums), floored at `0`. So a clean report scores `100`, and one
+critical finding costs 10 points.
+
+The grade boundaries mirror the `risk_level` thresholds, so the two never
+disagree:
+
+| Grade | Score    | `risk_level` | `risk_score` |
+| ----- | -------- | ------------ | ------------ |
+| `A`   | 96 – 100 | `SAFE`       | 0 – 4        |
+| `B`   | 86 – 95  | `LOW`        | 5 – 14       |
+| `C`   | 71 – 85  | `MEDIUM`     | 15 – 29      |
+| `D`   | 51 – 70  | `HIGH`       | 30 – 49      |
+| `F`   | 0 – 50   | `CRITICAL`   | 50 +         |
+
+`--format=json` exposes them as the additive root keys `score` and `grade`;
+`risk_score` and `risk_level` are unchanged.
+
 ### Exit codes
 
 | Code | Meaning                                                                                                                                                                                                                                                                                                                              |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -182,7 +182,10 @@ deprecated by the other.
   by baseline suppression — consumed by `audit:diff` to compare two reports.
   Each entry additionally carries a `cvss` object (`version`, `vector`,
   `base_score`) — a heuristic CVSS v4.0 base-metric estimate derived from the
-  finding's type and severity (another additive `MINOR` change).
+  finding's type and severity (another additive `MINOR` change). The report root
+  also carries `score` (a normalized 0-100 health score, since 1.19) and `grade`
+  (its `A`-`F` letter, since 1.19) beside the unchanged `risk_score` and
+  `risk_level` — both additive.
 - The **SARIF 2.1.0 output** produced by `--format=sarif`. The
   `runs[].tool.driver.name`, `informationUri`, and `version` fields are stable.
   The `version` is sourced dynamically from installed Composer metadata, so it

--- a/src/Audit/Domain/Model/AuditReport.php
+++ b/src/Audit/Domain/Model/AuditReport.php
@@ -239,6 +239,21 @@ final readonly class AuditReport
         );
     }
 
+    /**
+     * The bounded counterpart of {@see riskScore()}: 100 for a clean report,
+     * each finding deducting its severity's `score()` weight, floored at 0.
+     * Reusing that one weight table keeps the two scales from drifting apart.
+     */
+    public function normalizedScore(): int
+    {
+        return max(0, 100 - $this->riskScore());
+    }
+
+    public function grade(): SecurityGrade
+    {
+        return SecurityGrade::fromNormalizedScore($this->normalizedScore());
+    }
+
     public function riskLevel(): string
     {
         return strtoupper($this->riskLevelEnum()->value);
@@ -276,6 +291,8 @@ final readonly class AuditReport
             'files_scanned' => $this->reportIdentity->filesScanned,
             'risk_score' => $this->riskScore(),
             'risk_level' => $this->riskLevel(),
+            'score' => $this->normalizedScore(),
+            'grade' => $this->grade()->value,
             'total_vulnerabilities' => $this->totalVulnerabilities(),
             'by_severity' => $bySeverity,
             'vulnerabilities' => array_map(

--- a/src/Audit/Domain/Model/ExecutiveSummary.php
+++ b/src/Audit/Domain/Model/ExecutiveSummary.php
@@ -28,6 +28,8 @@ final readonly class ExecutiveSummary
     private function __construct(
         public RiskLevel $riskLevel,
         public int $riskScore,
+        public int $normalizedScore,
+        public SecurityGrade $grade,
         public int $totalFindings,
         public array $severityCounts,
         public array $typeCounts,
@@ -39,6 +41,8 @@ final readonly class ExecutiveSummary
         return new self(
             $auditReport->riskLevelEnum(),
             $auditReport->riskScore(),
+            $auditReport->normalizedScore(),
+            $auditReport->grade(),
             $auditReport->totalVulnerabilities(),
             self::severityCounts($auditReport),
             self::mostFrequentFirst(self::typeCounts($auditReport)),

--- a/src/Audit/Domain/Model/SecurityGrade.php
+++ b/src/Audit/Domain/Model/SecurityGrade.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
+
+/**
+ * The letter grade of an {@see AuditReport}, derived from its normalized
+ * 0-100 score. The boundaries mirror the {@see RiskLevel} thresholds in
+ * {@see AuditReport::riskLevelEnum()}, so a report never reads as a healthy
+ * grade while its risk level says otherwise: `A` is `safe`, `B` is `low`,
+ * `C` is `medium`, `D` is `high` and `F` is `critical`.
+ */
+enum SecurityGrade: string
+{
+    case A = 'A';
+    case B = 'B';
+    case C = 'C';
+    case D = 'D';
+    case F = 'F';
+
+    public static function fromNormalizedScore(int $normalizedScore): self
+    {
+        return match (true) {
+            $normalizedScore >= 96 => self::A,
+            $normalizedScore >= 86 => self::B,
+            $normalizedScore >= 71 => self::C,
+            $normalizedScore >= 51 => self::D,
+            default => self::F,
+        };
+    }
+}

--- a/tests/Phpunit/EndToEnd/__snapshots__/default-audit.json
+++ b/tests/Phpunit/EndToEnd/__snapshots__/default-audit.json
@@ -7,6 +7,8 @@
     "files_scanned": 3,
     "risk_score": 10,
     "risk_level": "LOW",
+    "score": 90,
+    "grade": "B",
     "total_vulnerabilities": 1,
     "by_severity": {
         "critical": 1,

--- a/tests/Phpunit/Unit/Domain/Model/AuditReportTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditReportTest.php
@@ -24,6 +24,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditContext;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\CodeLocation;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\RiskLevel;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SecurityGrade;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityClassification;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilityNarrative;
@@ -258,6 +259,27 @@ final class AuditReportTest extends TestCase
     }
 
     /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_it_serializes_the_score_and_grade_alongside_the_unchanged_risk_fields(): void
+    {
+        $array = $this->reportWithExactScore(29)->toArray();
+
+        self::assertSame(
+            ['risk_score' => 29, 'risk_level' => 'MEDIUM', 'score' => 71, 'grade' => 'C'],
+            [
+                'risk_score' => $array['risk_score'],
+                'risk_level' => $array['risk_level'],
+                'score' => $array['score'],
+                'grade' => $array['grade'],
+            ],
+        );
+    }
+
+    /**
      * @throws InvalidAuditContextException
      */
     public function test_it_calculates_duration(): void
@@ -337,6 +359,71 @@ final class AuditReportTest extends TestCase
         yield 'low at 5' => [5, RiskLevel::Low];
         yield 'safe at 4' => [4, RiskLevel::Safe];
         yield 'safe at 0' => [0, RiskLevel::Safe];
+    }
+
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    #[DataProvider('normalizedScoreCases')]
+    public function test_normalized_score_deducts_the_aggregate_risk_from_a_hundred(int $score, int $expectedNormalizedScore): void
+    {
+        self::assertSame($expectedNormalizedScore, $this->reportWithExactScore($score)->normalizedScore());
+    }
+
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function normalizedScoreCases(): iterable
+    {
+        yield 'a clean report scores a hundred' => [0, 100];
+        yield 'a single low finding costs two points' => [2, 98];
+        yield 'the safe ceiling' => [4, 96];
+        yield 'the low ceiling' => [14, 86];
+        yield 'the medium ceiling' => [29, 71];
+        yield 'the high ceiling' => [49, 51];
+        yield 'the critical floor' => [50, 50];
+    }
+
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_normalized_score_is_clamped_at_zero_for_an_overwhelming_risk_score(): void
+    {
+        self::assertSame(0, $this->reportWithExactScore(140)->normalizedScore());
+    }
+
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    #[DataProvider('gradeCases')]
+    public function test_grade_agrees_with_the_risk_level_at_every_boundary(int $score, SecurityGrade $securityGrade): void
+    {
+        self::assertSame($securityGrade, $this->reportWithExactScore($score)->grade());
+    }
+
+    /**
+     * @return iterable<string, array{int, SecurityGrade}>
+     */
+    public static function gradeCases(): iterable
+    {
+        yield 'safe is an A' => [0, SecurityGrade::A];
+        yield 'the safe ceiling is an A' => [4, SecurityGrade::A];
+        yield 'the low floor is a B' => [5, SecurityGrade::B];
+        yield 'the low ceiling is a B' => [14, SecurityGrade::B];
+        yield 'the medium floor is a C' => [15, SecurityGrade::C];
+        yield 'the medium ceiling is a C' => [29, SecurityGrade::C];
+        yield 'the high floor is a D' => [30, SecurityGrade::D];
+        yield 'the high ceiling is a D' => [49, SecurityGrade::D];
+        yield 'the critical floor is an F' => [50, SecurityGrade::F];
     }
 
     /**

--- a/tests/Phpunit/Unit/Domain/Model/ExecutiveSummaryTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/ExecutiveSummaryTest.php
@@ -62,6 +62,23 @@ final class ExecutiveSummaryTest extends TestCase
      * @throws InvalidVulnerabilityClassificationException
      * @throws InvalidVulnerabilityNarrativeException
      */
+    public function test_it_carries_the_reports_normalized_score_and_grade(): void
+    {
+        $auditReport = $this->report($this->vulnerability());
+        $executiveSummary = ExecutiveSummary::of($auditReport);
+
+        self::assertSame(
+            [$auditReport->normalizedScore(), $auditReport->grade()],
+            [$executiveSummary->normalizedScore, $executiveSummary->grade],
+        );
+    }
+
+    /**
+     * @throws InvalidAuditContextException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
     public function test_severity_counts_are_ordered_most_severe_first_and_omit_absent_severities(): void
     {
         $executiveSummary = ExecutiveSummary::of($this->report(

--- a/tests/Phpunit/Unit/Domain/Model/SecurityGradeTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/SecurityGradeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SecurityGrade;
+
+final class SecurityGradeTest extends TestCase
+{
+    #[DataProvider('boundaryCases')]
+    public function test_it_derives_a_grade_from_a_normalized_score(int $normalizedScore, SecurityGrade $securityGrade): void
+    {
+        self::assertSame($securityGrade, SecurityGrade::fromNormalizedScore($normalizedScore));
+    }
+
+    /**
+     * @return iterable<string, array{int, SecurityGrade}>
+     */
+    public static function boundaryCases(): iterable
+    {
+        yield 'a perfect score is an A' => [100, SecurityGrade::A];
+        yield 'the lowest A' => [96, SecurityGrade::A];
+        yield 'the highest B' => [95, SecurityGrade::B];
+        yield 'the lowest B' => [86, SecurityGrade::B];
+        yield 'the highest C' => [85, SecurityGrade::C];
+        yield 'the lowest C' => [71, SecurityGrade::C];
+        yield 'the highest D' => [70, SecurityGrade::D];
+        yield 'the lowest D' => [51, SecurityGrade::D];
+        yield 'the highest F' => [50, SecurityGrade::F];
+        yield 'a floored score is an F' => [0, SecurityGrade::F];
+    }
+}


### PR DESCRIPTION
## Summary

Add a bounded 0-100 score and an `A`-`F` grade to `AuditReport`, so a badge, a PR
comment or a numeric CI gate has something to render. Purely additive.

Closes #257 — unblocks #258, #259 and #260.

## Type of change

- [x] New feature

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## What changed

- `AuditReport::normalizedScore(): int` — 100 minus each finding's
  `VulnerabilitySeverity::score()` weight, floored at 0.
- `AuditReport::grade(): SecurityGrade` — the new `A`…`F` enum.
- `toArray()` gains the root keys `score` and `grade`.
- `ExecutiveSummary` carries `normalizedScore` and `grade` beside `riskScore`.

## Two decisions worth reviewing

The issue left the deduction weights open ("need tuning for this project's
finding distribution, not a straight copy of another tool's table"). Rather than
introduce a second table, the deductions **are** the existing
`VulnerabilitySeverity::score()` weights (critical 10, high 7, medium 5, low 2,
info 0). One table means the two scales cannot drift apart when a severity case
changes — and `.claude/rules/domain-models.md` already requires updating
`score()` on such a change, so both scales stay covered by one rule.

The grade boundaries then mirror the `riskLevelEnum()` thresholds exactly, so a
report can never read as a healthy grade while its risk level says otherwise:

| Grade | Score    | `risk_level` | `risk_score` |
| ----- | -------- | ------------ | ------------ |
| `A`   | 96 – 100 | `SAFE`       | 0 – 4        |
| `B`   | 86 – 95  | `LOW`        | 5 – 14       |
| `C`   | 71 – 85  | `MEDIUM`     | 15 – 29      |
| `D`   | 51 – 70  | `HIGH`       | 30 – 49      |
| `F`   | 0 – 50   | `CRITICAL`   | 50 +         |

## Snapshot

`default-audit.json` is regenerated: its single critical finding scores 10, so
the report reads 90 / `B`. That is the only test the additive keys rippled to.

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection` — 12/12
      mutants killed on the diff
- [x] No `createMock` without a matching `expects()` (use `createStub`
      otherwise)
- [x] Commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org/)