### PR TITLE
refactor: carry pending reviews in a value object

### DIFF
--- a/src/Audit/Application/Agent/Review/ConcurrentReviewAnalyzer.php
+++ b/src/Audit/Application/Agent/Review/ConcurrentReviewAnalyzer.php
@@ -70,11 +70,7 @@ final readonly class ConcurrentReviewAnalyzer
                 continue;
             }
 
-            $pending[] = [
-                'index' => $index,
-                'vulnerability' => $vulnerability,
-                'cacheContext' => $bypassCache ? null : $codeContext,
-            ];
+            $pending[] = new PendingReview($index, $vulnerability, $bypassCache ? null : $codeContext);
             $requests[] = $this->buildRequest($vulnerability, $codeContext);
         }
 
@@ -114,8 +110,8 @@ final readonly class ConcurrentReviewAnalyzer
      * before the next window is attempted, so a failure partway through never
      * discards an earlier window's completed work.
      *
-     * @param list<array{system: string, user: string}>                                        $requests
-     * @param list<array{index: int, vulnerability: Vulnerability, cacheContext: string|null}> $pending
+     * @param list<array{system: string, user: string}> $requests
+     * @param list<PendingReview>                       $pending
      *
      * @return array<int, Vulnerability>
      *
@@ -147,8 +143,8 @@ final readonly class ConcurrentReviewAnalyzer
     }
 
     /**
-     * @param list<array{system: string, user: string}>                                        $requestWindow
-     * @param list<array{index: int, vulnerability: Vulnerability, cacheContext: string|null}> $pendingWindow
+     * @param list<array{system: string, user: string}> $requestWindow
+     * @param list<PendingReview>                       $pendingWindow
      *
      * @return array<int, Vulnerability>
      *
@@ -166,35 +162,32 @@ final readonly class ConcurrentReviewAnalyzer
         }
 
         $reviewed = [];
-        foreach ($pendingWindow as $position => $entry) {
-            $reviewed[$entry['index']] = $this->applyResponseOrRecordError($entry, $responses[$position], $coverageRecorder);
+        foreach ($pendingWindow as $position => $pendingReview) {
+            $reviewed[$pendingReview->index] = $this->applyResponseOrRecordError($pendingReview, $responses[$position], $coverageRecorder);
         }
 
         return $reviewed;
     }
 
-    /**
-     * @param array{index: int, vulnerability: Vulnerability, cacheContext: string|null} $entry
-     */
-    private function applyResponseOrRecordError(array $entry, LLMResponse $llmResponse, CoverageRecorderInterface $coverageRecorder): Vulnerability
+    private function applyResponseOrRecordError(PendingReview $pendingReview, LLMResponse $llmResponse, CoverageRecorderInterface $coverageRecorder): Vulnerability
     {
         try {
-            return $this->reviewOutcomeRecorder->applyResponse($entry['vulnerability'], $llmResponse, $coverageRecorder, $entry['cacheContext']);
+            return $this->reviewOutcomeRecorder->applyResponse($pendingReview->vulnerability, $llmResponse, $coverageRecorder, $pendingReview->cacheContext);
         } catch (Throwable $throwable) {
-            return $this->reviewOutcomeRecorder->recordReviewError($entry['vulnerability'], $throwable, $coverageRecorder);
+            return $this->reviewOutcomeRecorder->recordReviewError($pendingReview->vulnerability, $throwable, $coverageRecorder);
         }
     }
 
     /**
-     * @param list<array{index: int, vulnerability: Vulnerability, cacheContext: string|null}> $pendingWindow
+     * @param list<PendingReview> $pendingWindow
      *
      * @return array<int, Vulnerability>
      */
     private function recordWindowErrors(array $pendingWindow, Throwable $throwable, CoverageRecorderInterface $coverageRecorder): array
     {
         $reviewed = [];
-        foreach ($pendingWindow as $entry) {
-            $reviewed[$entry['index']] = $this->reviewOutcomeRecorder->recordReviewError($entry['vulnerability'], $throwable, $coverageRecorder);
+        foreach ($pendingWindow as $pendingReview) {
+            $reviewed[$pendingReview->index] = $this->reviewOutcomeRecorder->recordReviewError($pendingReview->vulnerability, $throwable, $coverageRecorder);
         }
 
         return $reviewed;
@@ -205,7 +198,7 @@ final readonly class ConcurrentReviewAnalyzer
      * not yet attempted, as failed — without touching windows that already
      * finalized successfully.
      *
-     * @param list<list<array{index: int, vulnerability: Vulnerability, cacheContext: string|null}>> $pendingWindows
+     * @param list<list<PendingReview>> $pendingWindows
      */
     private function failRemainingWindows(array $pendingWindows, int $fromWindowNumber, string $status, CoverageRecorderInterface $coverageRecorder): void
     {
@@ -214,8 +207,8 @@ final readonly class ConcurrentReviewAnalyzer
                 continue;
             }
 
-            foreach ($window as $entry) {
-                $this->reviewOutcomeRecorder->recordUnreached($entry['vulnerability'], $status, $coverageRecorder);
+            foreach ($window as $pendingReview) {
+                $this->reviewOutcomeRecorder->recordUnreached($pendingReview->vulnerability, $status, $coverageRecorder);
             }
         }
     }

--- a/src/Audit/Application/Agent/Review/PendingReview.php
+++ b/src/Audit/Application/Agent/Review/PendingReview.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Review;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
+
+/**
+ * One finding awaiting a dispatched verdict: its position in the caller's
+ * finding list, the finding itself, and the code context to cache the verdict
+ * under — `null` when caching is bypassed for this run.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class PendingReview
+{
+    public function __construct(
+        public int $index,
+        public Vulnerability $vulnerability,
+        public ?string $cacheContext,
+    ) {}
+}


### PR DESCRIPTION
## Summary

`ConcurrentReviewAnalyzer` threaded `array{index: int, vulnerability: Vulnerability, cacheContext: string|null}` through five private methods, repeating the shape at every signature. The new `PendingReview` value object carries it instead, so each signature names the type rather than re-declaring its keys.

First of three PRs for #269. Refs #269 — the issue also covers `PendingChunk` in `ConcurrentChunkAnalyzer` and `ConversationState` in `ToolConversationWavefront`, so it stays open until those land.

The `{system, user}` request shape in the same class is **deliberately left inline**: it also appears in `BatchCapableLLMClientInterface` and `ToolBatchCapableLLMClientInterface`, which are BC-covered Domain ports, so a value object there needs a deprecation cycle rather than an internal-only change. Split out as #270.

No behaviour change — existing coverage for the class is the regression guard.

## Type of change

- [x] Refactor / internal improvement

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)