### PR TITLE
refactor: carry pending chunks in a value object

### DIFF
--- a/src/Audit/Application/Agent/Chunk/ConcurrentChunkAnalyzer.php
+++ b/src/Audit/Application/Agent/Chunk/ConcurrentChunkAnalyzer.php
@@ -73,7 +73,7 @@ final readonly class ConcurrentChunkAnalyzer
 
         /** @var array<int, VulnerabilityHydrationResult> $cachedResults */
         $cachedResults = [];
-        /** @var array<int, array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}> $pending */
+        /** @var array<int, PendingChunk> $pending */
         $pending = [];
         foreach ($chunks as $index => $chunk) {
             $this->reportChunkStarted($index, $totalChunks);
@@ -126,22 +126,18 @@ final readonly class ConcurrentChunkAnalyzer
     /**
      * @param list<ProjectFile> $chunk
      *
-     * @return array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}
-     *
      * @throws InvalidToolRegistryException
      */
-    private function buildPendingChunk(array $chunk, ChunkContext $chunkContext, ?ToolRegistry $toolRegistry): array
+    private function buildPendingChunk(array $chunk, ChunkContext $chunkContext, ?ToolRegistry $toolRegistry): PendingChunk
     {
-        $structuredVulnerabilityCollectionSession = StructuredVulnerabilityCollectionSession::begin($this->recordVulnerabilityToolFactory, $this->logger, $toolRegistry?->tools() ?? []);
-
-        return [
-            'chunk' => $chunk,
-            'contextKey' => $chunkContext->contextKey,
-            'cacheable' => $chunkContext->cacheable,
-            'session' => $structuredVulnerabilityCollectionSession,
-            'systemPrompt' => $chunkContext->systemPrompt,
-            'userMessage' => $chunkContext->userMessage,
-        ];
+        return new PendingChunk(
+            $chunk,
+            $chunkContext->contextKey,
+            $chunkContext->cacheable,
+            StructuredVulnerabilityCollectionSession::begin($this->recordVulnerabilityToolFactory, $this->logger, $toolRegistry?->tools() ?? []),
+            $chunkContext->systemPrompt,
+            $chunkContext->userMessage,
+        );
     }
 
     /**
@@ -198,7 +194,7 @@ final readonly class ConcurrentChunkAnalyzer
      * completes, before the next window is attempted, so a failure partway
      * through never discards an earlier window's completed work.
      *
-     * @param array<int, array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}> $pending
+     * @param array<int, PendingChunk> $pending
      *
      * @return array<int, VulnerabilityHydrationResult>
      *
@@ -234,7 +230,7 @@ final readonly class ConcurrentChunkAnalyzer
     }
 
     /**
-     * @param array<int, array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}> $window
+     * @param array<int, PendingChunk> $window
      *
      * @return array<int, VulnerabilityHydrationResult>
      *
@@ -244,15 +240,15 @@ final readonly class ConcurrentChunkAnalyzer
     private function dispatchWindow(array $window, CoverageRecorderInterface $coverageRecorder): array
     {
         $requests = array_values(array_map(
-            static fn (array $entry): array => ['system' => $entry['systemPrompt'], 'user' => $entry['userMessage'], 'tools' => $entry['session']->toolRegistry],
+            static fn (PendingChunk $pendingChunk): array => ['system' => $pendingChunk->systemPrompt, 'user' => $pendingChunk->userMessage, 'tools' => $pendingChunk->session->toolRegistry],
             $window,
         ));
 
         $this->toolBatchCapableLLMClient->completeBatchWithTools($requests, $this->maxConcurrent, $this->maxToolIterations);
 
         $results = [];
-        foreach ($window as $index => $entry) {
-            $results[$index] = $this->finalizeOrRecordErrored($entry, $coverageRecorder);
+        foreach ($window as $index => $pendingChunk) {
+            $results[$index] = $this->finalizeOrRecordErrored($pendingChunk, $coverageRecorder);
         }
 
         return $results;
@@ -263,18 +259,16 @@ final readonly class ConcurrentChunkAnalyzer
      * error) to that entry alone, mirroring `SequentialChunkAnalyzer`'s
      * per-chunk isolation — a sibling entry in the same window that already
      * finalized successfully must keep its result.
-     *
-     * @param array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string} $entry
      */
-    private function finalizeOrRecordErrored(array $entry, CoverageRecorderInterface $coverageRecorder): VulnerabilityHydrationResult
+    private function finalizeOrRecordErrored(PendingChunk $pendingChunk, CoverageRecorderInterface $coverageRecorder): VulnerabilityHydrationResult
     {
         try {
-            return $this->finalize($entry, $coverageRecorder);
+            return $this->finalize($pendingChunk, $coverageRecorder);
         } catch (Throwable $throwable) {
             $this->logger->warning('Finalizing an attacker chunk result failed; the chunk is recorded as errored and its siblings in the same window are preserved.', [
                 'error' => $throwable->getMessage(),
             ]);
-            ChunkCoverageRecorder::record($entry['chunk'], 'errored', $coverageRecorder);
+            ChunkCoverageRecorder::record($pendingChunk->chunk, 'errored', $coverageRecorder);
 
             return $this->vulnerabilityFactory->fromList([]);
         }
@@ -287,7 +281,7 @@ final readonly class ConcurrentChunkAnalyzer
      * Side effects only: the caller rethrows, so no hydration result is
      * returned or consumed.
      *
-     * @param list<array<int, array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}>> $windows
+     * @param list<array<int, PendingChunk>> $windows
      */
     private function recordRemainingWindows(array $windows, int $fromWindowNumber, string $status, CoverageRecorderInterface $coverageRecorder): void
     {
@@ -305,16 +299,16 @@ final readonly class ConcurrentChunkAnalyzer
      * recorded before the batch aborted. Used both to fail the window that
      * threw and — for a fatal budget/provider abort — every window after it.
      *
-     * @param array<int, array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}> $window
+     * @param array<int, PendingChunk> $window
      *
      * @return array<int, VulnerabilityHydrationResult>
      */
     private function failWindow(array $window, string $status, CoverageRecorderInterface $coverageRecorder): array
     {
         $results = [];
-        foreach ($window as $index => $entry) {
-            ChunkCoverageRecorder::record($entry['chunk'], $status, $coverageRecorder);
-            $this->recordDrainedFindings($entry['session'], $coverageRecorder);
+        foreach ($window as $index => $pendingChunk) {
+            ChunkCoverageRecorder::record($pendingChunk->chunk, $status, $coverageRecorder);
+            $this->recordDrainedFindings($pendingChunk->session, $coverageRecorder);
             $results[$index] = $this->vulnerabilityFactory->fromList([]);
         }
 
@@ -339,18 +333,15 @@ final readonly class ConcurrentChunkAnalyzer
         ChunkFindingProgress::report($this->progressReporter, $vulnerabilities);
     }
 
-    /**
-     * @param array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string} $entry
-     */
-    private function finalize(array $entry, CoverageRecorderInterface $coverageRecorder): VulnerabilityHydrationResult
+    private function finalize(PendingChunk $pendingChunk, CoverageRecorderInterface $coverageRecorder): VulnerabilityHydrationResult
     {
-        $rawData = $entry['session']->drain();
+        $rawData = $pendingChunk->session->drain();
 
-        if ($entry['cacheable']) {
-            $this->attackerChunkCache->store($entry['chunk'], $entry['contextKey'], $rawData);
+        if ($pendingChunk->cacheable) {
+            $this->attackerChunkCache->store($pendingChunk->chunk, $pendingChunk->contextKey, $rawData);
         }
 
-        ChunkCoverageRecorder::record($entry['chunk'], 'analyzed', $coverageRecorder);
+        ChunkCoverageRecorder::record($pendingChunk->chunk, 'analyzed', $coverageRecorder);
 
         $vulnerabilityHydrationResult = $this->vulnerabilityFactory->fromList($rawData);
         foreach ($vulnerabilityHydrationResult->vulnerabilities() as $vulnerability) {

--- a/src/Audit/Application/Agent/Chunk/PendingChunk.php
+++ b/src/Audit/Application/Agent/Chunk/PendingChunk.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\Chunk;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+
+/**
+ * One cache-miss chunk awaiting a dispatched batch call: the files it covers,
+ * the cache coordinates its findings are stored under, the collection session
+ * the `record_vulnerability` calls land in, and the rendered prompts.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class PendingChunk
+{
+    /**
+     * @param list<ProjectFile> $chunk
+     */
+    public function __construct(
+        public array $chunk,
+        public string $contextKey,
+        public bool $cacheable,
+        public StructuredVulnerabilityCollectionSession $session,
+        public string $systemPrompt,
+        public string $userMessage,
+    ) {}
+}


### PR DESCRIPTION
## Summary

`ConcurrentChunkAnalyzer` threaded `array{chunk: list<ProjectFile>, contextKey: string, cacheable: bool, session: StructuredVulnerabilityCollectionSession, systemPrompt: string, userMessage: string}` through seven methods — `buildPendingChunk()`, `dispatchInWindows()`, `dispatchWindow()`, `finalizeOrRecordErrored()`, `recordRemainingWindows()`, `failWindow()`, `finalize()` — re-declaring all six keys at every signature. The new `PendingChunk` value object carries it instead.

Second of three PRs for #269. Refs #269 — `ConversationState` in `ToolConversationWavefront` is still to come, so the issue stays open.

No behaviour change — existing coverage for the class is the regression guard.

## Type of change

- [x] Refactor / internal improvement

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)