### PR TITLE
refactor: type the batch request shape behind the ports

### DIFF
--- a/src/Audit/Domain/Port/LLMRequest.php
+++ b/src/Audit/Domain/Port/LLMRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
+
+/**
+ * One prompt pair bound for a batch-capable client.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class LLMRequest
+{
+    public function __construct(
+        public string $system,
+        public string $user,
+    ) {}
+
+    /**
+     * @param list<array{system: string, user: string}> $requests
+     *
+     * @return list<self>
+     */
+    public static function listFromArrays(array $requests): array
+    {
+        return array_map(
+            static fn (array $request): self => new self($request['system'], $request['user']),
+            $requests,
+        );
+    }
+}

--- a/src/Audit/Domain/Port/ToolLLMRequest.php
+++ b/src/Audit/Domain/Port/ToolLLMRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port;
+
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
+
+/**
+ * One tool-using conversation bound for a tool-batch-capable client. Separate
+ * from {@see LLMRequest} so the registry is never nullable.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class ToolLLMRequest
+{
+    public function __construct(
+        public string $system,
+        public string $user,
+        public ToolRegistry $tools,
+    ) {}
+
+    /**
+     * @param list<array{system: string, user: string, tools: ToolRegistry}> $requests
+     *
+     * @return list<self>
+     */
+    public static function listFromArrays(array $requests): array
+    {
+        return array_map(
+            static fn (array $request): self => new self($request['system'], $request['user'], $request['tools']),
+            $requests,
+        );
+    }
+}

--- a/src/Audit/Infrastructure/LLM/BatchWindowResolver.php
+++ b/src/Audit/Infrastructure/LLM/BatchWindowResolver.php
@@ -23,6 +23,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\BudgetTracker;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\BudgetExceededException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\TokenUsageSnapshot;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMRequest;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\MissingAiPlatformException;
@@ -52,7 +53,7 @@ final readonly class BatchWindowResolver
     ) {}
 
     /**
-     * @param list<array{system: string, user: string}> $window
+     * @param list<LLMRequest> $window
      *
      * @return list<LLMResponse>
      *
@@ -65,12 +66,12 @@ final readonly class BatchWindowResolver
 
         $platform = $this->platform ?? throw MissingAiPlatformException::create();
         $deferred = [];
-        foreach ($window as $index => $request) {
+        foreach ($window as $index => $llmRequest) {
             $messageBag = new MessageBag(
-                Message::forSystem($request['system']),
-                Message::ofUser($request['user']),
+                Message::forSystem($llmRequest->system),
+                Message::ofUser($llmRequest->user),
             );
-            $estimatedInputTokens = $this->promptTokenEstimator->estimate($request['system'], $request['user']);
+            $estimatedInputTokens = $this->promptTokenEstimator->estimate($llmRequest->system, $llmRequest->user);
             $this->rateLimiter->acquire($estimatedInputTokens);
 
             try {
@@ -81,24 +82,22 @@ final readonly class BatchWindowResolver
         }
 
         $resolved = [];
-        foreach ($window as $index => $request) {
-            $resolved[$index] = $this->resolveOne($deferred[$index], $request);
+        foreach ($window as $index => $llmRequest) {
+            $resolved[$index] = $this->resolveOne($deferred[$index], $llmRequest);
         }
 
         return array_values($resolved);
     }
 
     /**
-     * @param array{system: string, user: string} $request
-     *
      * @throws BudgetExceededException
      */
-    private function resolveOne(?DeferredResult $deferredResult, array $request): LLMResponse
+    private function resolveOne(?DeferredResult $deferredResult, LLMRequest $llmRequest): LLMResponse
     {
         if (!$deferredResult instanceof DeferredResult) {
             $this->rateLimiter->record(0, 0);
 
-            return $this->llmClient->complete($request['system'], $request['user']);
+            return $this->llmClient->complete($llmRequest->system, $llmRequest->user);
         }
 
         $reconciled = false;
@@ -128,7 +127,7 @@ final readonly class BatchWindowResolver
 
             $this->logger->warning('Batch-window response failed to resolve after dispatch; falling back to a fresh complete() call that may duplicate provider billing for the already-dispatched request');
 
-            return $this->llmClient->complete($request['system'], $request['user']);
+            return $this->llmClient->complete($llmRequest->system, $llmRequest->user);
         }
     }
 }

--- a/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
+++ b/src/Audit/Infrastructure/LLM/SymfonyAiLLMClient.php
@@ -24,10 +24,12 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Budget\Exception\Budg
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\NegativeTokenCountException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidTokenUsageException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\TokenUsageSnapshot;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMRequest;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ToolBatchCapableLLMClientInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ToolLLMRequest;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\EmptyLLMResponseException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\InvalidRetryConfigurationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\MissingAiPlatformException;
@@ -216,7 +218,7 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         $windowSize = max(1, $maxConcurrent);
         $responses = [];
 
-        foreach (array_chunk($requests, $windowSize) as $window) {
+        foreach (array_chunk(LLMRequest::listFromArrays($requests), $windowSize) as $window) {
             foreach ($this->batchWindowResolver->resolveWindow($window) as $llmResponse) {
                 $responses[] = $llmResponse;
             }
@@ -239,7 +241,7 @@ final readonly class SymfonyAiLLMClient implements ToolBatchCapableLLMClientInte
         $windowSize = max(1, $maxConcurrent);
         $responses = [];
 
-        foreach (array_chunk($requests, $windowSize) as $window) {
+        foreach (array_chunk(ToolLLMRequest::listFromArrays($requests), $windowSize) as $window) {
             foreach ($this->toolConversationWavefront->resolveToolWindow($window, $maxToolIterations) as $llmResponse) {
                 $responses[] = $llmResponse;
             }

--- a/src/Audit/Infrastructure/LLM/ToolConversationWavefront.php
+++ b/src/Audit/Infrastructure/LLM/ToolConversationWavefront.php
@@ -30,7 +30,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\TokenUsageSnapshot;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMResponse;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\RateLimiterInterface;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\Tool\ToolRegistry;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\ToolLLMRequest;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\MissingAiPlatformException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\Exception\NonTransientLLMFailureException;
 
@@ -71,7 +71,7 @@ final readonly class ToolConversationWavefront
     ) {}
 
     /**
-     * @param list<array{system: string, user: string, tools: ToolRegistry}> $window
+     * @param list<ToolLLMRequest> $window
      *
      * @return list<LLMResponse>
      *
@@ -94,18 +94,18 @@ final readonly class ToolConversationWavefront
     }
 
     /**
-     * @param list<array{system: string, user: string, tools: ToolRegistry}> $window
+     * @param list<ToolLLMRequest> $window
      *
      * @return array<int, ConversationState>
      */
     private function initializeConversationStates(array $window): array
     {
         $states = [];
-        foreach ($window as $index => $request) {
+        foreach ($window as $index => $toolLLMRequest) {
             $options = $this->platformOptionsFactory->baseOptions();
-            $options['tools'] = PlatformToolsMapper::map($request['tools']->definitions());
+            $options['tools'] = PlatformToolsMapper::map($toolLLMRequest->tools->definitions());
             $states[$index] = new ConversationState(
-                new MessageBag(Message::forSystem($request['system']), Message::ofUser($request['user'])),
+                new MessageBag(Message::forSystem($toolLLMRequest->system), Message::ofUser($toolLLMRequest->user)),
                 $options,
                 0,
                 0,
@@ -113,7 +113,7 @@ final readonly class ToolConversationWavefront
                 0,
                 false,
                 null,
-                $this->promptTokenEstimator->estimate($request['system'], $request['user']),
+                $this->promptTokenEstimator->estimate($toolLLMRequest->system, $toolLLMRequest->user),
             );
         }
 
@@ -121,8 +121,8 @@ final readonly class ToolConversationWavefront
     }
 
     /**
-     * @param array<int, ConversationState>                                  $states
-     * @param list<array{system: string, user: string, tools: ToolRegistry}> $window
+     * @param array<int, ConversationState> $states
+     * @param list<ToolLLMRequest>          $window
      *
      * @return array<int, ConversationState>
      *
@@ -196,36 +196,32 @@ final readonly class ToolConversationWavefront
     }
 
     /**
-     * @param array{system: string, user: string, tools: ToolRegistry} $request
-     *
      * @throws BudgetExceededException
      * @throws InvalidTokenUsageException
      * @throws NonTransientLLMFailureException
      */
-    private function advanceConversation(ConversationState $conversationState, ?DeferredResult $deferredResult, array $request, int $maxToolIterations): ConversationState
+    private function advanceConversation(ConversationState $conversationState, ?DeferredResult $deferredResult, ToolLLMRequest $toolLLMRequest, int $maxToolIterations): ConversationState
     {
         if (!$deferredResult instanceof DeferredResult) {
             $this->rateLimiter->record(0, 0);
 
-            return $this->retryOrAbortConversation($conversationState, $request, $maxToolIterations);
+            return $this->retryOrAbortConversation($conversationState, $toolLLMRequest, $maxToolIterations);
         }
 
         try {
-            return $this->processDeferredResult($conversationState, $deferredResult, $request);
+            return $this->processDeferredResult($conversationState, $deferredResult, $toolLLMRequest);
         } catch (BudgetExceededException $budgetExceededException) {
             throw $budgetExceededException;
         } catch (Throwable) {
-            return $this->retryOrAbortConversation($conversationState, $request, $maxToolIterations);
+            return $this->retryOrAbortConversation($conversationState, $toolLLMRequest, $maxToolIterations);
         }
     }
 
     /**
-     * @param array{system: string, user: string, tools: ToolRegistry} $request
-     *
      * @throws BudgetExceededException
      * @throws InvalidTokenUsageException
      */
-    private function processDeferredResult(ConversationState $conversationState, DeferredResult $deferredResult, array $request): ConversationState
+    private function processDeferredResult(ConversationState $conversationState, DeferredResult $deferredResult, ToolLLMRequest $toolLLMRequest): ConversationState
     {
         try {
             $platformResult = $deferredResult->getResult();
@@ -251,7 +247,7 @@ final readonly class ToolConversationWavefront
         $toolCalls = $this->platformResultExtractor->extractToolCalls($platformResult);
 
         if ([] !== $toolCalls) {
-            return $this->runToolCalls($conversationState, $toolCalls, $request);
+            return $this->runToolCalls($conversationState, $toolCalls, $toolLLMRequest);
         }
 
         return $conversationState->withResponse(LLMResponse::of(
@@ -273,13 +269,11 @@ final readonly class ToolConversationWavefront
      * is rethrown rather than finalized, since a restart can't happen and
      * masking the failure would produce a false-negative SAFE result.
      *
-     * @param array{system: string, user: string, tools: ToolRegistry} $request
-     *
      * @throws BudgetExceededException
      * @throws InvalidTokenUsageException
      * @throws NonTransientLLMFailureException
      */
-    private function retryOrAbortConversation(ConversationState $conversationState, array $request, int $maxToolIterations): ConversationState
+    private function retryOrAbortConversation(ConversationState $conversationState, ToolLLMRequest $toolLLMRequest, int $maxToolIterations): ConversationState
     {
         try {
             $deferredResult = $this->retryingPlatformInvoker->invoke($conversationState->bag, $conversationState->options, $conversationState->estimatedInputTokens);
@@ -288,31 +282,30 @@ final readonly class ToolConversationWavefront
                 throw $nonTransientLLMFailureException;
             }
 
-            return $this->abortConversation($conversationState, $request, $maxToolIterations);
+            return $this->abortConversation($conversationState, $toolLLMRequest, $maxToolIterations);
         } catch (Throwable) {
-            return $this->abortConversation($conversationState, $request, $maxToolIterations);
+            return $this->abortConversation($conversationState, $toolLLMRequest, $maxToolIterations);
         }
 
         try {
-            return $this->processDeferredResult($conversationState, $deferredResult, $request);
+            return $this->processDeferredResult($conversationState, $deferredResult, $toolLLMRequest);
         } catch (BudgetExceededException $budgetExceededException) {
             throw $budgetExceededException;
         } catch (Throwable) {
-            return $this->abortConversation($conversationState, $request, $maxToolIterations);
+            return $this->abortConversation($conversationState, $toolLLMRequest, $maxToolIterations);
         }
     }
 
     /**
-     * @param list<ToolCall>                                           $toolCalls
-     * @param array{system: string, user: string, tools: ToolRegistry} $request
+     * @param list<ToolCall> $toolCalls
      */
-    private function runToolCalls(ConversationState $conversationState, array $toolCalls, array $request): ConversationState
+    private function runToolCalls(ConversationState $conversationState, array $toolCalls, ToolLLMRequest $toolLLMRequest): ConversationState
     {
         $conversationState->bag->add(new AssistantMessage(...$toolCalls));
 
         $toolResults = [];
         foreach ($toolCalls as $toolCall) {
-            $result = $request['tools']->execute($toolCall->getName(), $toolCall->getArguments());
+            $result = $toolLLMRequest->tools->execute($toolCall->getName(), $toolCall->getArguments());
             $conversationState->bag->add(new ToolCallMessage($toolCall, new Text($result)));
             $toolResults[] = $result;
         }
@@ -321,14 +314,12 @@ final readonly class ToolConversationWavefront
     }
 
     /**
-     * @param array{system: string, user: string, tools: ToolRegistry} $request
-     *
      * @throws InvalidTokenUsageException
      */
-    private function abortConversation(ConversationState $conversationState, array $request, int $maxToolIterations): ConversationState
+    private function abortConversation(ConversationState $conversationState, ToolLLMRequest $toolLLMRequest, int $maxToolIterations): ConversationState
     {
         if (!$conversationState->toolsRan) {
-            return $conversationState->withResponse($this->llmClient->completeWithTools($request['system'], $request['user'], $request['tools'], $maxToolIterations));
+            return $conversationState->withResponse($this->llmClient->completeWithTools($toolLLMRequest->system, $toolLLMRequest->user, $toolLLMRequest->tools, $maxToolIterations));
         }
 
         $this->logger->warning('Concurrent tool-using conversation failed after tool execution; keeping recorded tool results', [

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -26,7 +26,9 @@ use Symfony\AI\Platform\FinishReason\FinishReason;
 use Symfony\AI\Platform\FinishReason\FinishReasonCase;
 use Symfony\AI\Platform\Message\AssistantMessage;
 use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\SystemMessage;
 use Symfony\AI\Platform\Message\ToolCallMessage;
+use Symfony\AI\Platform\Message\UserMessage;
 use Symfony\AI\Platform\Model;
 use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
 use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
@@ -1044,6 +1046,50 @@ final class SymfonyAiLLMClientTest extends TestCase
         ));
         self::assertCount(1, $capLogs);
         self::assertSame(2, $capLogs[0][1]['max_iterations']);
+    }
+
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     */
+    public function test_complete_batch_sends_each_prompt_under_its_own_role(): void
+    {
+        $platformInvocationLog = new PlatformInvocationLog();
+        $platform = $this->scriptedPlatform([new TextResult('ok')], $platformInvocationLog);
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding($platform, 'm', new NullLogger()));
+
+        $symfonyAiLLMClient->completeBatch([['system' => 'sys-prompt', 'user' => 'usr-prompt']], 4);
+
+        $messages = $platformInvocationLog->messageSnapshots[0];
+        self::assertInstanceOf(SystemMessage::class, $messages[0]);
+        self::assertSame('sys-prompt', $messages[0]->getContent());
+        self::assertInstanceOf(UserMessage::class, $messages[1]);
+    }
+
+    /**
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     * @throws InvalidToolRegistryException
+     * @throws InvalidTokenUsageException
+     * @throws NonTransientLLMFailureException
+     */
+    public function test_complete_batch_with_tools_sends_each_prompt_under_its_own_role(): void
+    {
+        $toolRegistry = new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger());
+        $platformInvocationLog = new PlatformInvocationLog();
+        $platform = $this->scriptedPlatform([new TextResult('ok')], $platformInvocationLog);
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(new PlatformBinding($platform, 'm', new NullLogger()));
+
+        $symfonyAiLLMClient->completeBatchWithTools([
+            ['system' => 'sys-prompt', 'user' => 'usr-prompt', 'tools' => $toolRegistry],
+        ], 4, 2);
+
+        $messages = $platformInvocationLog->messageSnapshots[0];
+        self::assertInstanceOf(SystemMessage::class, $messages[0]);
+        self::assertSame('sys-prompt', $messages[0]->getContent());
+        self::assertInstanceOf(UserMessage::class, $messages[1]);
     }
 
     /**


### PR DESCRIPTION
## Summary

`array{system: string, user: string}` and its `+ tools: ToolRegistry` variant were repeated across `BatchWindowResolver` (2 occurrences) and `ToolConversationWavefront` (8). `LLMRequest` and `ToolLLMRequest` carry them instead, mapped once at the two `SymfonyAiLLMClient` entry points.

Closes #270 — though see the scope note below, since this deliberately lands less than the issue describes.

**No BC break.** Both Domain port signatures are byte-identical: `completeBatch()` and `completeBatchWithTools()` still accept the same array shapes. #270 originally proposed adding VO-typed methods to those ports and deprecating the array ones — but adding a method to an existing interface breaks every third-party implementor, and both ports are BC-covered (no `@internal`). So the conversion happens on our side of an unchanged seam: no new public interfaces, no deprecation cycle, ships as a plain `MINOR`.

Two VOs rather than one with a nullable `ToolRegistry`, so the registry is never nullable on the path that always has one — no new failure mode, no `?->` at the call sites.

## Scope note

The remaining 4 occurrences (`ConcurrentReviewAnalyzer`, `ConcurrentReviewBatch`, `ConcurrentStructuredReviewAnalyzer`) sit *adjacent* to the port call and are deliberately left alone. Converting them now would mean adding a `toArray()` that exists purely to feed an unchanged port — and that helper gets deleted again in #239 (`feat!: narrow the Domain port BC surface`), which is where those signatures legitimately change. 10 of 14 occurrences here; the last 4 belong to #239.

## Type of change

- [x] Refactor / internal improvement

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)