### PR TITLE
fix: PR-comment escaping and failing-gate message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,46 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   BC break: `composer.json` metadata is not part of the public API surface in
   [`docs/versioning.md`](docs/versioning.md).
 
+### Security
+
+- **A finding title can no longer ping an arbitrary GitHub account from a posted
+  pull-request comment.** `MarkdownTextEscaper::escapeStructuralMarkers()`
+  enumerated the Markdown-active characters it neutralizes (`` ` ``, `~`, `#`,
+  `<`, `>`, `[`, `]`) but omitted `@`, and GitHub autolinks a bare `@handle` in
+  a comment body into a live profile mention. A finding title is LLM-authored
+  from attacker-influenceable repository content, and `action.yml`'s
+  `comment-pr` step posts the rendered body verbatim with a
+  `pull-requests: write` token — so a crafted target project could notify any
+  GitHub user through the audited repository's own automation. `@` is now
+  HTML-entity-encoded as `&#64;`, the same treatment `<`/`>` already had, so it
+  renders as a literal `@` without triggering the mention.
+
+- **A file path containing `|` can no longer forge a column in the pull-request
+  comment table.** `MarkdownTextEscaper::inlineCode()` wraps text in a backtick
+  run, but GFM splits a table row on unescaped `|` _before_ inline parsing, so a
+  code span does not shield one — and `CodeLocation` accepts any non-blank
+  `filePath`, fed straight from LLM tool-call output with no character
+  allowlist. `GithubCommentReportRenderer` rendered the Location and Type cells
+  through `inlineCode()`, so a path like `src/Foo|Bar.php` corrupted the row a
+  reviewer reads to see validated findings. The new
+  `MarkdownTextEscaper::tableInlineCode()` backslash-escapes `|` and is used for
+  both cells; plain `inlineCode()` is unchanged, since `\|` renders literally in
+  a code span outside a table.
+
 ### Fixed
+
+- **A failing audit no longer blames the `--fail-on` threshold for a
+  `--min-score` failure.** `AuditExitCodeResolver::resolve()` fails a run when
+  the risk gate **or** the independent `--min-score` gate trips, but only the
+  resulting exit code reaches `AuditPresenter::result()`, which unconditionally
+  printed `Audit completed at or above the fail-on threshold. Risk: %s.` So
+  `audit:run --fail-on=critical --min-score=96` against a project with one
+  MEDIUM finding (risk `LOW`, score 95) reported a fail-on breach that had not
+  happened, pointing engineers at a risk-level regression that did not exist.
+  The message now reads
+  `Audit failed a configured gate. Risk: %s. Score: %d/100.` — naming neither
+  gate and surfacing both gated values, matching what `audit:run --help` already
+  documented.
 
 - **Standalone configuration resolves `%env(...)%` placeholders outside the
   `platform` block.** `StandaloneConfigLoader::load()` splits the raw YAML into

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ bin/castor up
 | Lint + auto-fix         | `bin/castor lint:fix`                                                       |
 | Markdown check only     | `bin/castor lint:docs` (fast pre-push check)                                |
 | Run PHP tests           | `docker compose exec php vendor/bin/phpunit`                                |
-| Run mutation tests      | `docker compose exec php bin/infection`                                     |
+| Run mutation tests      | `bin/castor lint` (its Infection step mirrors CI's flags — see below)       |
 | Score detection quality | `bin/castor eval` (audits a ground-truth fixture, reports precision/recall) |
 | Symfony console         | `docker compose exec php bin/console <command>`                             |
 
@@ -59,6 +59,17 @@ bin/castor up
 scan) → Install script tests (`tests/Shell/install_script_test.sh`) → PHPUnit →
 Infection. `bin/castor lint:fix` auto-fixes steps 1–3 (Prettier, Markdown lint,
 Composer Normalize); the remaining steps are check-only.
+
+Run Infection **through `bin/castor lint`**, never as a bare `bin/infection`.
+The task's PHPUnit step emits the
+`--coverage-clover`/`--coverage-xml`/`--log-junit` set that its Infection step
+then reuses via
+`--coverage=build/coverage --skip-initial-tests --min-msi=100 --min-covered-msi=100`,
+matching `.github/workflows/ci.yaml`; invoking `bin/infection` with ad-hoc flags
+has twice reported a green 100% MSI on a commit CI then rejected. Note that a
+single green run is still not proof of CI parity: Infection rewrites
+`phpunit.dist.xml` to force `executionOrder="defects,random"` while disabling
+result caching, so test order is effectively random per invocation — see #275.
 
 Commit messages are validated separately in CI via
 [commitlint](https://commitlint.js.org/) (`commitlint.config.js`) — see

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,19 @@ Common scopes: `agent`, `pipeline`, `domain`, `llm`, `command`, `bundle`,
 `standalone`, `scan`, `deps`, `ci`, `rate-limit`. Breaking changes: `feat!:`
 with `BREAKING CHANGE:` footer.
 
+## Pull Requests
+
+Fill in [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)
+and keep the top of the PR short:
+
+- **Title: 50 characters or fewer**, same
+  [Conventional Commits](https://www.conventionalcommits.org/) format as a
+  commit subject.
+- **`## Summary`: 500 characters or fewer.** State the user-visible outcome and
+  stop. Per-finding walkthroughs, verification tables and reviewer notes belong
+  in their own sections further down — the summary is the part everyone reads,
+  so it must stay skimmable.
+
 ## CI Pipeline
 
 Seven jobs must all pass before merging: **Prettier Check** (markdown

--- a/castor.php
+++ b/castor.php
@@ -206,10 +206,10 @@ function runCodeQualityTools(bool $fixMode = false): void
     run('sh tests/Shell/install_script_test.sh');
 
     io()->section('PHPUnit');
-    run('docker compose exec php vendor/bin/phpunit --coverage-clover=build/coverage/clover.xml');
+    run('docker compose exec php vendor/bin/phpunit --coverage-clover=build/coverage/clover.xml --coverage-xml=build/coverage/coverage-xml --log-junit=build/coverage/junit.xml');
 
     io()->section('Infection');
-    run('docker compose exec php php -d memory_limit=2G bin/infection');
+    run('docker compose exec php php -d memory_limit=2G bin/infection --configuration=infection.json5 --threads=max --coverage=build/coverage --skip-initial-tests --min-msi=100 --min-covered-msi=100');
 
     io()->success($fixMode ? 'Fixing complete.' : 'Linting complete.');
 }

--- a/src/Audit/Infrastructure/Report/GithubCommentReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/GithubCommentReportRenderer.php
@@ -111,8 +111,8 @@ final readonly class GithubCommentReportRenderer implements ReportRendererInterf
             '| %s | %s | %s | %s |',
             $vulnerability->severity()->label(),
             MarkdownTextEscaper::tableCell($vulnerability->title()),
-            MarkdownTextEscaper::inlineCode(\sprintf('%s:%d', $vulnerability->filePath(), $vulnerability->lineStart())),
-            MarkdownTextEscaper::inlineCode($vulnerability->type()->value),
+            MarkdownTextEscaper::tableInlineCode(\sprintf('%s:%d', $vulnerability->filePath(), $vulnerability->lineStart())),
+            MarkdownTextEscaper::tableInlineCode($vulnerability->type()->value),
         );
     }
 

--- a/src/Audit/Infrastructure/Report/MarkdownTextEscaper.php
+++ b/src/Audit/Infrastructure/Report/MarkdownTextEscaper.php
@@ -33,17 +33,19 @@ final readonly class MarkdownTextEscaper
      * A backtick/tilde run would open a code fence, `#` a fake heading, and
      * `[`/`]` a live link — each would swallow or rewrite everything rendered
      * after it. `<`/`>` are HTML-entity-encoded since CommonMark passes raw
-     * inline HTML through verbatim. A backslash already present is escaped
-     * first, so it can't combine with an escape added below into a sequence
-     * CommonMark still parses as live.
+     * inline HTML through verbatim. `@` is encoded the same way because GitHub
+     * autolinks a bare `@handle` into a live profile mention, notifying that
+     * account when a report is posted as a pull-request comment. A backslash
+     * already present is escaped first, so it can't combine with an escape
+     * added below into a sequence CommonMark still parses as live.
      */
     private static function escapeStructuralMarkers(string $text): string
     {
         $backslashesEscaped = str_replace('\\', '\\\\', $text);
 
         return str_replace(
-            ['`', '~', '#', '<', '>', '[', ']'],
-            ['\\`', '\\~', '\\#', '&lt;', '&gt;', '\\[', '\\]'],
+            ['`', '~', '#', '<', '>', '[', ']', '@'],
+            ['\\`', '\\~', '\\#', '&lt;', '&gt;', '\\[', '\\]', '&#64;'],
             $backslashesEscaped,
         );
     }
@@ -102,6 +104,17 @@ final readonly class MarkdownTextEscaper
     public static function tableCell(string $text): string
     {
         return str_replace('|', '\\|', self::heading($text));
+    }
+
+    /**
+     * GFM splits a table row on unescaped `|` before inline parsing, so a code
+     * span does not shield one — {@see self::inlineCode()} alone still lets a
+     * pipe in the text forge a column. The escape is applied only here because
+     * a code span outside a table renders `\|` literally.
+     */
+    public static function tableInlineCode(string $text): string
+    {
+        return str_replace('|', '\\|', self::inlineCode($text));
     }
 
     /**

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -215,8 +215,9 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         if (Command::FAILURE === $exitCode) {
             $totalVulnerabilities = $auditReport->totalVulnerabilities();
             $symfonyStyle->caution(\sprintf(
-                'Audit completed at or above the fail-on threshold. Risk: %s. %d %s found.',
+                'Audit failed a configured gate. Risk: %s. Score: %d/100. %d %s found.',
                 $auditReport->riskLevel(),
+                $auditReport->normalizedScore(),
                 $totalVulnerabilities,
                 1 === $totalVulnerabilities ? 'vulnerability' : 'vulnerabilities',
             ));

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -175,6 +175,31 @@ final class AuditPresenterTest extends TestCase
     }
 
     /**
+     * `AuditExitCodeResolver` fails a run when the risk gate OR the independent
+     * `--min-score` gate trips, and only the exit code reaches the presenter —
+     * so it must not attribute the failure to one specific gate. A LOW-risk
+     * report failing under `--fail-on=critical --min-score=96` is a
+     * score-only failure the old wording described as a fail-on breach.
+     *
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_result_for_failure_exit_does_not_blame_a_gate_it_cannot_identify(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->result($symfonyStyle, $this->makeLowRiskReport(), Command::FAILURE);
+
+        $flattened = preg_replace('/\s+/', ' ', $bufferedOutput->fetch()) ?? '';
+        self::assertStringNotContainsString('at or above the fail-on threshold', $flattened);
+        self::assertStringContainsString('Risk: LOW', $flattened);
+        self::assertStringContainsString('Score: 95/100', $flattened);
+    }
+
+    /**
      * @throws InvalidAuditContextException
      */
     public function test_result_for_success_exit_emits_success_message(): void
@@ -583,6 +608,30 @@ final class AuditPresenterTest extends TestCase
                 )->withReviewerValidation(true),
             );
         }
+
+        return AuditReport::fromContext($auditContext);
+    }
+
+    /**
+     * One MEDIUM finding scores 5, so risk is LOW and the normalized score is
+     * 95 — the shape a `--min-score=96` run fails on while the risk gate passes.
+     *
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidAuditContextException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    private function makeLowRiskReport(): AuditReport
+    {
+        $auditContext = AuditContext::forProject($this->tmpDir);
+        $auditContext->addVulnerability(
+            Vulnerability::of(
+                new VulnerabilityClassification(VulnerabilityType::SQL_INJECTION, VulnerabilitySeverity::MEDIUM, 'Medium vuln', 0.9),
+                new CodeLocation('src/File.php', 1, 5),
+                new VulnerabilityNarrative('desc', 'inject', "' OR 1", 'fix'),
+                '$q',
+            )->withReviewerValidation(true),
+        );
 
         return AuditReport::fromContext($auditContext);
     }

--- a/tests/Phpunit/Unit/Infrastructure/Report/GithubCommentReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/GithubCommentReportRendererTest.php
@@ -242,6 +242,41 @@ final class GithubCommentReportRendererTest extends AbstractReportRendererTestCa
     }
 
     /**
+     * GFM splits a table row on unescaped `|` before inline parsing, so a code
+     * span does not contain one — a pipe in the LLM-authored file path would
+     * forge a column in the Location cell.
+     *
+     * @throws InvalidAuditContextException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_a_pipe_in_a_file_path_cannot_forge_a_table_column(): void
+    {
+        $output = $this->renderer->render($this->makeReport($this->makeValidatedVuln(filePath: 'src/Foo|Bar.php')));
+
+        self::assertStringContainsString('`src/Foo\\|Bar.php:1`', $output);
+    }
+
+    /**
+     * GitHub autolinks a bare `@handle` in a comment body into a live profile
+     * mention, notifying that account — driven purely by attacker-influenced
+     * repository content once the rendered body is posted to a pull request.
+     *
+     * @throws InvalidAuditContextException
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_a_mention_in_a_title_cannot_ping_a_github_account(): void
+    {
+        $output = $this->renderer->render($this->makeReport($this->titled('Ping @octocat about this')));
+
+        self::assertStringContainsString('Ping &#64;octocat about this', $output);
+        self::assertStringNotContainsString('@octocat', $output);
+    }
+
+    /**
      * @throws InvalidAuditContextException
      * @throws InvalidCodeLocationException
      * @throws InvalidVulnerabilityClassificationException


### PR DESCRIPTION
## Summary

Three defects found auditing the 1.19.0 candidate, each written test-first and confirmed RED before its fix.

Two are `### Security` issues in the new PR-comment renderer: `MarkdownTextEscaper` neutralized neither `@` (a finding title could ping any GitHub account) nor `|` in a file path (forged a table column). The third: a `--min-score` failure was reported as a `--fail-on` breach.

:warning: Neither security issue has ever shipped — both files are new on `1.x`.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)