### PR TITLE
fix: stop the audited project executing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `Configuration` check. Project files that carry audit settings — chunking
   strategy, `fail_on`, excluded paths — are unaffected.
 
+- **The audited project can no longer execute code on the audit host.**
+  `SymfonyProcessComposerAuditRunner::defaultProcessBuilder()` ran
+  `composer audit --format=json --locked --no-interaction` with the audited
+  project as the working directory, without `--no-scripts` or `--no-plugins`.
+  Composer dispatches the project's `pre-command-run` script and activates the
+  plugins in its `vendor/` for that command, so a repository carrying a
+  `composer.json` such as `"scripts": {"pre-command-run": "php -r \"…\""}`
+  obtained arbitrary command execution as the auditing user — reached on the
+  documented happy path, since `audit.tools_enabled` defaults to `true` and the
+  attacker agent's `lookup_advisory` tool triggers the advisory database.
+  Reproduced end to end: the hostile script ran and wrote its marker file, and
+  the `AdvisorySourceUnavailableException` the runner then raised was no
+  mitigation because the code had already executed. Both flags are now passed;
+  neither changes what `audit --locked` reports, since the advisory check reads
+  `composer.lock`. Users auditing an untrusted project with a release before
+  this fix should assume the project's Composer scripts ran.
+
 ### Fixed
 
 - **A failing audit no longer blames the `--fail-on` threshold for a

--- a/src/Audit/Infrastructure/Advisory/SymfonyProcessComposerAuditRunner.php
+++ b/src/Audit/Infrastructure/Advisory/SymfonyProcessComposerAuditRunner.php
@@ -28,6 +28,13 @@ use function Symfony\Component\String\u;
  * exit code is non-zero whenever advisories are found, so we only treat a failure
  * as fatal when stdout is empty (the JSON is the contract).
  *
+ * `--no-scripts` and `--no-plugins` are mandatory, not tidiness: composer runs
+ * inside the audited project, which is untrusted, and would otherwise dispatch
+ * that project's `pre-command-run` script and activate the plugins in its
+ * `vendor/`. Either is arbitrary command execution on the audit host. Neither
+ * flag changes what `audit --locked` reports, since the advisory check reads
+ * `composer.lock`.
+ *
  * @internal not part of the BC promise — see docs/versioning.md
  */
 final readonly class SymfonyProcessComposerAuditRunner implements ComposerAuditRunnerInterface
@@ -48,7 +55,7 @@ final readonly class SymfonyProcessComposerAuditRunner implements ComposerAuditR
     public static function defaultProcessBuilder(): Closure
     {
         return static fn (string $path): Process => new Process(
-            ['composer', 'audit', '--format=json', '--locked', '--no-interaction'],
+            ['composer', 'audit', '--format=json', '--locked', '--no-interaction', '--no-scripts', '--no-plugins'],
             $path,
         );
     }

--- a/tests/Phpunit/Integration/Advisory/SymfonyProcessComposerAuditRunnerTest.php
+++ b/tests/Phpunit/Integration/Advisory/SymfonyProcessComposerAuditRunnerTest.php
@@ -106,6 +106,21 @@ final class SymfonyProcessComposerAuditRunnerTest extends TestCase
     }
 
     /**
+     * The audited project is untrusted, and composer runs inside it. Composer
+     * dispatches that project's `pre-command-run` script and activates the
+     * plugins in its `vendor/` unless told not to — either one is arbitrary
+     * command execution on the audit host, which for the shipped GitHub Action
+     * is a runner holding a write-scoped token.
+     */
+    public function test_default_process_builder_refuses_the_audited_projects_scripts_and_plugins(): void
+    {
+        $commandLine = (SymfonyProcessComposerAuditRunner::defaultProcessBuilder())('/some/path')->getCommandLine();
+
+        self::assertStringContainsString("'--no-scripts'", $commandLine);
+        self::assertStringContainsString("'--no-plugins'", $commandLine);
+    }
+
+    /**
      * @throws AdvisorySourceUnavailableException
      */
     public function test_it_throws_when_stdout_is_only_whitespace(): void


### PR DESCRIPTION
## Summary

`composer audit` ran in the untrusted project's directory without `--no-scripts` or `--no-plugins`, so Composer dispatched that project's `pre-command-run` script and activated the plugins in its `vendor/` — arbitrary command execution as the auditing user, on the documented happy path.

Reproduced end to end against a hostile fixture, and the counterfactual confirms the fix. Both flags are now passed.

## The vulnerability

`SymfonyProcessComposerAuditRunner::defaultProcessBuilder()` built:

```php
['composer', 'audit', '--format=json', '--locked', '--no-interaction']
```

with the audited project as the process working directory. Composer runs that project's `pre-command-run` script and activates plugins from its `vendor/` unless told otherwise, so a repository shipping

```json
{ "scripts": { "pre-command-run": "php -r \"…\"" } }
```

gets code execution on the audit host. For the shipped GitHub Action that host is a runner holding a write-scoped `GITHUB_TOKEN`.

**Reachable by default**, not a corner case: `audit.tools_enabled` defaults to `true`, `LookupAdvisoryTool` is always registered, and its own description tells the model to call it when it sees `composer.json`/`composer.lock` — attacker-controlled files. `privacy.offline_only: true` avoids the path but defaults to `false`.

## Scope, stated honestly

In **bundle** mode the Action already runs `composer install` inside the target and executes `bin/console` from it, so this grants no *new* capability there. The genuinely new exposure is the README-recommended **standalone binary**, which otherwise only reads files, plus bundle-mode runs pointed at another directory. High rather than critical on that basis, and the one-line fix is worth taking regardless.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)