### PR TITLE
ci: retarget dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: composer
     directory: /
+    target-branch: "1.x"
     schedule:
       interval: daily
     cooldown:
@@ -14,6 +15,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: "1.x"
     schedule:
       interval: daily
     cooldown:

--- a/.github/workflows/pr-target.yaml
+++ b/.github/workflows/pr-target.yaml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   target:
     name: Base branch matches the declared target
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check the description follows the template and the base matches


### PR DESCRIPTION
## Summary

Dependabot opens PRs against the default branch, `main` — release merges only per `docs/versioning.md#branches--maintenance` — instead of `1.x`, where ordinary work belongs. Set `target-branch: "1.x"` on both `dependabot.yaml` update entries to fix that.

Separately, Dependabot's auto-generated PR body never contains the Summary/Type of change/Target branch/Checklist sections the `pr-target` job requires, so every Dependabot PR fails it regardless of base branch (e.g. run 31410678397 on #281). Skip that job when the PR author is `dependabot[bot]`.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated — n/a, workflow/config YAML only
- [x] All checks pass: `bin/castor lint` — YAML parse + Prettier verified directly; full run needs Docker, unavailable here
- [x] 100% MSI maintained — n/a, no PHP source changed
- [x] No `createMock` without a matching `expects()` — n/a
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)