### PR TITLE
feat(agent): add XSSI detection for GET controller actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,10 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   (`src/Audit/Infrastructure/Prompt/Skill/`) now hunts for this pattern and
   explicitly does not flag it on routes whose `methods:` exclude `GET`. New
   `VulnerabilityType::JSON_HIJACKING` case (`src/Audit/Domain/Model/`), mapped
-  to CWE-352 and OWASP A01:2025 (Broken Access Control) alongside the existing
-  CSRF and SSRF variants. `AttackerPromptBuilder` and `ReviewerPromptSections`
+  to CWE-200 (it leaks data cross-origin rather than forging a state-changing
+  request, so CWE-352's request-forgery framing doesn't fit) and OWASP A01:2025
+  (Broken Access Control) alongside the existing CSRF and SSRF variants.
+  `AttackerPromptBuilder` and `ReviewerPromptSections`
   (`src/Audit/Infrastructure/Prompt/`) list `json_hijacking` among the valid
   `type`/`corrected_type` values so both agents can name it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,9 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   explicitly does not flag it on routes whose `methods:` exclude `GET`. New
   `VulnerabilityType::JSON_HIJACKING` case (`src/Audit/Domain/Model/`), mapped
   to CWE-352 and OWASP A01:2025 (Broken Access Control) alongside the existing
-  CSRF and SSRF variants.
+  CSRF and SSRF variants. `AttackerPromptBuilder` and `ReviewerPromptSections`
+  (`src/Audit/Infrastructure/Prompt/`) list `json_hijacking` among the valid
+  `type`/`corrected_type` values so both agents can name it.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   untouched, so nothing existing breaks. `DependencyExpansionStage` reads the
   neutral map exclusively and no longer names a Symfony type.
 
+- **The attacker now detects XSSI "JSON Hijacking" on GET endpoints.** Per the
+  [Symfony `JsonResponse` documentation](https://symfony.com/doc/current/components/http_foundation.html#creating-a-json-response),
+  a `GET` action that returns a bare top-level indexed JSON array (e.g.
+  `[{...}, {...}]`) instead of an object (`{"data": [...]}`) is exploitable via
+  a cross-origin `<script src="...">` include, since only `GET` requests can be
+  triggered that way. `ControllerAttackerSkill`
+  (`src/Audit/Infrastructure/Prompt/Skill/`) now hunts for this pattern and
+  explicitly does not flag it on routes whose `methods:` exclude `GET`. New
+  `VulnerabilityType::JSON_HIJACKING` case (`src/Audit/Domain/Model/`), mapped
+  to CWE-352 and OWASP A01:2025 (Broken Access Control) alongside the existing
+  CSRF and SSRF variants.
+
 ### Deprecated
 
 - **Four `SymfonyMapping` accessors, in favour of `ApplicationSecurityMap`.**

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ bin/console audit:run --dry-run
   positives across up to 3 iterations, with confirmed findings fed back so later
   iterations generalize patterns instead of re-finding the same bugs, and the
   Reviewer remembering its own rejections across runs.
-- **48 vulnerability types** covering OWASP-aligned categories: Injection,
+- **49 vulnerability types** covering OWASP-aligned categories: Injection,
   Broken Access Control, Logic Flaws, Symfony-specific, Data Exposure,
   Cryptographic — including the modern Symfony 7.x/8.x surface (Authenticators,
   Messenger handlers, Webhooks, Serializer denormalizers, Schedules,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,7 +281,7 @@ Fields: `id`, `type` (enum), `severity` (enum), `title`, `description`,
 
 ### `VulnerabilityType` — backed enum with OWASP and CWE references
 
-48 cases in six categories:
+49 cases in six categories:
 
 | Category              | Examples                                                                   |
 | --------------------- | -------------------------------------------------------------------------- |

--- a/examples/vulnerable-app/README.md
+++ b/examples/vulnerable-app/README.md
@@ -15,6 +15,7 @@ Run the auditor against it and observe the report.
 | ---------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------- |
 | `src/Controller/UserController.php::deleteAction()`  | Missing `#[IsGranted]` / no `denyAccessUnlessGranted()` on a `DELETE` route. | A01 — Broken Access Control |
 | `src/Controller/UserController.php::showAction()`    | Direct object reference (`$id` from URL → `find()`) with no ownership check. | A01 — Broken Access Control |
+| `src/Controller/UserController.php::listAction()`    | Bare indexed-array `JsonResponse` on a `GET` route (XSSI "JSON Hijacking").  | A01 — Broken Access Control |
 | `src/Controller/SearchController.php::queryAction()` | Raw `$request->get('q')` concatenated into a DQL/SQL string.                 | A03 — Injection             |
 | `src/Entity/User.php::fromRequest()`                 | Mass-assigning every request field, including `isAdmin`, into the entity.    | A04 — Insecure Design       |
 
@@ -31,7 +32,7 @@ Expected outcome:
 
 - Exit code **1** (risk level `CRITICAL` once the controller findings are
   validated).
-- Report lists ≈ 4 findings, one per row of the table above. Severity and
+- Report lists ≈ 5 findings, one per row of the table above. Severity and
   wording vary by model.
 
 To try a different provider, edit

--- a/examples/vulnerable-app/ground-truth.json
+++ b/examples/vulnerable-app/ground-truth.json
@@ -9,6 +9,10 @@
       "file": "src/Controller/UserController.php",
       "type": "broken_access_control"
     },
-    { "file": "src/Entity/User.php", "type": "mass_assignment" }
+    { "file": "src/Entity/User.php", "type": "mass_assignment" },
+    {
+      "file": "src/Controller/UserController.php",
+      "type": "json_hijacking"
+    }
   ]
 }

--- a/examples/vulnerable-app/src/Controller/UserController.php
+++ b/examples/vulnerable-app/src/Controller/UserController.php
@@ -57,4 +57,16 @@ final class UserController extends AbstractController
 
         return new JsonResponse($user->toArray(), 201);
     }
+
+    // VULN: XSSI "JSON Hijacking" — a GET action returning a bare top-level
+    // indexed array. A cross-origin <script src="/users"> include can read
+    // the array literal. Wrapping it in an object (e.g. {"users": [...]})
+    // closes the hole.
+    #[Route('/users', name: 'user_list', methods: ['GET'])]
+    public function listAction(EntityManagerInterface $entityManager): JsonResponse
+    {
+        $users = $entityManager->getRepository(User::class)->findAll();
+
+        return new JsonResponse(array_map(static fn (User $user): array => $user->toArray(), $users));
+    }
 }

--- a/src/Audit/Domain/Model/VulnerabilityType.php
+++ b/src/Audit/Domain/Model/VulnerabilityType.php
@@ -279,8 +279,8 @@ enum VulnerabilityType: string
             self::VOTER_BYPASS => CweReference::of(863),
             self::ROLE_ESCALATION => CweReference::of(269),
             self::INSECURE_DIRECT_OBJECT_REFERENCE => CweReference::of(639),
-            self::MISSING_CSRF_PROTECTION,
-            self::JSON_HIJACKING => CweReference::of(352),
+            self::MISSING_CSRF_PROTECTION => CweReference::of(352),
+            self::JSON_HIJACKING => CweReference::of(200),
 
             self::BUSINESS_LOGIC_FLAW,
             self::INSECURE_WORKFLOW,

--- a/src/Audit/Domain/Model/VulnerabilityType.php
+++ b/src/Audit/Domain/Model/VulnerabilityType.php
@@ -30,6 +30,7 @@ enum VulnerabilityType: string
     case ROLE_ESCALATION = 'role_escalation';
     case INSECURE_DIRECT_OBJECT_REFERENCE = 'insecure_direct_object_reference';
     case MISSING_CSRF_PROTECTION = 'missing_csrf_protection';
+    case JSON_HIJACKING = 'json_hijacking';
 
     // Logic Flaws
     case BUSINESS_LOGIC_FLAW = 'business_logic_flaw';
@@ -94,6 +95,7 @@ enum VulnerabilityType: string
             self::ROLE_ESCALATION,
             self::INSECURE_DIRECT_OBJECT_REFERENCE,
             self::MISSING_CSRF_PROTECTION,
+            self::JSON_HIJACKING,
             self::AUTHENTICATOR_BYPASS => 'Broken Access Control',
 
             self::BUSINESS_LOGIC_FLAW,
@@ -159,6 +161,8 @@ enum VulnerabilityType: string
 
             self::MISSING_CSRF_PROTECTION => 'OWASP A01:2025 - Broken Access Control (CSRF)',
 
+            self::JSON_HIJACKING => 'OWASP A01:2025 - Broken Access Control (XSSI)',
+
             self::SSRF => 'OWASP A01:2025 - Broken Access Control (SSRF)',
 
             self::AUTHENTICATOR_BYPASS => 'OWASP A07:2025 - Authentication Failures',
@@ -217,6 +221,7 @@ enum VulnerabilityType: string
             self::INSECURE_DIRECT_OBJECT_REFERENCE,
             self::PATH_TRAVERSAL,
             self::MISSING_CSRF_PROTECTION,
+            self::JSON_HIJACKING,
             self::SSRF,
             self::INSECURE_REDIRECT,
             self::OPEN_REDIRECT => 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/',
@@ -274,7 +279,8 @@ enum VulnerabilityType: string
             self::VOTER_BYPASS => CweReference::of(863),
             self::ROLE_ESCALATION => CweReference::of(269),
             self::INSECURE_DIRECT_OBJECT_REFERENCE => CweReference::of(639),
-            self::MISSING_CSRF_PROTECTION => CweReference::of(352),
+            self::MISSING_CSRF_PROTECTION,
+            self::JSON_HIJACKING => CweReference::of(352),
 
             self::BUSINESS_LOGIC_FLAW,
             self::INSECURE_WORKFLOW,

--- a/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
+++ b/src/Audit/Infrastructure/Prompt/AttackerPromptBuilder.php
@@ -204,7 +204,7 @@ final readonly class AttackerPromptBuilder implements AttackerPromptBuilderInter
             Valid type values:
             sql_injection, command_injection, ldap_injection, xpath_injection, twig_injection, header_injection,
             broken_access_control, missing_voter, voter_bypass, role_escalation, insecure_direct_object_reference,
-            missing_csrf_protection, business_logic_flaw, race_condition, insecure_workflow, price_manipulation,
+            missing_csrf_protection, json_hijacking, business_logic_flaw, race_condition, insecure_workflow, price_manipulation,
             state_machine_bypass, mass_assignment, insecure_deserialization, unsafe_parameter_binding,
             exposed_internal_service, misconfigured_firewall, insecure_redirect, sensitive_data_exposure,
             log_injection, path_traversal, ssrf, xxe, open_redirect, weak_cryptography, insecure_random,

--- a/src/Audit/Infrastructure/Prompt/Reviewer/ReviewerPromptSections.php
+++ b/src/Audit/Infrastructure/Prompt/Reviewer/ReviewerPromptSections.php
@@ -83,7 +83,7 @@ final readonly class ReviewerPromptSections implements ReviewerPromptSectionsInt
         Valid `corrected_type` values (same enum the attacker uses):
         sql_injection, command_injection, ldap_injection, xpath_injection, twig_injection, header_injection,
         broken_access_control, missing_voter, voter_bypass, role_escalation, insecure_direct_object_reference,
-        missing_csrf_protection, business_logic_flaw, race_condition, insecure_workflow, price_manipulation,
+        missing_csrf_protection, json_hijacking, business_logic_flaw, race_condition, insecure_workflow, price_manipulation,
         state_machine_bypass, mass_assignment, insecure_deserialization, unsafe_parameter_binding,
         exposed_internal_service, misconfigured_firewall, insecure_redirect, sensitive_data_exposure,
         log_injection, path_traversal, ssrf, xxe, open_redirect, weak_cryptography, insecure_random,

--- a/src/Audit/Infrastructure/Prompt/Skill/ControllerAttackerSkill.php
+++ b/src/Audit/Infrastructure/Prompt/Skill/ControllerAttackerSkill.php
@@ -46,10 +46,12 @@ final readonly class ControllerAttackerSkill implements AttackerSkillInterface
             - Authentication endpoints (login, password reset, 2FA, registration) without rate-limiter binding (`RateLimiterFactory::create()` / `framework.rate_limiter`).
             - `Request::get()` / `getContent()` flowing into Doctrine raw queries, `exec`, `passthru`, `eval`, `unserialize`, `simplexml_load_string`.
             - Live Components: `#[LiveAction]` / `#[LiveProp(writable: true)]` exposing privileged setters or unbounded properties to the browser.
+            - `JsonResponse`/serialized payloads returned from a `GET`-only action with a bare top-level indexed array (`[{...}, {...}]` instead of `{"data": [...]}`) — XSSI "JSON Hijacking": a cross-origin `<script src>` include can read the array literal before same-origin policy applies. Report as `json_hijacking`.
             Do NOT flag:
             - Controllers inheriting `denyAccessUnlessGranted()` from a parent class or a `#[IsGranted]` attribute on the class itself.
             - Routes restricted by `methods: ['POST']` plus a CSRF-protected form — the form covers the CSRF concern.
             - `#[MapRequestPayload]` / `#[MapQueryString]` over a DTO with validation constraints (`#[Assert\…]`) AND no privileged setters.
+            - A bare indexed-array JSON response from an action whose route `methods:` excludes `GET` (e.g. `POST`/`PUT`/`PATCH`/`DELETE` only) — `<script src>` inclusion only issues GET requests, so a non-GET route cannot be hijacked this way.
             </skills>
             SKILL;
     }

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
@@ -207,7 +207,7 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::ROLE_ESCALATION, 'CWE-269'];
         yield [VulnerabilityType::INSECURE_DIRECT_OBJECT_REFERENCE, 'CWE-639'];
         yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'CWE-352'];
-        yield [VulnerabilityType::JSON_HIJACKING, 'CWE-352'];
+        yield [VulnerabilityType::JSON_HIJACKING, 'CWE-200'];
         yield [VulnerabilityType::BUSINESS_LOGIC_FLAW, 'CWE-841'];
         yield [VulnerabilityType::RACE_CONDITION, 'CWE-362'];
         yield [VulnerabilityType::INSECURE_WORKFLOW, 'CWE-841'];

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTypeTest.php
@@ -35,6 +35,7 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::ROLE_ESCALATION, 'Broken Access Control'];
         yield [VulnerabilityType::INSECURE_DIRECT_OBJECT_REFERENCE, 'Broken Access Control'];
         yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'Broken Access Control'];
+        yield [VulnerabilityType::JSON_HIJACKING, 'Broken Access Control'];
         yield [VulnerabilityType::BUSINESS_LOGIC_FLAW, 'Logic Flaw'];
         yield [VulnerabilityType::RACE_CONDITION, 'Logic Flaw'];
         yield [VulnerabilityType::INSECURE_WORKFLOW, 'Logic Flaw'];
@@ -87,6 +88,7 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::ROLE_ESCALATION, 'A01:2025'];
         yield [VulnerabilityType::INSECURE_DIRECT_OBJECT_REFERENCE, 'A01:2025'];
         yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'A01:2025'];
+        yield [VulnerabilityType::JSON_HIJACKING, 'A01:2025'];
         yield [VulnerabilityType::INSECURE_DESERIALIZATION, 'A08:2025'];
         yield [VulnerabilityType::SENSITIVE_DATA_EXPOSURE, 'A04:2025'];
         yield [VulnerabilityType::WEAK_CRYPTOGRAPHY, 'A04:2025'];
@@ -160,6 +162,7 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::SQL_INJECTION, 'https://owasp.org/Top10/2025/A05_2025-Injection/'];
         yield [VulnerabilityType::BROKEN_ACCESS_CONTROL, 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/'];
         yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/'];
+        yield [VulnerabilityType::JSON_HIJACKING, 'https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/'];
         yield [VulnerabilityType::AUTHENTICATOR_BYPASS, 'https://owasp.org/Top10/2025/A07_2025-Authentication_Failures/'];
         yield [VulnerabilityType::MISSING_SIGNATURE_VERIFICATION, 'https://owasp.org/Top10/2025/A08_2025-Software_or_Data_Integrity_Failures/'];
         yield [VulnerabilityType::BUSINESS_LOGIC_FLAW, 'https://owasp.org/Top10/2025/A06_2025-Insecure_Design/'];
@@ -204,6 +207,7 @@ final class VulnerabilityTypeTest extends TestCase
         yield [VulnerabilityType::ROLE_ESCALATION, 'CWE-269'];
         yield [VulnerabilityType::INSECURE_DIRECT_OBJECT_REFERENCE, 'CWE-639'];
         yield [VulnerabilityType::MISSING_CSRF_PROTECTION, 'CWE-352'];
+        yield [VulnerabilityType::JSON_HIJACKING, 'CWE-352'];
         yield [VulnerabilityType::BUSINESS_LOGIC_FLAW, 'CWE-841'];
         yield [VulnerabilityType::RACE_CONDITION, 'CWE-362'];
         yield [VulnerabilityType::INSECURE_WORKFLOW, 'CWE-841'];

--- a/tests/Phpunit/Unit/Infrastructure/Prompt/Skill/AttackerSkillRegistryTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Prompt/Skill/AttackerSkillRegistryTest.php
@@ -335,4 +335,19 @@ final class AttackerSkillRegistryTest extends TestCase
 
         self::assertStringContainsString('setPermission(', $block);
     }
+
+    public function test_controller_skill_flags_bare_array_json_responses_on_get_routes_as_json_hijacking(): void
+    {
+        $block = (new ControllerAttackerSkill())->block();
+
+        self::assertStringContainsString('XSSI', $block);
+        self::assertStringContainsString('Report as `json_hijacking`.', $block);
+    }
+
+    public function test_controller_skill_does_not_flag_json_hijacking_on_routes_that_exclude_get(): void
+    {
+        $block = (new ControllerAttackerSkill())->block();
+
+        self::assertStringContainsString('a non-GET route cannot be hijacked this way.', $block);
+    }
 }


### PR DESCRIPTION
## Summary

Adds detection for XSSI JSON Hijacking: a GET controller action returning a bare top-level indexed JSON array (instead of an object) is exploitable via a cross-origin `<script src>` include, since only GET requests can be triggered that way.

## Type of change

- [x] New feature

## Target branch

Tick one and open the pull request against it — CI fails if they disagree. The
default base `main` is almost never right
([why](docs/versioning.md#branches--maintenance)).

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Details

- `ControllerAttackerSkill` now hunts for this pattern and explicitly excludes routes whose `methods:` don't include GET.
- New `VulnerabilityType::JSON_HIJACKING` case, mapped to CWE-352 and OWASP A01:2025 alongside the existing CSRF/SSRF variants.
- The vulnerable-app fixture gains a matching GET endpoint and ground-truth entry.
- `AttackerPromptBuilder` and `ReviewerPromptSections` list `json_hijacking` among the valid `type`/`corrected_type` values so both agents can name it.
- `CHANGELOG.md` updated under the appropriate MINOR entry.

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)