### PR TITLE
fix: harden git-filter, MCP path, and PR-comment exposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -425,6 +425,39 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `message.text` with the override intact. `resultFor()` now scrubs the title
   the same way before stripping control characters.
 
+- **Auditing an untrusted repository with `--since` could execute an
+  attacker-controlled command.** `ProcessGitChangedFilesResolver` runs
+  `git diff` with the audited project as its working directory
+  (`src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php`), so the
+  audited repo's own local `.git/config` — attacker data, not ours — is honored
+  by that `git` invocation. A `core.fsmonitor` entry there names an arbitrary
+  command git runs on any working-tree comparison, including the plain
+  `git diff --name-only HEAD` this resolver issues for uncommitted changes,
+  letting a malicious clone execute code as the auditor's own process the moment
+  `audit:run --since=<ref>` runs against it. `buildDefaultGitDiffProcess()` now
+  passes `-c core.fsmonitor=` alongside the existing `-c core.quotepath=off`,
+  neutralizing the hook the same way.
+
+- **The MCP `audit` tool resolved advisories, SARIF imports, and triage cache
+  entries against the bundle's own directory instead of the audited project.**
+  `AuditCommand` sets `AuditedProjectPathHolder` from the resolved CLI argument
+  before running (`src/Command/AuditCommand.php`), but `AuditTool::audit()`
+  (`src/Command/Mcp/AuditTool.php`) never did the equivalent for its own `path`
+  argument, so `ComposerAuditAdvisoryDatabase`, `SarifImportingPreScanner` and
+  `FilesystemTriageMemoryStore` — all of which read
+  `AuditedProjectPathHolder::path()` — fell back to `kernel.project_dir`
+  whenever the tool was invoked over MCP rather than `audit:run`. `AuditTool`
+  now sets the holder from its own `path` argument before delegating to
+  `RunAuditUseCase`, matching the command's behavior.
+
+- **A public marker string let any PR commenter hijack the action's own report
+  comment.** `comment-pr` (`action.yml`) finds the comment to edit in place by
+  matching a body marker that is visible in this repository's own source, with
+  no check on who posted it — so a PR author (or anyone else able to comment)
+  could post that marker first and have the job's `pull-requests: write` token
+  edit their comment on every subsequent rerun instead of posting its own. The
+  `jq` selector now also requires `.user.login == "github-actions[bot]"`.
+
 - **`audit.budget.max_tokens` did not bound a run's real token spend once
   provider prompt caching was involved.** `LLMResponse::totalTokens()`
   (`src/Audit/Domain/Port/LLMResponse.php`) returned only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,6 +438,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   passes `-c core.fsmonitor=` alongside the existing `-c core.quotepath=off`,
   neutralizing the hook the same way.
 
+- **The `core.fsmonitor` fix above still left a second, equally exploitable
+  command-execution path through the audited repo's own git config.** A
+  `.gitattributes` `filter=<name>` assignment plus a matching
+  `filter.<name>.clean` command in the same untrusted `.git/config` reaches an
+  arbitrary command too — git runs the clean filter to normalize a working-tree
+  file before comparing it against the index, which the plain
+  `git diff --name-only HEAD` this resolver used for uncommitted changes
+  triggers for any file whose stat info looks changed. Neither
+  `-c core.fsmonitor=` nor `-c core.attributesFile=` block it, since the driver
+  name is attacker-chosen and the repo's own `.gitattributes` is always honored
+  regardless of that setting. `ProcessGitChangedFilesResolver::changedSince()`
+  (`src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php`) now gets
+  the same "uncommitted changes" information from `git diff-index --cached HEAD`
+  (index vs tree) plus `git diff-files` (working tree vs index) instead of
+  `git diff HEAD` — both plumbing commands answer the same "did this file
+  change" question without ever invoking a content filter.
+
 - **The MCP `audit` tool resolved advisories, SARIF imports, and triage cache
   entries against the bundle's own directory instead of the audited project.**
   `AuditCommand` sets `AuditedProjectPathHolder` from the resolved CLI argument
@@ -449,6 +466,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   whenever the tool was invoked over MCP rather than `audit:run`. `AuditTool`
   now sets the holder from its own `path` argument before delegating to
   `RunAuditUseCase`, matching the command's behavior.
+
+- **That MCP path fix above copied `AuditCommand`'s call but not its
+  normalization.** `AuditCommandInput::resolvedProjectPath()`
+  (`src/Command/AuditCommandInput.php`) canonicalizes an absolute CLI argument
+  via `Path::canonicalize()` before anything downstream sees it, but
+  `AuditTool::audit()` passed the MCP tool's raw `path` argument straight
+  through — a relative path silently reached `Process`'s `$cwd` in
+  `SymfonyProcessComposerAuditRunner`, a `..`-bearing absolute path hashed to a
+  different triage-cache key than its canonical form, and
+  `SarifImportingPreScanner::normalizeUri()` silently failed to strip a
+  non-canonical prefix from imported SARIF artifact URIs. `AuditTool` now
+  rejects a non-absolute `path` with the new `InvalidProjectPathException`
+  (`src/Command/Exception/InvalidProjectPathException.php`) and canonicalizes an
+  absolute one before setting the holder, matching the CLI path exactly.
 
 - **A public marker string let any PR commenter hijack the action's own report
   comment.** `comment-pr` (`action.yml`) finds the comment to edit in place by

--- a/action.yml
+++ b/action.yml
@@ -251,11 +251,14 @@ runs:
         fi
 
         # The renderer opens the body with this marker so a rerun edits its own
-        # comment instead of appending another one to the thread.
+        # comment instead of appending another one to the thread. The marker is
+        # public, so the author is checked too — otherwise anyone able to
+        # comment on the PR could post it first and hijack this job's write
+        # access to edit their own comment on every rerun.
         marker='<!-- symfony-security-auditor:pr-comment -->'
         matches="$RUNNER_TEMP/ssa-comment-matches.txt"
         gh api --paginate "$SSA_COMMENTS_URL" \
-          --jq ".[] | select(.body | contains(\"$marker\")) | .url" > "$matches"
+          --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$marker\"))) | .url" > "$matches"
         existing="$(head -n 1 "$matches")"
 
         payload="$RUNNER_TEMP/ssa-comment-payload.json"

--- a/config/services.php
+++ b/config/services.php
@@ -727,6 +727,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service(RunAuditUseCase::class),
             service(JsonReportRenderer::class),
+            service(AuditedProjectPathHolder::class),
         ]);
 
     $defaultsConfigurator->set(McpServerFactory::class)

--- a/src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php
+++ b/src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php
@@ -27,28 +27,43 @@ use function Symfony\Component\String\u;
 /**
  * @internal not part of the BC promise — see docs/versioning.md
  *
- * Resolves the set of changed files via two git invocations:
+ * Resolves the set of changed files via three git invocations:
  *
  *   1. `git diff --relative --name-only --diff-filter=ACMR <ref>...HEAD`
  *      — committed changes that diverge from the ref's merge base. The triple
  *      dot semantics handle topic branches diverged from the ref correctly:
  *      only changes ON the branch are returned, not changes the ref accrued
- *      since branch point.
+ *      since branch point. Pure tree-to-tree comparison — never touches the
+ *      working tree, so it cannot invoke a `.gitattributes` content filter.
  *
- *   2. `git diff --relative --name-only --diff-filter=ACMR HEAD`
- *      — uncommitted changes against HEAD: staged changes (including files
- *      already `git add`ed) plus unstaged edits to already-tracked files.
- *      `git diff` never reports genuinely untracked files (ones never staged
- *      at all) — those are invisible to this resolver. Merged into the result
- *      so a local dev running `audit:run --since=main` sees their staged and
- *      already-tracked in-flight work too.
+ *   2. `git diff-index --relative --name-only --diff-filter=ACMR --cached HEAD`
+ *      — staged changes against HEAD (including files already `git add`ed):
+ *      index vs tree, both already-hashed objects, so no working-tree content
+ *      filter runs either.
+ *
+ *   3. `git diff-files --relative --name-only --diff-filter=ACMR`
+ *      — unstaged edits to already-tracked files: working tree vs index.
+ *      Deliberately the plumbing form rather than `git diff HEAD` — the
+ *      porcelain form normalizes a working-tree file through its
+ *      `.gitattributes` `filter=<name>` `clean` command before comparing it,
+ *      and both the attribute assignment and the `filter.<name>.clean`
+ *      command live in the audited (untrusted) repo's own `.gitattributes`/
+ *      `.git/config`, making it as exploitable as the `core.fsmonitor` hook
+ *      neutralized below. `diff-files` reports the same "did this tracked
+ *      file change" answer without ever invoking a content filter.
+ *
+ *      Together, invocations 2 and 3 never report genuinely untracked files
+ *      (ones never staged at all) — those are invisible to this resolver.
+ *      Merged into the result so a local dev running `audit:run --since=main`
+ *      sees their staged and already-tracked in-flight work too.
  *
  * `--relative` rewrites paths relative to `$projectPath` instead of the git
  * root, and excludes changes outside it — required so the result lines up
  * with `ProjectFile::relativePath()` when the audited project is a
  * subdirectory of a larger repository (a monorepo layout).
  *
- * Both lists are merged, deduplicated, and returned in deterministic order.
+ * All three lists are merged, deduplicated, and returned in deterministic
+ * order.
  */
 final readonly class ProcessGitChangedFilesResolver implements GitChangedFilesResolverInterface
 {
@@ -78,9 +93,10 @@ final readonly class ProcessGitChangedFilesResolver implements GitChangedFilesRe
         }
 
         $committed = $this->runGit($projectPath, ['diff', '--relative', '--name-only', '--diff-filter=ACMR', \sprintf('%s...HEAD', $ref)]);
-        $uncommitted = $this->runGit($projectPath, ['diff', '--relative', '--name-only', '--diff-filter=ACMR', 'HEAD']);
+        $staged = $this->runGit($projectPath, ['diff-index', '--relative', '--name-only', '--diff-filter=ACMR', '--cached', 'HEAD']);
+        $unstaged = $this->runGit($projectPath, ['diff-files', '--relative', '--name-only', '--diff-filter=ACMR']);
 
-        return $this->mergeAndNormalize([...$committed, ...$uncommitted]);
+        return $this->mergeAndNormalize([...$committed, ...$staged, ...$unstaged]);
     }
 
     /**

--- a/src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php
+++ b/src/Audit/Infrastructure/Diff/ProcessGitChangedFilesResolver.php
@@ -126,14 +126,18 @@ final readonly class ProcessGitChangedFilesResolver implements GitChangedFilesRe
     }
 
     /**
+     * `-z` NUL-terminates each path instead of newline-terminating it, and disables
+     * git's C-style quoting of non-ASCII bytes AND of literal quotes/backslashes/
+     * control characters alike — `core.quotepath=off` alone only covers the former.
+     * `core.fsmonitor=` neutralizes the audited (untrusted) repo's own local config:
+     * otherwise a hostile `core.fsmonitor` hook set in its `.git/config` runs as an
+     * arbitrary command on this working-tree comparison.
+     *
      * @param list<string> $argv
      */
     private function buildDefaultGitDiffProcess(array $argv, string $projectPath): Process
     {
-        // -z NUL-terminates each path instead of newline-terminating it, and disables
-        // git's C-style quoting of non-ASCII bytes AND of literal quotes/backslashes/
-        // control characters alike — core.quotepath=off alone only covers the former.
-        return new Process(['git', '-c', 'core.quotepath=off', ...$argv, '-z'], $projectPath);
+        return new Process(['git', '-c', 'core.quotepath=off', '-c', 'core.fsmonitor=', ...$argv, '-z'], $projectPath);
     }
 
     /**

--- a/src/Command/Exception/InvalidProjectPathException.php
+++ b/src/Command/Exception/InvalidProjectPathException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Command\Exception;
+
+use InvalidArgumentException;
+
+/** @internal not part of the BC promise — see docs/versioning.md */
+final class InvalidProjectPathException extends InvalidArgumentException
+{
+    public static function forNonAbsolutePath(string $path): self
+    {
+        return new self(\sprintf('Project path must be absolute, got "%s".', $path));
+    }
+}

--- a/src/Command/Mcp/AuditTool.php
+++ b/src/Command/Mcp/AuditTool.php
@@ -19,6 +19,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCa
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditContextException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCostException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidTokenUsageException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRendererInterface;
 
 /** @internal not part of the BC promise — the MCP tool *name* (`audit`) is public, but the PHP class itself is for internal use only. */
@@ -27,6 +28,7 @@ final readonly class AuditTool
     public function __construct(
         private RunAuditUseCase $runAuditUseCase,
         private ReportRendererInterface $reportRenderer,
+        private AuditedProjectPathHolder $auditedProjectPathHolder,
     ) {}
 
     /**
@@ -38,6 +40,8 @@ final readonly class AuditTool
      */
     public function audit(string $path): string
     {
+        $this->auditedProjectPathHolder->set($path);
+
         return $this->reportRenderer->render($this->runAuditUseCase->execute($path));
     }
 }

--- a/src/Command/Mcp/AuditTool.php
+++ b/src/Command/Mcp/AuditTool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp;
 
+use Symfony\Component\Filesystem\Path;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByBudgetException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\AuditAbortedByProviderException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
@@ -21,6 +22,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCost
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidTokenUsageException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRendererInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\InvalidProjectPathException;
 
 /** @internal not part of the BC promise — the MCP tool *name* (`audit`) is public, but the PHP class itself is for internal use only. */
 final readonly class AuditTool
@@ -36,12 +38,18 @@ final readonly class AuditTool
      * @throws AuditAbortedByProviderException
      * @throws InvalidAuditContextException
      * @throws InvalidAuditCostException
+     * @throws InvalidProjectPathException
      * @throws InvalidTokenUsageException
      */
     public function audit(string $path): string
     {
-        $this->auditedProjectPathHolder->set($path);
+        if (!Path::isAbsolute($path)) {
+            throw InvalidProjectPathException::forNonAbsolutePath($path);
+        }
 
-        return $this->reportRenderer->render($this->runAuditUseCase->execute($path));
+        $canonicalPath = Path::canonicalize($path);
+        $this->auditedProjectPathHolder->set($canonicalPath);
+
+        return $this->reportRenderer->render($this->runAuditUseCase->execute($canonicalPath));
     }
 }

--- a/tests/Phpunit/Integration/Command/Mcp/AuditToolTest.php
+++ b/tests/Phpunit/Integration/Command/Mcp/AuditToolTest.php
@@ -27,6 +27,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\PipelineInterface
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JsonReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRendererInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Command\Exception\InvalidProjectPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\AuditTool;
 
 final class AuditToolTest extends TestCase
@@ -51,6 +52,7 @@ final class AuditToolTest extends TestCase
      * @throws AuditAbortedByProviderException
      * @throws InvalidAuditContextException
      * @throws InvalidAuditCostException
+     * @throws InvalidProjectPathException
      * @throws InvalidTokenUsageException
      */
     public function test_it_audits_the_given_path_and_returns_the_rendered_json_report(): void
@@ -68,6 +70,7 @@ final class AuditToolTest extends TestCase
      * @throws AuditAbortedByProviderException
      * @throws InvalidAuditContextException
      * @throws InvalidAuditCostException
+     * @throws InvalidProjectPathException
      * @throws InvalidTokenUsageException
      */
     public function test_it_returns_the_report_as_rendered_by_the_report_renderer(): void
@@ -93,6 +96,7 @@ final class AuditToolTest extends TestCase
      * @throws AuditAbortedByProviderException
      * @throws InvalidAuditContextException
      * @throws InvalidAuditCostException
+     * @throws InvalidProjectPathException
      * @throws InvalidTokenUsageException
      */
     public function test_it_sets_the_audited_project_path_holder_before_running_the_use_case(): void
@@ -101,6 +105,57 @@ final class AuditToolTest extends TestCase
         $auditTool = new AuditTool($this->runAuditUseCase(), new JsonReportRenderer(), $auditedProjectPathHolder);
 
         $auditTool->audit($this->projectPath);
+
+        self::assertSame($this->projectPath, $auditedProjectPathHolder->path());
+    }
+
+    /**
+     * The MCP tool's own JSON schema documents `path` as "Absolute path to
+     * the Symfony project directory to audit" but nothing enforced that
+     * contract — unlike `AuditCommandInput::resolvedProjectPath()`, which
+     * resolves a relative CLI argument against a known working directory.
+     * An MCP tool call has no equivalent "current directory" concept to fall
+     * back to, so a relative `path` is rejected rather than silently
+     * resolved against the server process's own cwd.
+     *
+     * @throws AuditAbortedByBudgetException
+     * @throws AuditAbortedByProviderException
+     * @throws InvalidAuditContextException
+     * @throws InvalidAuditCostException
+     * @throws InvalidProjectPathException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_it_rejects_a_non_absolute_path(): void
+    {
+        $auditTool = new AuditTool($this->runAuditUseCase(), new JsonReportRenderer(), $this->auditedProjectPathHolder());
+
+        $this->expectException(InvalidProjectPathException::class);
+        $this->expectExceptionMessage('must be absolute');
+
+        $auditTool->audit('relative/path');
+    }
+
+    /**
+     * `AuditCommandInput::resolvedProjectPath()` canonicalizes an absolute
+     * CLI argument via `Path::canonicalize()` before anything downstream
+     * sees it; `AuditTool` must do the same for its own `path` argument so a
+     * `..`-bearing MCP path resolves identically to the CLI path, keeping
+     * `AuditedProjectPathHolder::path()` a stable cache/lookup key regardless
+     * of entry point.
+     *
+     * @throws AuditAbortedByBudgetException
+     * @throws AuditAbortedByProviderException
+     * @throws InvalidAuditContextException
+     * @throws InvalidAuditCostException
+     * @throws InvalidProjectPathException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_it_canonicalizes_the_path_before_setting_the_holder_and_running(): void
+    {
+        $auditedProjectPathHolder = $this->auditedProjectPathHolder();
+        $auditTool = new AuditTool($this->runAuditUseCase(), new JsonReportRenderer(), $auditedProjectPathHolder);
+
+        $auditTool->audit($this->projectPath.'/nested/..');
 
         self::assertSame($this->projectPath, $auditedProjectPathHolder->path());
     }

--- a/tests/Phpunit/Integration/Command/Mcp/AuditToolTest.php
+++ b/tests/Phpunit/Integration/Command/Mcp/AuditToolTest.php
@@ -24,6 +24,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCont
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCostException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidTokenUsageException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\PipelineInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JsonReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportRendererInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\AuditTool;
@@ -54,7 +55,7 @@ final class AuditToolTest extends TestCase
      */
     public function test_it_audits_the_given_path_and_returns_the_rendered_json_report(): void
     {
-        $auditTool = new AuditTool($this->runAuditUseCase(), new JsonReportRenderer());
+        $auditTool = new AuditTool($this->runAuditUseCase(), new JsonReportRenderer(), $this->auditedProjectPathHolder());
 
         $report = json_decode($auditTool->audit($this->projectPath), true, flags: \JSON_THROW_ON_ERROR);
 
@@ -74,13 +75,43 @@ final class AuditToolTest extends TestCase
         $renderer = self::createStub(ReportRendererInterface::class);
         $renderer->method('render')->willReturn('RENDERED-REPORT');
 
-        $auditTool = new AuditTool($this->runAuditUseCase(), $renderer);
+        $auditTool = new AuditTool($this->runAuditUseCase(), $renderer, $this->auditedProjectPathHolder());
 
         self::assertSame('RENDERED-REPORT', $auditTool->audit($this->projectPath));
+    }
+
+    /**
+     * `ComposerAuditAdvisoryDatabase`, `SarifImportingPreScanner` and
+     * `FilesystemTriageMemoryStore` all resolve the audited project through
+     * `AuditedProjectPathHolder::path()`, which falls back to the bundle's own
+     * `kernel.project_dir` when never `set()`. `AuditCommand` sets it from the
+     * resolved CLI argument before running; the MCP entrypoint must do the
+     * same for its own `path` argument, or those collaborators silently
+     * resolve against the wrong project when the tool is invoked over MCP.
+     *
+     * @throws AuditAbortedByBudgetException
+     * @throws AuditAbortedByProviderException
+     * @throws InvalidAuditContextException
+     * @throws InvalidAuditCostException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_it_sets_the_audited_project_path_holder_before_running_the_use_case(): void
+    {
+        $auditedProjectPathHolder = $this->auditedProjectPathHolder();
+        $auditTool = new AuditTool($this->runAuditUseCase(), new JsonReportRenderer(), $auditedProjectPathHolder);
+
+        $auditTool->audit($this->projectPath);
+
+        self::assertSame($this->projectPath, $auditedProjectPathHolder->path());
     }
 
     private function runAuditUseCase(): RunAuditUseCase
     {
         return new RunAuditUseCase(self::createStub(PipelineInterface::class), new NullLogger());
+    }
+
+    private function auditedProjectPathHolder(): AuditedProjectPathHolder
+    {
+        return new AuditedProjectPathHolder('/default/project/dir');
     }
 }

--- a/tests/Phpunit/Integration/Command/Mcp/McpServeCommandTest.php
+++ b/tests/Phpunit/Integration/Command/Mcp/McpServeCommandTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\PipelineInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JsonReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\AuditTool;
@@ -69,7 +70,7 @@ final class McpServeCommandTest extends TestCase
     private function command(): McpServeCommand
     {
         $mcpServerFactory = new McpServerFactory(
-            new AuditTool(new RunAuditUseCase(self::createStub(PipelineInterface::class), new NullLogger()), new JsonReportRenderer()),
+            new AuditTool(new RunAuditUseCase(self::createStub(PipelineInterface::class), new NullLogger()), new JsonReportRenderer(), new AuditedProjectPathHolder('/default/project/dir')),
             new ReportPackage(),
         );
 

--- a/tests/Phpunit/Integration/Command/Mcp/McpServerFactoryTest.php
+++ b/tests/Phpunit/Integration/Command/Mcp/McpServerFactoryTest.php
@@ -19,6 +19,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\UseCase\RunAuditUseCase;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Pipeline\PipelineInterface;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Advisory\AuditedProjectPathHolder;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\JsonReportRenderer;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\Mcp\AuditTool;
@@ -74,7 +75,7 @@ final class McpServerFactoryTest extends TestCase
     private function converse(): string
     {
         $server = (new McpServerFactory(
-            new AuditTool(new RunAuditUseCase(self::createStub(PipelineInterface::class), new NullLogger()), new JsonReportRenderer()),
+            new AuditTool(new RunAuditUseCase(self::createStub(PipelineInterface::class), new NullLogger()), new JsonReportRenderer(), new AuditedProjectPathHolder('/default/project/dir')),
             new ReportPackage(),
         ))->create();
 

--- a/tests/Phpunit/Integration/Diff/ProcessGitChangedFilesResolverTest.php
+++ b/tests/Phpunit/Integration/Diff/ProcessGitChangedFilesResolverTest.php
@@ -329,6 +329,37 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
     }
 
     /**
+     * `core.fsmonitor=` (added above) only closes one config-driven command
+     * hook. A `.gitattributes` `filter=` assignment plus a matching
+     * `filter.<name>.clean` command in the same untrusted `.git/config`
+     * reaches an arbitrary command too — git runs the clean filter to
+     * normalize a working-tree file before comparing it against the index,
+     * which `git diff HEAD` (the plain worktree-vs-HEAD comparison this
+     * resolver used for uncommitted changes) triggers for any file whose
+     * stat info looks changed. `git diff-index --cached` (index vs HEAD) and
+     * `git diff-files` (worktree vs index) together cover the same ground
+     * without ever invoking a content filter.
+     *
+     * @throws GitChangedFilesUnavailableException
+     */
+    public function test_it_does_not_execute_the_audited_repos_clean_filter(): void
+    {
+        $this->initRepo();
+        $this->commit('src/Foo.php', '<?php // initial', 'init');
+
+        $marker = $this->tmpDir.'-clean-filter-pwned';
+        $this->writeFile('.gitattributes', '*.php filter=dangerous');
+        $this->stage('.gitattributes');
+        $this->runGit(['git', 'commit', '-m', 'add gitattributes']);
+        $this->runGit(['git', 'config', 'filter.dangerous.clean', \sprintf('sh -c "touch %s"', $marker)]);
+        $this->writeFile('src/Foo.php', '<?php // uncommitted edit');
+
+        (new ProcessGitChangedFilesResolver())->changedSince($this->tmpDir, 'HEAD');
+
+        self::assertFileDoesNotExist($marker);
+    }
+
+    /**
      * @throws GitChangedFilesUnavailableException
      */
     public function test_it_wraps_a_git_diff_timeout_instead_of_leaking_a_raw_process_exception(): void
@@ -360,6 +391,7 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
     {
         $this->filesystem->remove($this->tmpDir);
         $this->filesystem->remove($this->tmpDir.'-fsmonitor-pwned');
+        $this->filesystem->remove($this->tmpDir.'-clean-filter-pwned');
     }
 
     private function initRepo(): void

--- a/tests/Phpunit/Integration/Diff/ProcessGitChangedFilesResolverTest.php
+++ b/tests/Phpunit/Integration/Diff/ProcessGitChangedFilesResolverTest.php
@@ -305,6 +305,30 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
     }
 
     /**
+     * The audited project is untrusted — its own `.git/config` is attacker
+     * data. `core.fsmonitor` lets a repo declare an arbitrary command that git
+     * runs on any working-tree comparison, including the plain `git diff
+     * --name-only HEAD` this resolver issues for uncommitted changes. Left
+     * unneutralized, auditing a malicious clone with `--since` executes that
+     * command as the auditor's own process.
+     *
+     * @throws GitChangedFilesUnavailableException
+     */
+    public function test_it_does_not_execute_the_audited_repos_fsmonitor_hook(): void
+    {
+        $this->initRepo();
+        $this->commit('src/Foo.php', '<?php // initial', 'init');
+
+        $marker = $this->tmpDir.'-fsmonitor-pwned';
+        $this->runGit(['git', 'config', 'core.fsmonitor', \sprintf('sh -c "touch %s"', $marker)]);
+        $this->writeFile('src/Foo.php', '<?php // uncommitted edit');
+
+        (new ProcessGitChangedFilesResolver())->changedSince($this->tmpDir, 'HEAD');
+
+        self::assertFileDoesNotExist($marker);
+    }
+
+    /**
      * @throws GitChangedFilesUnavailableException
      */
     public function test_it_wraps_a_git_diff_timeout_instead_of_leaking_a_raw_process_exception(): void
@@ -335,6 +359,7 @@ final class ProcessGitChangedFilesResolverTest extends TestCase
     protected function tearDown(): void
     {
         $this->filesystem->remove($this->tmpDir);
+        $this->filesystem->remove($this->tmpDir.'-fsmonitor-pwned');
     }
 
     private function initRepo(): void


### PR DESCRIPTION
## Summary

A malicious audited repo could run code via its own `core.fsmonitor` git config or a `.gitattributes` clean-filter; the MCP tool never set/canonicalized the audited-project path holder, so advisories/SARIF-import/cache resolved against the wrong directory; and the PR-comment action trusted an unauthenticated marker to pick which comment to edit.

**Note:** this PR originally also fixed the `RegexCodeSlicer` block-comment segfault and pinned `spc`'s release checksum in `release.yaml`. Both turned out to duplicate independent fixes discovered in a later audit pass — the `spc` checksum pinning is already merged (#296), and the segfault fix is `fix/regex-code-slicer-recursion-segfault` (#295, not yet merged). Both duplicate hunks are dropped here to avoid the fixes conflicting with each other; **this PR should merge after #295** so the segfault fix isn't lost in between.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPUnit (100% coverage), PHPStan, CS Fixer, Rector, Deptrac, zizmor — all green locally
- [x] 100% MSI maintained: diff-scoped Infection against `origin/1.x` — 17/17 mutants killed, 100% MSI
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
