### PR TITLE
fix: reject negative token counts unconditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -503,6 +503,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   edit their comment on every subsequent rerun instead of posting its own. The
   `jq` selector now also requires `.user.login == "github-actions[bot]"`.
 
+- **A negative token count from the LLM provider could permanently defeat the
+  configured rate limit for the rest of its window.** The only place that
+  rejected a negative token count was `TokenUsageRecorder::record()`, reached
+  through `PlatformResultExtractor::extractTokens()`'s optional
+  `$tokenUsageRecorder` collaborator
+  (`src/Audit/Infrastructure/LLM/PlatformResultExtractor.php`) — but
+  `PlatformAccountingConfig` defaults that collaborator to `null`, a legitimate,
+  supported configuration. Built without one, `extractTokens()` returned an
+  unvalidated negative value straight to `RateLimiterInterface::record()`
+  (`src/Audit/Infrastructure/LLM/RateLimit/TokenBucketRateLimiter.php`), whose
+  mutable window counters have no lower bound of their own — a single malformed
+  or compromised provider response could drive the counter deeply negative,
+  silently suppressing the input-tokens-per-minute limit for the rest of that
+  window regardless of how much real traffic followed. `extractTokens()` now
+  validates all four token counts itself, unconditionally, before any caller
+  ever sees them.
+
 - **`audit.budget.max_tokens` did not bound a run's real token spend once
   provider prompt caching was involved.** `LLMResponse::totalTokens()`
   (`src/Audit/Domain/Port/LLMResponse.php`) returned only

--- a/src/Audit/Infrastructure/LLM/PlatformResultExtractor.php
+++ b/src/Audit/Infrastructure/LLM/PlatformResultExtractor.php
@@ -57,9 +57,41 @@ final readonly class PlatformResultExtractor
         $outputTokens = $tokenUsage->getCompletionTokens() ?? 0;
         $cacheReadTokens = $tokenUsage->getCacheReadTokens() ?? 0;
         $cacheCreationTokens = $tokenUsage->getCacheCreationTokens() ?? 0;
+        $this->assertNonNegative($inputTokens, $outputTokens, $cacheReadTokens, $cacheCreationTokens);
         $this->tokenUsageRecorder?->record($inputTokens, $outputTokens, $cacheReadTokens, $cacheCreationTokens);
 
         return [$inputTokens, $outputTokens, $cacheReadTokens, $cacheCreationTokens];
+    }
+
+    /**
+     * A negative count here is a compromised or malfunctioning provider
+     * response — every caller relies on rejecting it before it ever reaches
+     * `RateLimiterInterface::record()`, whose mutable window counters have no
+     * lower bound of their own and would stay corrupted for the rest of the
+     * rate-limit window. `$tokenUsageRecorder` is optional
+     * ({@see PlatformAccountingConfig}
+     * defaults it to `null`), so this guard cannot live behind it — it must
+     * run unconditionally.
+     *
+     * @throws NegativeTokenCountException
+     */
+    private function assertNonNegative(int $inputTokens, int $outputTokens, int $cacheReadTokens, int $cacheCreationTokens): void
+    {
+        if ($inputTokens < 0) {
+            throw NegativeTokenCountException::forInputTokens($inputTokens);
+        }
+
+        if ($outputTokens < 0) {
+            throw NegativeTokenCountException::forOutputTokens($outputTokens);
+        }
+
+        if ($cacheReadTokens < 0) {
+            throw NegativeTokenCountException::forCacheReadTokens($cacheReadTokens);
+        }
+
+        if ($cacheCreationTokens < 0) {
+            throw NegativeTokenCountException::forCacheCreationTokens($cacheCreationTokens);
+        }
     }
 
     public function extractStopReason(DeferredResult $deferredResult): ?string

--- a/tests/Phpunit/Integration/LLM/Fixture/ScriptedTokenUsagePlatform.php
+++ b/tests/Phpunit/Integration/LLM/Fixture/ScriptedTokenUsagePlatform.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture;
+
+use Override;
+use RuntimeException;
+use Symfony\AI\Platform\Model;
+use Symfony\AI\Platform\ModelCatalog\FallbackModelCatalog;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\PlainConverter;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+use Symfony\AI\Platform\Result\InMemoryRawResult;
+use Symfony\AI\Platform\Result\ResultInterface;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+
+final class ScriptedTokenUsagePlatform implements PlatformInterface
+{
+    /**
+     * @param list<ResultInterface> $results
+     * @param list<TokenUsage>      $tokenUsages
+     */
+    public function __construct(
+        private array $results,
+        private array $tokenUsages,
+    ) {}
+
+    #[Override]
+    public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
+    {
+        $result = array_shift($this->results);
+        if (!$result instanceof ResultInterface) {
+            throw new RuntimeException('ScriptedTokenUsagePlatform invoked more times than scripted — invokeWithRetry never returned (a mutation removed a loop-exit branch).');
+        }
+
+        $tokenUsage = array_shift($this->tokenUsages);
+        $deferredResult = new DeferredResult(
+            new PlainConverter($result),
+            new InMemoryRawResult(['text' => ''], [], (object) []),
+            $options,
+        );
+        if ($tokenUsage instanceof TokenUsage) {
+            $deferredResult->getMetadata()->add('token_usage', $tokenUsage);
+        }
+
+        return $deferredResult;
+    }
+
+    #[Override]
+    public function getModelCatalog(): ModelCatalogInterface
+    {
+        return new FallbackModelCatalog();
+    }
+}

--- a/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
+++ b/tests/Phpunit/Integration/LLM/SymfonyAiLLMClientTest.php
@@ -81,6 +81,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture\FakeSleep
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture\FixedTokenEstimator;
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture\InvocationOptionsCapture;
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture\PlatformInvocationLog;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture\ScriptedTokenUsagePlatform;
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\LLM\Fixture\ThrowingConverter;
 
 final class SymfonyAiLLMClientTest extends TestCase
@@ -786,6 +787,46 @@ final class SymfonyAiLLMClientTest extends TestCase
     }
 
     /**
+     * The negative-token guard above only fires through
+     * `TokenUsageRecorder::record()`, reached via
+     * `PlatformResultExtractor::extractTokens()`'s optional, nullable
+     * `$tokenUsageRecorder` collaborator. `PlatformAccountingConfig` defaults
+     * that collaborator to `null` — a legitimate, supported configuration —
+     * so building the client without one (as this test does) must not let a
+     * provider-reported negative token count reach the rate limiter
+     * unvalidated: `extractTokens()` itself must reject it before any caller
+     * ever sees the value.
+     *
+     * @throws MissingAiPlatformException
+     * @throws BudgetExceededException
+     * @throws TransientLLMFailureException
+     * @throws NonTransientLLMFailureException
+     * @throws InvalidTokenUsageException
+     * @throws InvalidRetryConfigurationException
+     */
+    public function test_complete_releases_the_rate_limiter_reservation_when_token_extraction_fails_without_a_token_usage_recorder(): void
+    {
+        $fakeRateLimiter = new FakeRateLimiter();
+        $platform = $this->scriptedPlatformWithTokenUsage(new TextResult('a'), new TokenUsage(promptTokens: -1, completionTokens: 0));
+
+        $symfonyAiLLMClient = new SymfonyAiLLMClient(
+            new PlatformBinding($platform, 'm', new NullLogger()),
+            platformResilienceConfig: new PlatformResilienceConfig(rateLimiter: $fakeRateLimiter),
+        );
+
+        $threw = false;
+        try {
+            $symfonyAiLLMClient->complete('s', 'u');
+        } catch (NegativeTokenCountException) {
+            $threw = true;
+        }
+
+        self::assertTrue($threw);
+        self::assertCount(1, $fakeRateLimiter->acquired);
+        self::assertSame([[0, 0]], $fakeRateLimiter->recorded);
+    }
+
+    /**
      * @throws MissingAiPlatformException
      * @throws BudgetExceededException
      * @throws TransientLLMFailureException
@@ -893,10 +934,15 @@ final class SymfonyAiLLMClientTest extends TestCase
     }
 
     /**
+     * A dispatch whose token extraction fails must release its own
+     * reservation as `[0, 0]` — not the poisoned value that failed to
+     * extract — and the fallback `complete()` call's own reservation must
+     * still be recorded correctly and independently alongside it.
+     *
      * @throws MissingAiPlatformException
      * @throws BudgetExceededException
      */
-    public function test_complete_batch_does_not_release_an_already_reconciled_reservation_when_a_later_step_fails(): void
+    public function test_complete_batch_releases_a_clean_reservation_when_extraction_fails_then_records_the_fallbacks_reservation_independently(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
         $platform = $this->scriptedPlatformWithTokenUsage(
@@ -912,7 +958,7 @@ final class SymfonyAiLLMClientTest extends TestCase
         $responses = $symfonyAiLLMClient->completeBatch([['system' => 's', 'user' => 'u']], 4);
 
         self::assertSame('recovered', $responses[0]->content());
-        self::assertSame([[-1, 0], [5, 2]], $fakeRateLimiter->recorded);
+        self::assertSame([[0, 0], [5, 2]], $fakeRateLimiter->recorded);
     }
 
     /**
@@ -1276,13 +1322,18 @@ final class SymfonyAiLLMClientTest extends TestCase
     }
 
     /**
+     * A dispatch whose token extraction fails must release its own
+     * reservation as `[0, 0]` — not the poisoned value that failed to
+     * extract — and the fallback conversation's own reservation must still
+     * be recorded correctly and independently alongside it.
+     *
      * @throws MissingAiPlatformException
      * @throws BudgetExceededException
      * @throws InvalidToolRegistryException
      * @throws InvalidTokenUsageException
      * @throws NonTransientLLMFailureException
      */
-    public function test_complete_batch_with_tools_does_not_release_an_already_reconciled_reservation_when_a_later_step_fails(): void
+    public function test_complete_batch_with_tools_releases_a_clean_reservation_when_extraction_fails_then_records_the_fallbacks_reservation_independently(): void
     {
         $fakeRateLimiter = new FakeRateLimiter();
         $toolRegistry = new ToolRegistry([$this->makeTool('record', 'd')], new NullLogger());
@@ -1301,7 +1352,7 @@ final class SymfonyAiLLMClientTest extends TestCase
         ], 4, 3);
 
         self::assertSame('recovered', $responses[0]->content());
-        self::assertSame([[-1, 0], [5, 2]], $fakeRateLimiter->recorded);
+        self::assertSame([[0, 0], [5, 2]], $fakeRateLimiter->recorded);
     }
 
     /**
@@ -2852,43 +2903,7 @@ final class SymfonyAiLLMClientTest extends TestCase
         $resultList = $results instanceof ResultInterface ? [$results] : $results;
         $tokenUsageList = $tokenUsages instanceof TokenUsage ? [$tokenUsages] : $tokenUsages;
 
-        return new class($resultList, $tokenUsageList) implements PlatformInterface {
-            /**
-             * @param list<ResultInterface> $results
-             * @param list<TokenUsage>      $tokenUsages
-             */
-            public function __construct(
-                private array $results,
-                private array $tokenUsages,
-            ) {}
-
-            #[Override]
-            public function invoke(Model|string $model, array|string|object $input, array $options = []): DeferredResult
-            {
-                $result = array_shift($this->results);
-                if (!$result instanceof ResultInterface) {
-                    throw new RuntimeException('scriptedPlatformWithTokenUsage invoked more times than scripted — invokeWithRetry never returned (a mutation removed a loop-exit branch).');
-                }
-
-                $tokenUsage = array_shift($this->tokenUsages);
-                $deferredResult = new DeferredResult(
-                    new PlainConverter($result),
-                    new InMemoryRawResult(['text' => ''], [], (object) []),
-                    $options,
-                );
-                if ($tokenUsage instanceof TokenUsage) {
-                    $deferredResult->getMetadata()->add('token_usage', $tokenUsage);
-                }
-
-                return $deferredResult;
-            }
-
-            #[Override]
-            public function getModelCatalog(): ModelCatalogInterface
-            {
-                return new FallbackModelCatalog();
-            }
-        };
+        return new ScriptedTokenUsagePlatform($resultList, $tokenUsageList);
     }
 
     /**

--- a/tests/Phpunit/Unit/Infrastructure/LLM/PlatformResultExtractorTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/LLM/PlatformResultExtractorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\LLM;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\FinishReason\FinishReason;
@@ -21,10 +22,66 @@ use Symfony\AI\Platform\PlainConverter;
 use Symfony\AI\Platform\Result\DeferredResult;
 use Symfony\AI\Platform\Result\InMemoryRawResult;
 use Symfony\AI\Platform\Result\TextResult;
+use Symfony\AI\Platform\TokenUsage\TokenUsage;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Exception\NegativeTokenCountException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\PlatformAccountingConfig;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\LLM\PlatformResultExtractor;
 
 final class PlatformResultExtractorTest extends TestCase
 {
+    /**
+     * @throws NegativeTokenCountException
+     */
+    public function test_it_extracts_all_four_token_counts_with_no_recorder(): void
+    {
+        $platformResultExtractor = new PlatformResultExtractor(null);
+
+        $tokens = $platformResultExtractor->extractTokens(
+            $this->deferredResultWithTokenUsage(new TokenUsage(promptTokens: 10, completionTokens: 5, cacheCreationTokens: 2, cacheReadTokens: 3)),
+        );
+
+        self::assertSame([10, 5, 3, 2], $tokens);
+    }
+
+    /**
+     * A negative count is a compromised or malfunctioning provider response.
+     * `$tokenUsageRecorder` is optional and defaults to `null`
+     * ({@see PlatformAccountingConfig}),
+     * so this guard must reject the value itself rather than relying on the
+     * recorder's own validation — every caller depends on it running before
+     * the value ever reaches `RateLimiterInterface::record()`, whose
+     * mutable window counters have no lower bound of their own.
+     *
+     * @throws NegativeTokenCountException
+     */
+    #[DataProvider('negativeTokenCases')]
+    public function test_it_rejects_a_negative_token_count_with_no_recorder(TokenUsage $tokenUsage, string $expectedMessage): void
+    {
+        $platformResultExtractor = new PlatformResultExtractor(null);
+
+        $this->expectException(NegativeTokenCountException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $platformResultExtractor->extractTokens($this->deferredResultWithTokenUsage($tokenUsage));
+    }
+
+    /** @return iterable<string, array{TokenUsage, string}> */
+    public static function negativeTokenCases(): iterable
+    {
+        yield 'input tokens' => [new TokenUsage(promptTokens: -1, completionTokens: 0), 'Input tokens must be >= 0, got -1'];
+        yield 'output tokens' => [new TokenUsage(promptTokens: 0, completionTokens: -1), 'Output tokens must be >= 0, got -1'];
+        yield 'cache read tokens' => [new TokenUsage(promptTokens: 0, completionTokens: 0, cacheReadTokens: -1), 'Cache read tokens must be >= 0, got -1'];
+        yield 'cache creation tokens' => [new TokenUsage(promptTokens: 0, completionTokens: 0, cacheCreationTokens: -1), 'Cache creation tokens must be >= 0, got -1'];
+    }
+
+    private function deferredResultWithTokenUsage(TokenUsage $tokenUsage): DeferredResult
+    {
+        $deferredResult = $this->deferredResult();
+        $deferredResult->getMetadata()->add('token_usage', $tokenUsage);
+
+        return $deferredResult;
+    }
+
     public function test_it_extracts_the_raw_provider_stop_reason(): void
     {
         $platformResultExtractor = new PlatformResultExtractor(null);


### PR DESCRIPTION
## Summary

`PlatformResultExtractor::extractTokens()` only rejected a negative provider-reported token count when an optional `TokenUsageRecorder` happened to be wired — but that collaborator defaults to `null`. Without one, a malformed or malicious provider response could drive the rate limiter's window counters permanently negative, silently defeating the configured tokens-per-minute limit for the rest of that window.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)