### PR TITLE
ci(release): scope binary job's write token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,11 +53,9 @@ jobs:
           compression-level: 9
 
   binary:
-    name: ${{ matrix.asset }}
+    name: Build ${{ matrix.asset }}
     runs-on: ${{ matrix.runner }}
     needs: phar
-    permissions:
-      contents: write
     env:
       SPC_VERSION: '2.8.5'
 
@@ -226,6 +224,36 @@ jobs:
             shasum -a 256 "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
           fi
 
+      - name: Upload the binary and checksum
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.asset }}
+          path: |
+            ${{ matrix.asset }}
+            ${{ matrix.asset }}.sha256
+          retention-days: 1
+
+  binary-publish:
+    name: Publish ${{ matrix.asset }}
+    runs-on: ubuntu-latest
+    needs: binary
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        asset:
+          - symfony-security-auditor-linux-x86_64
+          - symfony-security-auditor-linux-aarch64
+          - symfony-security-auditor-macos-x86_64
+          - symfony-security-auditor-macos-arm64
+          - symfony-security-auditor-windows-x86_64.exe
+    steps:
+      - name: Download the binary and checksum
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.asset }}
+
       - name: Attach the binary and checksum to the release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # zizmor: ignore[superfluous-actions] v3.0.2 -- not a security issue per zizmor's own docs; migrating to `gh release` is a separate follow-up
         with:
@@ -271,7 +299,7 @@ jobs:
   prune:
     name: Prune stale release assets
     runs-on: ubuntu-latest
-    needs: binary
+    needs: binary-publish
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

The `binary` job in `release.yaml` held `contents: write` for its entire duration - checkout, curl/apt downloads, `spc` build, and the final release upload - though only the last step needs it. Split into `binary` (build + upload artifact, no elevated permissions) and `binary-publish` (attach to release, `contents: write` scoped to just that job), mirroring the existing `phar` → `binary` artifact hand-off. `prune` now depends on `binary-publish`.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — N/A, CI-config-only change
- [x] All checks pass: YAML parse check + `zizmor --offline` (no findings)
- [x] 100% MSI maintained — N/A, no PHP changed
- [x] No `createMock` without a matching `expects()`
- [x] Commit messages follow Conventional Commits

## Notes

CI-only change, so no `CHANGELOG.md` entry per the changelog rule's CI-only exemption (matches how the earlier `action.yml`/`release.yaml` CI-hardening fixes in this branch's history were handled).