### PR TITLE
fix(domain): stop fingerprint() colliding on join

### DIFF
--- a/.claude/rules/domain-models.md
+++ b/.claude/rules/domain-models.md
@@ -20,6 +20,12 @@ paths:
   `filePath`/`lineStart` boundary (e.g. `src/Foo1`+`23` vs `src/Foo`+`123`)
   can't collide. Do not change this scheme without preserving that
   per-field-hash-then-join property.
+- Vulnerability `fingerprint`/`attackerFingerprint` (baseline/diff/trend
+  identity) is `SSA-{sha1(sha1(type).sha1(filePath).sha1(title))[0..11]}` — each
+  field is hashed individually before joining so a delimiter shift across a
+  field boundary (e.g. `title` starting with the same bytes that end `filePath`)
+  cannot collide two different findings onto the same fingerprint. Do not revert
+  to hashing a delimiter-joined string of the raw fields.
 - Adding a `ProjectFileType` case requires mapping it in
   `ProjectFileType::archetype()` — the `match` is exhaustive, so an unmapped
   case throws at runtime, and `SurfaceArchetypeTest` fails first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,25 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   now carries a pinned SHA-256 (`matrix.spc_sha256`), verified immediately after
   download and before either extraction or execution.
 
+- **A crafted `title` or `filePath` could forge the baseline/CI-gate identity of
+  a real, unrelated finding.** `Vulnerability::fingerprintOf()`
+  (`src/Audit/Domain/Model/Vulnerability.php`) joined `type`, `filePath`, and
+  `title` with a bare `|` before hashing, so a `filePath` ending in `|Bar` and a
+  `title` of `Unsafe SQL query` produced the exact same input string — and
+  therefore the exact same `SSA-…` fingerprint — as a `filePath` of `src/Foo`
+  paired with the title `Bar|Unsafe SQL query`. Both `filePath` and `title` are
+  attacker-influenceable (a PR author picks their own filenames; findings'
+  titles are visible in prior JSON/SARIF reports and PR comments). Because this
+  fingerprint is the sole suppression key for `Baseline`, and
+  `AuditExitCodeResolver`'s `--fail-on`/`--min-score` CI gate is computed
+  **after** baseline suppression, one innocuous-looking baseline entry could be
+  engineered to also suppress a real, unrelated HIGH/CRITICAL finding sharing
+  the colliding fingerprint — a false SAFE at the CI-gating layer. `audit:diff`
+  and `audit:trend` inherited the same weakness through `fingerprint`-keyed
+  matching. Fixed the same way as `generateId()`'s equivalent bug: each field is
+  now hashed individually before being joined, so no delimiter-free
+  concatenation can shift a byte across a field boundary.
+
 - **A finding title can no longer ping an arbitrary GitHub account from a posted
   pull-request comment.** `MarkdownTextEscaper::escapeStructuralMarkers()`
   enumerated the Markdown-active characters it neutralizes (`` ` ``, `~`, `#`,

--- a/src/Audit/Domain/Model/Vulnerability.php
+++ b/src/Audit/Domain/Model/Vulnerability.php
@@ -285,7 +285,7 @@ final readonly class Vulnerability
     {
         return \sprintf(
             'SSA-%s',
-            strtoupper(substr(sha1(\sprintf('%s|%s|%s', $vulnerabilityType, $filePath, $title)), 0, 12)),
+            strtoupper(substr(sha1(sha1($vulnerabilityType).sha1($filePath).sha1($title)), 0, 12)),
         );
     }
 

--- a/tests/Phpunit/EndToEnd/__snapshots__/default-audit.json
+++ b/tests/Phpunit/EndToEnd/__snapshots__/default-audit.json
@@ -20,7 +20,7 @@
     "vulnerabilities": [
         {
             "id": "VULN-61563E0B",
-            "fingerprint": "SSA-16C53DB2429B",
+            "fingerprint": "SSA-CA7C23B56FDC",
             "type": "broken_access_control",
             "category": "Broken Access Control",
             "owasp": "OWASP A01:2025 - Broken Access Control",

--- a/tests/Phpunit/EndToEnd/__snapshots__/default-audit.sarif.json
+++ b/tests/Phpunit/EndToEnd/__snapshots__/default-audit.sarif.json
@@ -33,7 +33,7 @@
                         "text": "Unprotected administrative action"
                     },
                     "partialFingerprints": {
-                        "symfonySecurityAuditor/v1": "SSA-16C53DB2429B"
+                        "symfonySecurityAuditor/v1": "SSA-CA7C23B56FDC"
                     },
                     "locations": [
                         {

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -2309,9 +2309,6 @@ final class AuditOrchestratorTest extends TestCase
 
     private function fingerprintFor(string $title, string $filePath = 'src/Controller/FooController.php'): string
     {
-        return \sprintf(
-            'SSA-%s',
-            strtoupper(substr(sha1(\sprintf('sql_injection|%s|%s', $filePath, $title)), 0, 12)),
-        );
+        return Vulnerability::fingerprintOf('sql_injection', $filePath, $title);
     }
 }

--- a/tests/Phpunit/Unit/Domain/Model/VulnerabilityTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/VulnerabilityTest.php
@@ -696,7 +696,7 @@ final class VulnerabilityTest extends TestCase
             'filePath' => 'src/Foo.php',
         ]);
 
-        self::assertSame('SSA-52DE9FC9CB6C', $vulnerability->fingerprint());
+        self::assertSame('SSA-6BCE9E066CD5', $vulnerability->fingerprint());
     }
 
     /**
@@ -723,6 +723,36 @@ final class VulnerabilityTest extends TestCase
             $this->makeVulnerability(['title' => 'Title A'])->fingerprint(),
             $this->makeVulnerability(['title' => 'Title B'])->fingerprint(),
         );
+    }
+
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_fingerprint_does_not_collide_when_a_pipe_shifts_across_the_file_path_and_title_boundary(): void
+    {
+        $vulnerability = $this->makeVulnerability(['filePath' => 'src/Foo', 'title' => 'Bar|Unsafe SQL query']);
+        $shifted = $this->makeVulnerability(['filePath' => 'src/Foo|Bar', 'title' => 'Unsafe SQL query']);
+
+        self::assertNotSame($vulnerability->fingerprint(), $shifted->fingerprint());
+    }
+
+    /**
+     * @throws InvalidCodeLocationException
+     * @throws InvalidVulnerabilityClassificationException
+     * @throws InvalidVulnerabilityNarrativeException
+     */
+    public function test_fingerprint_matches_exact_hash_of_the_individually_hashed_inputs(): void
+    {
+        $vulnerability = $this->makeVulnerability([
+            'vulnerabilityType' => VulnerabilityType::SQL_INJECTION,
+            'filePath' => 'src/Foo.php',
+            'title' => 'My Title',
+        ]);
+
+        $expected = \sprintf('SSA-%s', strtoupper(substr(sha1(sha1('sql_injection').sha1('src/Foo.php').sha1('My Title')), 0, 12)));
+        self::assertSame($expected, $vulnerability->fingerprint());
     }
 
     /**


### PR DESCRIPTION
## Summary

`Vulnerability::fingerprintOf()` hashed `type|filePath|title` with a bare `|` delimiter, so a `filePath` ending in `...|Bar` + title `Unsafe SQL query` collided with `filePath` `...Foo` + title `Bar|Unsafe SQL query` — same fingerprint, same `SSA-…` baseline identity. Since this fingerprint is the sole baseline-suppression key and `--fail-on`/`--min-score` is computed *after* suppression, one crafted baseline entry could mask an unrelated real HIGH/CRITICAL finding (a false SAFE at the CI-gating layer). Fixed the same way as the earlier `generateId()` fix (#292): hash each field individually before joining.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPUnit (100% coverage), PHPStan, CS Fixer, Rector, Deptrac, Swiss Knife — all green locally
- [x] 100% MSI maintained: diff-scoped Infection against `origin/1.x` — 41/41 mutants killed, 100% MSI
- [x] No `createMock` without a matching `expects()`
- [x] Commit messages follow Conventional Commits

## Why this is a PATCH, not a MAJOR

Same rationale as #292: `fingerprint()`/`attackerFingerprint()` are baseline/diff/trend identity values, not part of the JSON/SARIF report schema shape (the `fingerprint` *field* is unchanged; only its value derivation changed). Per `.claude/rules/domain-models.md`, this scheme is now documented and pinned. The two E2E golden snapshots embedding a literal fingerprint were regenerated in the same commit.