### PR TITLE
ci: verify static-php-cli checksum before use

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,21 +66,26 @@ jobs:
           - runner: ubuntu-latest
             asset: symfony-security-auditor-linux-x86_64
             spc: spc-linux-x86_64
+            spc_sha256: '523ba4279c54c7a377156c0dd3a36adf92ee64b01e9a7f5e9e2ec084b8e458e5'
           - runner: ubuntu-24.04-arm
             asset: symfony-security-auditor-linux-aarch64
             spc: spc-linux-aarch64
+            spc_sha256: '675a3840dcdc4ed041fe20eaa54310ce019a9984c1c03951df9ec66df5795213'
           - runner: macos-15-intel
             asset: symfony-security-auditor-macos-x86_64
             spc: spc-macos-x86_64
+            spc_sha256: 'e8b798048f62ca4960764196543b60ae703f7174aa418824cf542aeec1d2cd6a'
           - runner: macos-14
             asset: symfony-security-auditor-macos-arm64
             spc: spc-macos-aarch64
+            spc_sha256: 'acf2f25d56d0cbf8e65aa82e5054fef555f7be7c5c38046c6e0819f266d83225'
           # Pinned to windows-2022: spc 2.8.5 locates Visual Studio through a
           # hardcoded list of VS 2019/2022 paths, and windows-latest ships
           # VS 2026 (no VS 2022) since GitHub's June 2026 image migration.
           - runner: windows-2022
             asset: symfony-security-auditor-windows-x86_64.exe
             spc: spc-windows-x64.exe
+            spc_sha256: '425b54ab857e21409c1fd9b818899ffebabd1e2817ef0a0ed5ae8a3d9f5b463b'
     defaults:
       run:
         shell: bash
@@ -91,14 +96,25 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
-      - name: Setup static-php-cli (pinned stable release)
+      - name: Setup static-php-cli (pinned stable release, checksum-verified)
         run: |
+          verify_sha256() {
+            if command -v sha256sum >/dev/null 2>&1; then
+              echo "$1  $2" | sha256sum -c -
+            else
+              echo "$1  $2" | shasum -a 256 -c -
+            fi
+          }
+
           case "${{ matrix.spc }}" in
             *.exe)
               curl -fsSL --retry 3 -o spc.exe "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/${{ matrix.spc }}"
+              verify_sha256 "${{ matrix.spc_sha256 }}" spc.exe
               ;;
             *)
-              curl -fsSL --retry 3 "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/${{ matrix.spc }}.tar.gz" | tar -xz
+              curl -fsSL --retry 3 -o spc.tar.gz "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/${{ matrix.spc }}.tar.gz"
+              verify_sha256 "${{ matrix.spc_sha256 }}" spc.tar.gz
+              tar -xzf spc.tar.gz
               chmod +x spc
               ;;
           esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,21 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Security
 
+- **The release pipeline's `static-php-cli` (`spc`) download is now
+  checksum-verified.** `release.yaml`'s `binary` job pinned `spc` only to a
+  mutable version _tag_ (`SPC_VERSION: '2.8.5'`) and executed it
+  (`./spc doctor`, `./spc build`, …) with no integrity check, unlike every other
+  third-party download in the same job — the `autopoint`/`re2c` `.deb` fallback
+  two steps later is already SHA-256-verified before `dpkg -i`, and every
+  `uses:` in the repo is commit-SHA pinned. A GitHub release asset attached to
+  an existing tag can be replaced without the tag changing, so a compromised
+  upstream release would be downloaded and executed by the very job that
+  produces the officially published binaries — and the checksum this job later
+  publishes alongside them is generated _after_ `spc` has already run, so it
+  would happily match a backdoored artifact. Each matrix platform's `spc` asset
+  now carries a pinned SHA-256 (`matrix.spc_sha256`), verified immediately after
+  download and before either extraction or execution.
+
 - **A finding title can no longer ping an arbitrary GitHub account from a posted
   pull-request comment.** `MarkdownTextEscaper::escapeStructuralMarkers()`
   enumerated the Markdown-active characters it neutralizes (`` ` ``, `~`, `#`,


### PR DESCRIPTION
## Summary

`release.yaml`'s `binary` job pinned `static-php-cli` (`spc`) only to a mutable version tag (`SPC_VERSION: '2.8.5'`) and executed it with no integrity check — unlike everything else in the same job (the `autopoint`/`re2c` `.deb` fallback is SHA-256-verified before `dpkg -i`; every `uses:` is commit-SHA pinned). A GitHub release asset can be replaced without the tag changing, and the checksum this job later publishes alongside the built binaries is generated *after* `spc` already ran — so it would happily match a backdoored artifact. Each matrix platform now carries a pinned `spc_sha256`, verified immediately after download and before extraction/execution.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — N/A, CI-workflow-only change
- [x] All checks pass: `zizmor --offline .` (repo-wide, no findings) and a YAML parse check
- [x] 100% MSI maintained — N/A, no PHP source changed
- [x] No `createMock` without a matching `expects()` — N/A
- [x] Commit messages follow Conventional Commits