### PR TITLE
test: fix SARIF slash-escaping mutant gap

### DIFF
--- a/tests/Phpunit/Unit/Infrastructure/Report/SarifReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/SarifReportRendererTest.php
@@ -365,11 +365,10 @@ final class SarifReportRendererTest extends AbstractReportRendererTestCase
      */
     public function test_render_produces_valid_unescaped_slashes_json(): void
     {
-        $decoded = $this->decodeSarif($this->makeReport());
-        $schema = $decoded['$schema'];
+        $raw = $this->renderer->render($this->makeReport());
 
-        self::assertStringContainsString('/', $schema);
-        self::assertStringNotContainsString('\/', $schema);
+        self::assertStringContainsString('https://json.schemastore.org', $raw);
+        self::assertStringNotContainsString('\/', $raw);
     }
 
     /**


### PR DESCRIPTION
## Summary

`1.x`'s full (non-diff-scoped) Infection run is currently red on every PHP/Symfony matrix leg: `test_render_produces_valid_unescaped_slashes_json` asserted against `json_decode()`'d output, which normalizes `\/` and `/` to the identical PHP string — so the test could never fail regardless of whether `SarifReportRenderer::render()` actually passes `JSON_UNESCAPED_SLASHES` to `json_encode()`. A `BitwiseOr` mutant (`|` → `&` between `JSON_UNESCAPED_SLASHES` and `JSON_INVALID_UTF8_SUBSTITUTE`, which drops both flags since they share no bits and `&` binds tighter than `|`) escaped as a result. Fixed by asserting against the raw rendered string instead.

## Type of change

- [x] Tests only

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPUnit (100% coverage), PHPStan, CS Fixer, Rector, Deptrac — all green locally
- [x] 100% MSI maintained: `--filter=SarifReportRenderer.php` Infection run — 55/55 mutants killed, 100% MSI (previously 1 escaped)
- [x] No `createMock` without a matching `expects()`
- [x] Commit messages follow Conventional Commits

## Notes

Verified against the actual mutant by applying it manually: the new assertion fails with it applied (escaped slashes appear in the raw output) and passes on current code. No CHANGELOG entry — test-only change, no production behavior differs.