### PR TITLE
refactor(scan): decompose RegexCodeSlicer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Changed
 
+- **`RegexCodeSlicer` (`src/Audit/Infrastructure/Scan/`) split from one 465-line
+  class into eight single-responsibility collaborators.** `StringLiteralMasker`
+  neutralizes string-literal content; `SecurityRelevantLineClassifier` decides
+  structural/security-token retention; `BlockCommentStripper` and
+  `ParenContinuationTracker` track block-comment and paren-continuation state
+  across lines; `HeredocLineTracker` retains a heredoc/nowdoc body verbatim.
+  Retention itself is now a `LineRetentionDeciderInterface`, with
+  `ContinuationForcedLineRetentionDecider` decorating
+  `SecurityRelevantLineClassifier` so a line that continues an open construct is
+  retained regardless of the base classifier's verdict — replacing an inline
+  three-way boolean OR in `slice()`. `RegexCodeSlicer` itself is now a 93-line
+  orchestrator. Purely internal (`@internal`, not part of the BC promise);
+  identical output for every existing case.
+
 - **CI now runs on version branches.** `.github/workflows/ci.yaml` triggered on
   pushes to `main` only, so a commit pushed straight to a next-`MAJOR` branch
   like `2.x` would ship without the test matrix, PHPStan, Deptrac or Infection

--- a/src/Audit/Infrastructure/Scan/BlockCommentStripper.php
+++ b/src/Audit/Infrastructure/Scan/BlockCommentStripper.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Strips block-comment content from a line, carrying the open/close state
+ * across lines regardless of whether either line is elided.
+ */
+final readonly class BlockCommentStripper
+{
+    public function __construct(
+        private StringLiteralMasker $stringLiteralMasker = new StringLiteralMasker(),
+    ) {}
+
+    /**
+     * @return array{line: string, inside_block_comment: bool}
+     */
+    public function strip(string $line, bool $insideBlockComment): array
+    {
+        $kept = '';
+        $remaining = $line;
+
+        while (true) {
+            if ($insideBlockComment) {
+                $closeOffset = strpos($remaining, '*/');
+                if (false === $closeOffset) {
+                    return ['line' => $kept, 'inside_block_comment' => true];
+                }
+
+                $remaining = substr($remaining, $closeOffset + 2);
+                $insideBlockComment = false;
+
+                continue;
+            }
+
+            $openOffset = strpos($this->stringLiteralMasker->mask($remaining), '/*');
+            if (false === $openOffset) {
+                return ['line' => $kept.$remaining, 'inside_block_comment' => false];
+            }
+
+            $kept .= substr($remaining, 0, $openOffset);
+            $remaining = substr($remaining, $openOffset + 2);
+            $insideBlockComment = true;
+        }
+    }
+}

--- a/src/Audit/Infrastructure/Scan/ContinuationForcedLineRetentionDecider.php
+++ b/src/Audit/Infrastructure/Scan/ContinuationForcedLineRetentionDecider.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+use Override;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Decorates a {@see LineRetentionDeciderInterface}: retains a line that
+ * continues an open construct regardless of the wrapped decider's verdict.
+ */
+final readonly class ContinuationForcedLineRetentionDecider implements LineRetentionDeciderInterface
+{
+    public function __construct(
+        private LineRetentionDeciderInterface $lineRetentionDecider,
+    ) {}
+
+    #[Override]
+    public function isRetained(string $line, LineRetentionContext $lineRetentionContext): bool
+    {
+        if ($lineRetentionContext->openParenDepth > 0 || $lineRetentionContext->opensHeredoc) {
+            return true;
+        }
+
+        return $this->lineRetentionDecider->isRetained($line, $lineRetentionContext);
+    }
+}

--- a/src/Audit/Infrastructure/Scan/HeredocLineTracker.php
+++ b/src/Audit/Infrastructure/Scan/HeredocLineTracker.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Detects a heredoc/nowdoc opener and its closing identifier, so the caller
+ * retains the whole body verbatim instead of line-classifying it.
+ */
+final readonly class HeredocLineTracker
+{
+    public function __construct(
+        private ParenContinuationTracker $parenContinuationTracker = new ParenContinuationTracker(),
+    ) {}
+
+    public function identifierOpenedBy(string $line): ?string
+    {
+        if (1 !== preg_match('/<<<\s*[\'"]?([A-Za-z_]\w*)[\'"]?\s*$/', $line, $matches)) {
+            return null;
+        }
+
+        return $matches[1];
+    }
+
+    /**
+     * @return array{0: ?string, 1: int, 2: ?string}
+     */
+    public function consumeLine(string $line, string $openHeredocIdentifier, int $openParenDepth, ?string $openStringDelimiter): array
+    {
+        $trailer = $this->closeTrailer($line, $openHeredocIdentifier);
+        if (null === $trailer) {
+            return [$openHeredocIdentifier, $openParenDepth, $openStringDelimiter];
+        }
+
+        [$openParenDepth, $openStringDelimiter] = $this->parenContinuationTracker->advance(true, $trailer, $openParenDepth, $openStringDelimiter);
+
+        return [null, $openParenDepth, $openStringDelimiter];
+    }
+
+    // Matched at line start, not column 0: PHP's flexible heredoc syntax (7.3+) allows an indented closing identifier.
+    private function closeTrailer(string $line, string $identifier): ?string
+    {
+        if (1 !== preg_match(\sprintf('/^\s*%s\b(?<trailer>.*)$/', $identifier), $line, $matches)) {
+            return null;
+        }
+
+        return $matches['trailer'];
+    }
+}

--- a/src/Audit/Infrastructure/Scan/LineRetentionContext.php
+++ b/src/Audit/Infrastructure/Scan/LineRetentionContext.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class LineRetentionContext
+{
+    public function __construct(
+        public int $openParenDepth,
+        public bool $opensHeredoc,
+    ) {}
+}

--- a/src/Audit/Infrastructure/Scan/LineRetentionDeciderInterface.php
+++ b/src/Audit/Infrastructure/Scan/LineRetentionDeciderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Decides whether a single line of a sliced file is kept verbatim or elided.
+ */
+interface LineRetentionDeciderInterface
+{
+    public function isRetained(string $line, LineRetentionContext $lineRetentionContext): bool;
+}

--- a/src/Audit/Infrastructure/Scan/ParenContinuationTracker.php
+++ b/src/Audit/Infrastructure/Scan/ParenContinuationTracker.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Tracks the open-paren depth left behind by a retained line, ignoring parens
+ * inside string literals and trailing comments.
+ */
+final readonly class ParenContinuationTracker
+{
+    public function __construct(
+        private StringLiteralMasker $stringLiteralMasker = new StringLiteralMasker(),
+    ) {}
+
+    /**
+     * @return array{0: int, 1: ?string}
+     */
+    public function advance(bool $retain, string $line, int $openParenDepth, ?string $openStringDelimiter): array
+    {
+        if (!$retain) {
+            return [$openParenDepth, $openStringDelimiter];
+        }
+
+        $parenState = $this->parenDelta($line, $openStringDelimiter);
+
+        return [max(0, $openParenDepth + $parenState['delta']), $parenState['open_string_delimiter']];
+    }
+
+    /**
+     * @return array{delta: int, open_string_delimiter: ?string}
+     */
+    private function parenDelta(string $line, ?string $openStringDelimiter): array
+    {
+        if (null !== $openStringDelimiter) {
+            $closingQuoteOffset = $this->closingQuoteOffset($line, $openStringDelimiter);
+            if (null === $closingQuoteOffset) {
+                return ['delta' => 0, 'open_string_delimiter' => $openStringDelimiter];
+            }
+
+            $line = substr($line, $closingQuoteOffset + 1);
+        }
+
+        $withoutStringLiterals = $this->stringLiteralMasker->strip($line);
+        $withoutStringLiterals = $this->stripTrailingComment($withoutStringLiterals);
+
+        $danglingQuoteOffset = $this->danglingQuoteOffset($withoutStringLiterals);
+        $nextOpenStringDelimiter = null;
+        if (null !== $danglingQuoteOffset) {
+            $nextOpenStringDelimiter = $withoutStringLiterals[$danglingQuoteOffset];
+            $withoutStringLiterals = substr($withoutStringLiterals, 0, $danglingQuoteOffset);
+        }
+
+        return [
+            'delta' => substr_count($withoutStringLiterals, '(') - substr_count($withoutStringLiterals, ')'),
+            'open_string_delimiter' => $nextOpenStringDelimiter,
+        ];
+    }
+
+    private function closingQuoteOffset(string $line, string $quoteChar): ?int
+    {
+        $pattern = \sprintf('/^(?:\\\\.|[^%s\\\\])*%s/', $quoteChar, $quoteChar);
+        if (1 !== preg_match($pattern, $line, $matches)) {
+            return null;
+        }
+
+        return \strlen($matches[0]) - 1;
+    }
+
+    private function danglingQuoteOffset(string $text): ?int
+    {
+        if (1 !== preg_match('/[\'"]/', $text, $matches, \PREG_OFFSET_CAPTURE)) {
+            return null;
+        }
+
+        return $matches[0][1];
+    }
+
+    private function stripTrailingComment(string $text): string
+    {
+        $offsets = array_filter(
+            [$this->falseToNull(strpos($text, '//')), $this->hashCommentOffset($text)],
+            static fn (?int $offset): bool => null !== $offset,
+        );
+
+        return [] === $offsets ? $text : substr($text, 0, min($offsets));
+    }
+
+    // Negative lookahead: `#[` starts an attribute, not a comment.
+    private function hashCommentOffset(string $text): ?int
+    {
+        return 1 === preg_match('/#(?!\[)/', $text, $matches, \PREG_OFFSET_CAPTURE) ? $matches[0][1] : null;
+    }
+
+    private function falseToNull(int|false $offset): ?int
+    {
+        return false === $offset ? null : $offset;
+    }
+}

--- a/src/Audit/Infrastructure/Scan/RegexCodeSlicer.php
+++ b/src/Audit/Infrastructure/Scan/RegexCodeSlicer.php
@@ -17,35 +17,17 @@ use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CodeSlicerInterface;
 
-use function Symfony\Component\String\u;
-
 /**
  * @internal not part of the BC promise — see docs/versioning.md
  *
- * Lightweight line classifier that retains only the security-relevant lines of
- * a PHP file and replaces every other line with a `// elided` placeholder. A
- * line is kept when it is either:
- *
- *   - structural — a `<?php` tag, `namespace`/`use` declaration, PHP attribute,
- *     class/interface/trait/enum signature (with optional modifiers), method
- *     signature, or property/visibility-prefixed declaration; or
- *   - dangerous — it contains at least one security-relevant token (Request::
- *     access, Doctrine query builder, file I/O and upload handling, unserialize,
- *     shell exec, mailer setters, HttpClient request, weak crypto, …).
- *
- * A retained line with an unclosed `(` (a multi-line method signature or
- * attribute argument list) keeps every continuation line until its
- * parentheses close, even if a continuation line matches neither rule on its
- * own — otherwise parameter types/names would be silently dropped mid-signature.
- *
- * Because elided lines are replaced one-for-one (never removed), the file's
- * total line count is preserved and the attacker prompt's `line_start` /
- * `line_end` numbering protocol stays accurate against the original source.
- *
- * Non-PHP files (Twig, YAML, XML) pass through unchanged — they are already
- * small enough that slicing would only cost context. PHP files shorter than
- * `minLinesBeforeSlicing` also pass through: slicing a short service has no
- * token-saving upside.
+ * Replaces every line of a PHP file the collaborators below don't retain with
+ * a `// elided` placeholder, preserving total line count:
+ * {@see LineRetentionDeciderInterface} decides retention,
+ * {@see ParenContinuationTracker} extends it across an open multi-line
+ * signature, {@see HeredocLineTracker} retains a heredoc/nowdoc body
+ * verbatim, and {@see BlockCommentStripper} feeds both trackers comment-free
+ * text. Non-PHP files and files under `minLinesBeforeSlicing` pass through
+ * unchanged.
  */
 final readonly class RegexCodeSlicer implements CodeSlicerInterface
 {
@@ -53,130 +35,12 @@ final readonly class RegexCodeSlicer implements CodeSlicerInterface
 
     private const string ELIDED_PLACEHOLDER = '// elided';
 
-    /**
-     * Prefixes (matched after left-trim) that mark a line as structurally
-     * relevant and therefore always retained.
-     *
-     * @var list<string>
-     */
-    private const array STRUCTURAL_PREFIXES = [
-        '<?php',
-        'namespace ',
-        'use ',
-        '#[',
-        'class ',
-        'interface ',
-        'trait ',
-        'enum ',
-        'case ',
-        'final ',
-        'abstract ',
-        'readonly ',
-        'public ',
-        'protected ',
-        'private ',
-        'static ',
-        'function ',
-    ];
-
-    /**
-     * @var list<string>
-     */
-    private const array SECURITY_TOKENS = [
-        '$request->',
-        '$this->getUser(',
-        '->denyAccessUnlessGranted(',
-        '#[IsGranted',
-        '#[MapRequestPayload',
-        '#[MapQueryString',
-        '->isGranted(',
-        '->getRoles(',
-        '->createQuery(',
-        '->createQueryBuilder(',
-        '->executeQuery(',
-        '->executeStatement(',
-        '->setParameter(',
-        'getConnection()',
-        '->orderBy(',
-        '->where(',
-        '->andWhere(',
-        '->having(',
-        'file_get_contents(',
-        'file_put_contents(',
-        'fopen(',
-        'readfile(',
-        'unlink(',
-        'move_uploaded_file(',
-        '->move(',
-        'getClientOriginalName(',
-        'unserialize(',
-        'igbinary_unserialize(',
-        'shell_exec(',
-        'passthru(',
-        'proc_open(',
-        'system(',
-        'popen(',
-        'eval(',
-        'new Process(',
-        'Process::fromShellCommandline(',
-        'HttpClient',
-        '->request(',
-        '->redirect(',
-        'RedirectResponse',
-        '->submit(',
-        'allow_extra_fields',
-        '|raw',
-        '->getContent(',
-        'random_int(',
-        'mt_rand(',
-        'md5(',
-        'sha1(',
-        'hash_equals(',
-        '$_GET',
-        '$_POST',
-        '$_REQUEST',
-        '$_COOKIE',
-        '$_SERVER',
-        '->from(',
-        '->subject(',
-        '->addBcc(',
-        '->to(',
-        'MailerInterface',
-        'CacheInterface',
-        'LockFactory',
-        '->createLock(',
-        'RateLimiterFactory',
-        '->loadByIdentifier(',
-        'AccessTokenHandler',
-        'SelfValidatingPassport',
-        'hash_hmac(',
-        'evaluate(',
-        '->createTemplate(',
-        'simplexml_load_string(',
-        '->writeln(',
-        'json_decode(',
-        'getSession()',
-    ];
-
-    /**
-     * Bare-keyword security tokens that must be word-boundary matched rather
-     * than substring matched: a leading-character enumeration (space, `(`,
-     * `=`) misses column-0 statements (e.g. a bootstrap script's first line)
-     * and tab-indented ones — silently eliding a real file-inclusion or
-     * command-execution line instead of retaining it.
-     */
-    private const string BARE_KEYWORD_PATTERN = '/\b(?:exec|rand|include|include_once|require|require_once)\b/';
-
-    /**
-     * Matches single- or double-quoted string literals (with basic
-     * backslash-escape handling) so their contents can be stripped before
-     * counting parentheses — a default value like `'Confirm)'` must not be
-     * mistaken for a real closing paren that ends a multi-line signature.
-     */
-    private const string STRING_LITERAL_PATTERN = '/\'(?:\\\\.|[^\'\\\\])*\'|"(?:\\\\.|[^"\\\\])*"/';
-
     public function __construct(
         private int $minLinesBeforeSlicing = self::DEFAULT_MIN_LINES_BEFORE_SLICING,
+        private LineRetentionDeciderInterface $lineRetentionDecider = new ContinuationForcedLineRetentionDecider(new SecurityRelevantLineClassifier()),
+        private BlockCommentStripper $blockCommentStripper = new BlockCommentStripper(),
+        private ParenContinuationTracker $parenContinuationTracker = new ParenContinuationTracker(),
+        private HeredocLineTracker $heredocLineTracker = new HeredocLineTracker(),
     ) {}
 
     #[Override]
@@ -194,16 +58,16 @@ final readonly class RegexCodeSlicer implements CodeSlicerInterface
         foreach (explode("\n", $projectFile->content()) as $line) {
             if (null !== $openHeredocIdentifier) {
                 $output[] = $line;
-                [$openHeredocIdentifier, $openParenDepth, $openStringDelimiter] = $this->consumeHeredocLine($line, $openHeredocIdentifier, $openParenDepth, $openStringDelimiter);
+                [$openHeredocIdentifier, $openParenDepth, $openStringDelimiter] = $this->heredocLineTracker->consumeLine($line, $openHeredocIdentifier, $openParenDepth, $openStringDelimiter);
 
                 continue;
             }
 
-            $blockCommentState = $this->stripBlockComments($line, $insideBlockComment);
+            $blockCommentState = $this->blockCommentStripper->strip($line, $insideBlockComment);
             $insideBlockComment = $blockCommentState['inside_block_comment'];
 
-            $heredocIdentifier = $this->heredocIdentifierOpenedBy($blockCommentState['line']);
-            $retain = null !== $heredocIdentifier || $openParenDepth > 0 || $this->shouldRetain($line);
+            $heredocIdentifier = $this->heredocLineTracker->identifierOpenedBy($blockCommentState['line']);
+            $retain = $this->lineRetentionDecider->isRetained($line, new LineRetentionContext($openParenDepth, null !== $heredocIdentifier));
             $output[] = $retain ? $line : self::ELIDED_PLACEHOLDER;
 
             if (null !== $heredocIdentifier) {
@@ -212,73 +76,10 @@ final readonly class RegexCodeSlicer implements CodeSlicerInterface
                 continue;
             }
 
-            [$openParenDepth, $openStringDelimiter] = $this->advanceParenTracking($retain, $blockCommentState['line'], $openParenDepth, $openStringDelimiter);
+            [$openParenDepth, $openStringDelimiter] = $this->parenContinuationTracker->advance($retain, $blockCommentState['line'], $openParenDepth, $openStringDelimiter);
         }
 
         return implode("\n", $output);
-    }
-
-    /**
-     * @return array{0: int, 1: ?string}
-     */
-    private function advanceParenTracking(bool $retain, string $line, int $openParenDepth, ?string $openStringDelimiter): array
-    {
-        if (!$retain) {
-            return [$openParenDepth, $openStringDelimiter];
-        }
-
-        $parenState = $this->parenDelta($line, $openStringDelimiter);
-
-        return [max(0, $openParenDepth + $parenState['delta']), $parenState['open_string_delimiter']];
-    }
-
-    /**
-     * @return array{0: ?string, 1: int, 2: ?string}
-     */
-    private function consumeHeredocLine(string $line, string $openHeredocIdentifier, int $openParenDepth, ?string $openStringDelimiter): array
-    {
-        $trailer = $this->heredocCloseTrailer($line, $openHeredocIdentifier);
-        if (null === $trailer) {
-            return [$openHeredocIdentifier, $openParenDepth, $openStringDelimiter];
-        }
-
-        [$openParenDepth, $openStringDelimiter] = $this->advanceParenTracking(true, $trailer, $openParenDepth, $openStringDelimiter);
-
-        return [null, $openParenDepth, $openStringDelimiter];
-    }
-
-    private function heredocIdentifierOpenedBy(string $line): ?string
-    {
-        if (1 !== preg_match('/<<<\s*[\'"]?([A-Za-z_]\w*)[\'"]?\s*$/', $line, $matches)) {
-            return null;
-        }
-
-        return $matches[1];
-    }
-
-    /**
-     * A heredoc/nowdoc body is arbitrary text, not PHP code — treating it as
-     * such would misfire the security-token/structural checks on its content
-     * (a false negative when the body itself is the vulnerable line, e.g. raw
-     * SQL built with a heredoc) and feed unbalanced quotes/parens from prose
-     * into {@see self::parenDelta()}, desyncing continuation tracking for the
-     * rest of the file. The opener line and every line up to and including
-     * the closing identifier are retained verbatim instead. PHP allows the
-     * closing identifier to be indented (flexible heredoc syntax, PHP 7.3+)
-     * and requires nothing but whitespace before it, so it is matched at the
-     * start of the line rather than requiring column 0. Any code trailing
-     * the identifier on the same line (e.g. the `);` that closes an
-     * enclosing multi-line call, a common Doctrine/DBAL idiom) is real PHP,
-     * not heredoc body — it is returned so the caller can still feed it into
-     * continuation tracking instead of silently dropping it.
-     */
-    private function heredocCloseTrailer(string $line, string $identifier): ?string
-    {
-        if (1 !== preg_match(\sprintf('/^\s*%s\b(?<trailer>.*)$/', $identifier), $line, $matches)) {
-            return null;
-        }
-
-        return $matches['trailer'];
     }
 
     private function shouldSlice(ProjectFile $projectFile): bool
@@ -288,185 +89,5 @@ final readonly class RegexCodeSlicer implements CodeSlicerInterface
         }
 
         return $projectFile->linesCount() >= $this->minLinesBeforeSlicing;
-    }
-
-    private function shouldRetain(string $line): bool
-    {
-        if ($this->isStructural($line)) {
-            return true;
-        }
-
-        return $this->containsSecurityToken($line);
-    }
-
-    private function isStructural(string $line): bool
-    {
-        return u($line)->trimStart()->startsWith(self::STRUCTURAL_PREFIXES);
-    }
-
-    private function containsSecurityToken(string $line): bool
-    {
-        if (u($line)->containsAny(self::SECURITY_TOKENS)) {
-            return true;
-        }
-
-        return 1 === preg_match(self::BARE_KEYWORD_PATTERN, $line);
-    }
-
-    /**
-     * A retained line's `(`/`)` count drives the multi-line-signature
-     * continuation in {@see self::slice()}. A string literal that opens on
-     * this line but only closes on a later one (a raw newline inside a
-     * single- or double-quoted string, legal PHP) is invisible to
-     * `STRING_LITERAL_PATTERN`, which only matches a pair on the same line —
-     * an unbalanced `(` inside such a literal would otherwise never be
-     * stripped, permanently desyncing `openParenDepth` and forcing every
-     * remaining line in the file to be retained. The returned
-     * `open_string_delimiter` carries the open quote character forward until
-     * its match closes on a later line.
-     *
-     * @return array{delta: int, open_string_delimiter: ?string}
-     */
-    private function parenDelta(string $line, ?string $openStringDelimiter): array
-    {
-        if (null !== $openStringDelimiter) {
-            $closingQuoteOffset = $this->closingQuoteOffset($line, $openStringDelimiter);
-            if (null === $closingQuoteOffset) {
-                return ['delta' => 0, 'open_string_delimiter' => $openStringDelimiter];
-            }
-
-            $line = substr($line, $closingQuoteOffset + 1);
-        }
-
-        $withoutStringLiterals = preg_replace(self::STRING_LITERAL_PATTERN, '', $line) ?? $line;
-        $withoutStringLiterals = $this->stripTrailingComment($withoutStringLiterals);
-
-        $danglingQuoteOffset = $this->danglingQuoteOffset($withoutStringLiterals);
-        $nextOpenStringDelimiter = null;
-        if (null !== $danglingQuoteOffset) {
-            $nextOpenStringDelimiter = $withoutStringLiterals[$danglingQuoteOffset];
-            $withoutStringLiterals = substr($withoutStringLiterals, 0, $danglingQuoteOffset);
-        }
-
-        return [
-            'delta' => substr_count($withoutStringLiterals, '(') - substr_count($withoutStringLiterals, ')'),
-            'open_string_delimiter' => $nextOpenStringDelimiter,
-        ];
-    }
-
-    private function closingQuoteOffset(string $line, string $quoteChar): ?int
-    {
-        $pattern = \sprintf('/^(?:\\\\.|[^%s\\\\])*%s/', $quoteChar, $quoteChar);
-        if (1 !== preg_match($pattern, $line, $matches)) {
-            return null;
-        }
-
-        return \strlen($matches[0]) - 1;
-    }
-
-    private function danglingQuoteOffset(string $text): ?int
-    {
-        if (1 !== preg_match('/[\'"]/', $text, $matches, \PREG_OFFSET_CAPTURE)) {
-            return null;
-        }
-
-        return $matches[0][1];
-    }
-
-    /**
-     * An apostrophe inside a `//` line comment (e.g. `// don't remove this`)
-     * is indistinguishable from a genuine unterminated string open once
-     * {@see self::STRING_LITERAL_PATTERN} has already stripped every complete
-     * same-line pair — left unhandled, {@see self::danglingQuoteOffset()}
-     * would latch onto it and desync paren tracking for the rest of the file.
-     * Truncating unconditionally at the first `//` is still correct for a
-     * genuine unterminated string containing `//` (e.g. a URL split across
-     * lines, `'http://`): its opening quote sits before the `//` and survives
-     * the truncation, so {@see self::danglingQuoteOffset()} still finds it.
-     */
-    private function stripTrailingComment(string $text): string
-    {
-        $offsets = array_filter(
-            [$this->falseToNull(strpos($text, '//')), $this->hashCommentOffset($text)],
-            static fn (?int $offset): bool => null !== $offset,
-        );
-
-        return [] === $offsets ? $text : substr($text, 0, min($offsets));
-    }
-
-    /**
-     * A `#[` starts a PHP attribute, not a comment — the negative lookahead
-     * keeps an attribute's own argument list (which may span multiple lines
-     * and must be paren-tracked like any other retained line) from being
-     * truncated away at the `#`.
-     */
-    private function hashCommentOffset(string $text): ?int
-    {
-        return 1 === preg_match('/#(?!\[)/', $text, $matches, \PREG_OFFSET_CAPTURE) ? $matches[0][1] : null;
-    }
-
-    private function falseToNull(int|false $offset): ?int
-    {
-        return false === $offset ? null : $offset;
-    }
-
-    /**
-     * `/* *\/` block-comment boundaries must be tracked on every line — even
-     * an elided one — because they are a property of the raw source text, not
-     * of the elision decision. An elided `/**` opening line still needs its
-     * "inside a block comment" state carried forward so a later, independently
-     * retained continuation line (e.g. a PHPDoc note mentioning a
-     * security-token function by name) has its comment content stripped
-     * before {@see self::parenDelta()} counts parentheses in it — otherwise a
-     * stray unbalanced paren inside prose desyncs tracking for the rest of the
-     * file.
-     *
-     * @return array{line: string, inside_block_comment: bool}
-     */
-    private function stripBlockComments(string $line, bool $insideBlockComment): array
-    {
-        $kept = '';
-        $remaining = $line;
-
-        while (true) {
-            if ($insideBlockComment) {
-                $closeOffset = strpos($remaining, '*/');
-                if (false === $closeOffset) {
-                    return ['line' => $kept, 'inside_block_comment' => true];
-                }
-
-                $remaining = substr($remaining, $closeOffset + 2);
-                $insideBlockComment = false;
-
-                continue;
-            }
-
-            $openOffset = strpos($this->maskStringLiterals($remaining), '/*');
-            if (false === $openOffset) {
-                return ['line' => $kept.$remaining, 'inside_block_comment' => false];
-            }
-
-            $kept .= substr($remaining, 0, $openOffset);
-            $remaining = substr($remaining, $openOffset + 2);
-            $insideBlockComment = true;
-        }
-    }
-
-    /**
-     * A string literal containing a bare `/*` (e.g. the `'image/*'` MIME
-     * wildcard) is indistinguishable from a genuine block-comment opener to a
-     * plain {@see strpos()} scan — masking same-line string literals to a
-     * same-length run of `x` before searching keeps offsets aligned with the
-     * original line (so the caller can still slice it correctly) while
-     * preventing a quoted `/*` from ever being mistaken for real comment
-     * syntax and permanently desyncing tracking for the rest of the file.
-     */
-    private function maskStringLiterals(string $line): string
-    {
-        return preg_replace_callback(
-            self::STRING_LITERAL_PATTERN,
-            static fn (array $matches): string => str_repeat('x', \strlen($matches[0])),
-            $line,
-        ) ?? $line;
     }
 }

--- a/src/Audit/Infrastructure/Scan/SecurityRelevantLineClassifier.php
+++ b/src/Audit/Infrastructure/Scan/SecurityRelevantLineClassifier.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+use Override;
+
+use function Symfony\Component\String\u;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ *
+ * Retains a line that is either structural (declarations, attributes) or
+ * dangerous (matches a known security-relevant token or keyword).
+ */
+final readonly class SecurityRelevantLineClassifier implements LineRetentionDeciderInterface
+{
+    /**
+     * Prefixes (matched after left-trim) that mark a line as structurally
+     * relevant and therefore always retained.
+     *
+     * @var list<string>
+     */
+    private const array STRUCTURAL_PREFIXES = [
+        '<?php',
+        'namespace ',
+        'use ',
+        '#[',
+        'class ',
+        'interface ',
+        'trait ',
+        'enum ',
+        'case ',
+        'final ',
+        'abstract ',
+        'readonly ',
+        'public ',
+        'protected ',
+        'private ',
+        'static ',
+        'function ',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const array SECURITY_TOKENS = [
+        '$request->',
+        '$this->getUser(',
+        '->denyAccessUnlessGranted(',
+        '#[IsGranted',
+        '#[MapRequestPayload',
+        '#[MapQueryString',
+        '->isGranted(',
+        '->getRoles(',
+        '->createQuery(',
+        '->createQueryBuilder(',
+        '->executeQuery(',
+        '->executeStatement(',
+        '->setParameter(',
+        'getConnection()',
+        '->orderBy(',
+        '->where(',
+        '->andWhere(',
+        '->having(',
+        'file_get_contents(',
+        'file_put_contents(',
+        'fopen(',
+        'readfile(',
+        'unlink(',
+        'move_uploaded_file(',
+        '->move(',
+        'getClientOriginalName(',
+        'unserialize(',
+        'igbinary_unserialize(',
+        'shell_exec(',
+        'passthru(',
+        'proc_open(',
+        'system(',
+        'popen(',
+        'eval(',
+        'new Process(',
+        'Process::fromShellCommandline(',
+        'HttpClient',
+        '->request(',
+        '->redirect(',
+        'RedirectResponse',
+        '->submit(',
+        'allow_extra_fields',
+        '|raw',
+        '->getContent(',
+        'random_int(',
+        'mt_rand(',
+        'md5(',
+        'sha1(',
+        'hash_equals(',
+        '$_GET',
+        '$_POST',
+        '$_REQUEST',
+        '$_COOKIE',
+        '$_SERVER',
+        '->from(',
+        '->subject(',
+        '->addBcc(',
+        '->to(',
+        'MailerInterface',
+        'CacheInterface',
+        'LockFactory',
+        '->createLock(',
+        'RateLimiterFactory',
+        '->loadByIdentifier(',
+        'AccessTokenHandler',
+        'SelfValidatingPassport',
+        'hash_hmac(',
+        'evaluate(',
+        '->createTemplate(',
+        'simplexml_load_string(',
+        '->writeln(',
+        'json_decode(',
+        'getSession()',
+    ];
+
+    /**
+     * Bare-keyword security tokens that must be word-boundary matched rather
+     * than substring matched: a leading-character enumeration (space, `(`,
+     * `=`) misses column-0 statements (e.g. a bootstrap script's first line)
+     * and tab-indented ones — silently eliding a real file-inclusion or
+     * command-execution line instead of retaining it.
+     */
+    private const string BARE_KEYWORD_PATTERN = '/\b(?:exec|rand|include|include_once|require|require_once)\b/';
+
+    #[Override]
+    public function isRetained(string $line, LineRetentionContext $lineRetentionContext): bool
+    {
+        if ($this->isStructural($line)) {
+            return true;
+        }
+
+        return $this->containsSecurityToken($line);
+    }
+
+    private function isStructural(string $line): bool
+    {
+        return u($line)->trimStart()->startsWith(self::STRUCTURAL_PREFIXES);
+    }
+
+    private function containsSecurityToken(string $line): bool
+    {
+        if (u($line)->containsAny(self::SECURITY_TOKENS)) {
+            return true;
+        }
+
+        return 1 === preg_match(self::BARE_KEYWORD_PATTERN, $line);
+    }
+}

--- a/src/Audit/Infrastructure/Scan/StringLiteralMasker.php
+++ b/src/Audit/Infrastructure/Scan/StringLiteralMasker.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Scan;
+
+/**
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final readonly class StringLiteralMasker
+{
+    private const string STRING_LITERAL_PATTERN = '/\'(?:\\\\.|[^\'\\\\])*\'|"(?:\\\\.|[^"\\\\])*"/';
+
+    public function mask(string $line): string
+    {
+        return preg_replace_callback(
+            self::STRING_LITERAL_PATTERN,
+            static fn (array $matches): string => str_repeat('x', \strlen($matches[0])),
+            $line,
+        ) ?? $line;
+    }
+
+    public function strip(string $line): string
+    {
+        return preg_replace(self::STRING_LITERAL_PATTERN, '', $line) ?? $line;
+    }
+}


### PR DESCRIPTION
## Summary

`RegexCodeSlicer` had grown to 465 lines mixing line classification, block-comment stripping, paren-continuation tracking, heredoc handling, and orchestration in one class. Split into 5 single-responsibility collaborators (`StringLiteralMasker`, `SecurityRelevantLineClassifier`, `BlockCommentStripper`, `ParenContinuationTracker`, `HeredocLineTracker`), plus a `LineRetentionDeciderInterface` with a `ContinuationForcedLineRetentionDecider` decorating the classifier so continuation state forces retention transparently — replacing an inline three-way boolean OR. `RegexCodeSlicer` is now a ~93-line orchestrator.

## Type of change

- [x] Refactor / internal improvement

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable) — existing 85-test suite passes unchanged (pure refactor, identical output verified)
- [x] All checks pass: PHPUnit (100% coverage, 4398 tests), PHPStan, CS Fixer, Rector, Deptrac — all green locally
- [x] 100% MSI maintained: diff-scoped Infection against `origin/1.x` — 118/118 mutants killed, 100% MSI
- [x] No `createMock` without a matching `expects()`
- [x] Commit messages follow Conventional Commits

## Notes

Purely internal (`@internal`, not part of the BC promise per `docs/versioning.md`) — no public API, config, or schema change, hence classified as `MINOR` (internal refactor with visible maintainability benefit) per the changelog rules.

Rebased directly onto `1.x` after the segfault fix (#301) merged — this branch previously stacked on that fix's branch (was #298) but is now a clean, standalone diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDuBFh1cFke2u4qhVyC2Z4)_