### PR TITLE
chore: sync 1.x changelog after the 1.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.19.0] — 2026-08-12 — Bulwark
+
+A pre-release security hardening round. A fresh audit of the auditor's own trust
+boundaries found and closed nine gaps: secret-scrubbing now catches Azure
+Storage connection strings, `Authorization: Bearer` headers, OpenAI-style keys,
+and Slack incoming webhook URLs; five cache/dedup-key constructions that hashed
+a joined string instead of hashing each field first could collide two genuinely
+different inputs onto the same key, replaying a stale verdict or silently
+dropping a finding; and the audited project's own config could read an arbitrary
+file on the host via `scan.included_paths`, point the SARIF importer anywhere
+via `scan.import_sarif`, or stall the audit with an unvalidated
+catastrophic-backtracking `scan.custom_risk_patterns` regex. Alongside the
+security fixes, `RegexCodeSlicer` was decomposed into five focused collaborators
+behind a `LineRetentionDeciderInterface` decorator, replacing an inline
+three-way boolean OR with no behavior change.
+
 ### Added
 
 - **`FrameworkVocabulary` lifts the framework wording out of the synthesizer
@@ -3649,6 +3665,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.19.0]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.19.0
 [1.18.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.18.0
 [1.17.0]:

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ bin/console audit:run --dry-run
   fingerprint, `audit:trend` tracks counts across a series of them.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.18.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.19.0`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **Extensible** — strict DDD layering and a sole `LLMClientInterface` seam let

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -176,7 +176,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.18.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -212,7 +212,7 @@ aggregate `risk_level`) and `grade` (its `A`-`F` letter).
 ```yaml
       - name: Symfony Security Audit
         id: audit
-        uses: vinceamstoutz/symfony-security-auditor@1.18.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -243,7 +243,7 @@ tradeoffs.
 
 ```yaml
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.18.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -432,7 +432,7 @@ permissions:
 # …
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.18.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required by comment-pr
@@ -467,7 +467,7 @@ default branch rather than whichever pull request ran last.
 
 ```yaml
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.18.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -169,7 +169,7 @@ deprecated by the other.
   renaming or removing one is a `MAJOR`. The Marketplace `name`
   (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.18.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.19.0` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.18.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.19.0/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",


### PR DESCRIPTION
## Summary

`main`'s release PR (#305) was rebase-merged, which reapplies each commit with a fresh SHA rather than fast-forwarding — so `main` and `1.x` now carry the same content under different commit hashes for the shared history, and critically **`1.x`'s own `CHANGELOG.md` still listed the 1.19.0 fixes under `## [Unreleased]`** since the promotion commit only landed on `main`.

This is a straight cherry-pick of `main`'s release commit (`33f8784`) onto `1.x`, so both branches now agree byte-for-byte and future work resumes from a clean, empty `[Unreleased]` section.

## Type of change

- [x] Release / documentation

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] No code change — cherry-pick of the merged release commit
- [x] `resources/schema.json` valid JSON; Prettier and markdownlint clean
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDuBFh1cFke2u4qhVyC2Z4)_