### PR TITLE
ci: add a manual replay trigger to Auto Release

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -4,13 +4,23 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description:
+          "Version to tag and release (X.Y.Z) — replays a release the push
+          trigger missed, e.g. because this workflow did not exist yet on main"
+        required: true
+        type: string
 
 permissions: {}
 
 jobs:
   detect:
     name: Detect a release commit
-    if: "${{ startsWith(github.event.head_commit.message, 'chore: release ') }}"
+    if:
+      "${{ github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'chore: release ') }}"
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
@@ -23,12 +33,17 @@ jobs:
           # script: a push to main is trusted, but this still avoids the
           # habit of splicing ${{ }} expressions into shell code.
           MESSAGE: ${{ github.event.head_commit.message }}
+          MANUAL_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
 
-          version="$(printf '%s\n' "$MESSAGE" | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+          if [ -n "$MANUAL_VERSION" ]; then
+            version="$MANUAL_VERSION"
+          else
+            version="$(printf '%s\n' "$MESSAGE" | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+          fi
           if [ -z "$version" ]; then
-            echo "::error::Could not parse a X.Y.Z version out of the commit message. Expected \"chore: release X.Y.Z\"."
+            echo "::error::Could not determine a X.Y.Z version. Expected a workflow_dispatch \"version\" input or a \"chore: release X.Y.Z\" commit message."
             exit 1
           fi
 
@@ -44,6 +59,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: main
           fetch-depth: 0
           persist-credentials: true
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -408,7 +408,11 @@ generates a `What's Changed` summary from the merged pull requests since the
 previous tag, and drafts the GitHub Release — publish it when ready, which
 triggers the binary-build workflow. Cherry-pick the same release commit back
 onto `<N>.x` so its changelog doesn't keep listing the shipped fixes as
-`Unreleased`.
+`Unreleased`. Its `push` trigger only fires going forward, so it cannot cover a
+release commit that already landed on `main` before the workflow existed (or
+before the workflow's `if:` could match it); for that case, dispatch it manually
+with the `version` `workflow_dispatch` input — it always tags and diffs against
+`main`'s history regardless of which ref the dispatch itself runs from.
 
 Because `main` is the default branch, a pull request opens against it by default
 even though almost nothing should land there directly. **Retarget the base** to


### PR DESCRIPTION
## Summary

`auto-release.yaml`'s `push` trigger only fires going forward, so it can't retroactively cover the 1.19.0 release commit that already landed on `main` (#305) before this workflow existed. Adds a `workflow_dispatch` `version` input as a manual replay path, and pins the checkout to `ref: main` explicitly so the replay always tags and diffs the right history regardless of which branch the dispatch itself runs from (the workflow file currently only exists on `1.x`).

## Type of change

- [x] New feature (CI automation)

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated — n/a, no PHP source changed
- [x] All checks pass: `zizmor --offline .github/` clean; YAML validated; markdownlint clean
- [x] Docs updated: `docs/versioning.md` explains the manual replay path
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)