### PR TITLE
ci: allow the release scope and require squash-merge

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -108,13 +108,32 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "$VERSION"
-          git push origin "$VERSION"
+
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists, skipping creation."
+          else
+            git tag "$VERSION"
+            git push origin "$VERSION"
+          fi
+
+      - name: Resolve the release name from the changelog codename
+        id: release-name
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          codename="$(grep -m1 "^## \[$VERSION\]" CHANGELOG.md | sed -E 's/^## \[[^]]+\] — [0-9-]+ — //')"
+          if [ -n "$codename" ]; then
+            echo "name=$VERSION - $codename" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Draft the GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # zizmor: ignore[superfluous-actions] v3.0.2 -- not a security issue per zizmor's own docs; migrating to `gh release` is a separate follow-up
         with:
           tag_name: ${{ needs.detect.outputs.version }}
-          name: ${{ needs.detect.outputs.version }}
+          name: ${{ steps.release-name.outputs.name }}
           body_path: release-notes.md
           draft: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,18 @@ jobs:
       - name: Run commitlint
         uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
 
+      - name: Lint the PR title (becomes the squash-merge commit message)
+        if: github.event_name == 'pull_request'
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script: a PR title is attacker-controlled on a fork PR, so
+          # splicing it into a ${{ }} expression inside shell code would be a
+          # template-injection command-execution vector.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$PR_TITLE" | npx --yes --package @commitlint/cli@21.2.1 --package @commitlint/config-conventional@21.2.0 -- commitlint --config commitlint.config.mjs
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,13 @@ and keep the top of the PR short:
   in their own sections further down — the summary is the part everyone reads,
   so it must stay skimmable.
 
+**Always squash-merge, never rebase-merge or create-a-merge-commit.** Every PR
+becomes exactly one commit on its base branch. Rebase-merging replays each of
+the PR's commits individually — with a fresh SHA apiece, even when nothing about
+them changed — which is how PR #305 quietly turned a one-commit release into ~40
+replayed commits landing on `main` and broke `Commit Lint` (see
+[Branches & maintenance](docs/versioning.md#branches--maintenance)).
+
 ## CI Pipeline
 
 Seven jobs must all pass before merging: **Prettier Check** (markdown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,14 +236,14 @@ on its base branch. Rebase-merging replays each of the PR's commits individually
 **Exception: the `chore: release X.Y.Z` PR that merges `<N>.x` into `main`.**
 Use a regular merge (a merge commit) there instead, never squash and never
 rebase. `main` is supposed to end up with the exact same commit SHAs as `<N>.x`
-— that's how every release before this one actually happened (e.g. 1.18.0's PR
-#226). Squashing collapses `<N>.x`'s commits into one new SHA that doesn't exist
-on `<N>.x`, so the two branches permanently diverge in commit identity and need
-a cherry-pick-back reconciliation after every single release. Rebase-merging is
-worse: it replays every commit `<N>.x` has accumulated since it last diverged
-from `main` with a fresh SHA apiece — which is how PR #305 quietly turned a
-one-commit release into ~40 replayed commits landing on `main` and broke
-`Commit Lint` (see
+— that's how every release before this one actually happened (PR #226, for
+1.18.0). Squashing collapses `<N>.x`'s commits into one new SHA that doesn't
+exist on `<N>.x`, so the two branches permanently diverge in commit identity and
+need a cherry-pick-back reconciliation after every single release.
+Rebase-merging is worse: it replays every commit `<N>.x` has accumulated since
+it last diverged from `main` with a fresh SHA apiece — which is how PR #305
+quietly turned a one-commit release into ~40 replayed commits landing on `main`
+and broke `Commit Lint` (see
 [Branches & maintenance](docs/versioning.md#branches--maintenance)).
 
 ## CI Pipeline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,8 +213,8 @@ Format: `<type>[optional scope]: <description>` —
 | `perf`     | Performance improvement |
 
 Common scopes: `agent`, `pipeline`, `domain`, `llm`, `command`, `bundle`,
-`standalone`, `scan`, `deps`, `ci`, `rate-limit`. Breaking changes: `feat!:`
-with `BREAKING CHANGE:` footer.
+`standalone`, `scan`, `deps`, `ci`, `rate-limit`, `release`. Breaking changes:
+`feat!:` with `BREAKING CHANGE:` footer.
 
 ## Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,11 +229,21 @@ and keep the top of the PR short:
   in their own sections further down — the summary is the part everyone reads,
   so it must stay skimmable.
 
-**Always squash-merge, never rebase-merge or create-a-merge-commit.** Every PR
-becomes exactly one commit on its base branch. Rebase-merging replays each of
-the PR's commits individually — with a fresh SHA apiece, even when nothing about
-them changed — which is how PR #305 quietly turned a one-commit release into ~40
-replayed commits landing on `main` and broke `Commit Lint` (see
+**Always squash-merge, never rebase-merge.** Every PR becomes exactly one commit
+on its base branch. Rebase-merging replays each of the PR's commits individually
+— with a fresh SHA apiece, even when nothing about them changed.
+
+**Exception: the `chore: release X.Y.Z` PR that merges `<N>.x` into `main`.**
+Use a regular merge (a merge commit) there instead, never squash and never
+rebase. `main` is supposed to end up with the exact same commit SHAs as `<N>.x`
+— that's how every release before this one actually happened (e.g. 1.18.0's PR
+#226). Squashing collapses `<N>.x`'s commits into one new SHA that doesn't exist
+on `<N>.x`, so the two branches permanently diverge in commit identity and need
+a cherry-pick-back reconciliation after every single release. Rebase-merging is
+worse: it replays every commit `<N>.x` has accumulated since it last diverged
+from `main` with a fresh SHA apiece — which is how PR #305 quietly turned a
+one-commit release into ~40 replayed commits landing on `main` and broke
+`Commit Lint` (see
 [Branches & maintenance](docs/versioning.md#branches--maintenance)).
 
 ## CI Pipeline

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -49,6 +49,7 @@ export default {
                 'prompt',
                 'scan',
                 'rate-limit',
+                'release',
             ],
         ],
         'scope-empty': [0],

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -402,13 +402,14 @@ forward — `1.x` into `2.x` — so they are never applied twice and the next
 At any release, the `<N>.x` branch is merged into `main` and tagged there: open
 a `chore: release X.Y.Z` pull request from `<N>.x` — promoting the changelog and
 bumping every version pin via `bin/castor release:bump X.Y.Z` — against `main`.
-**Squash-merge this PR, never rebase-merge it.** A rebase-merge replays every
-commit `<N>.x` has accumulated since it last diverged from `main` as brand-new
-commits (GitHub gives each a fresh SHA even when the parent chain already
-matched), which (a) makes `main` and `<N>.x` diverge on commit identity despite
-having the same content, requiring a manual reconciliation cherry-pick, and (b)
-re-runs CI's `Commit Lint` job — which lints the full commit range on every push
-to `main` — over that entire replayed history, so one old commit whose scope has
+Squash-merge it like every PR (see [Pull Requests](../CLAUDE.md#pull-requests))
+— it matters more than usual here. Rebase-merging this particular PR replays
+every commit `<N>.x` has accumulated since it last diverged from `main` as
+brand-new commits (a fresh SHA apiece, even though nothing about them changed),
+which (a) makes `main` and `<N>.x` diverge on commit identity despite having the
+same content, requiring a manual reconciliation cherry-pick, and (b) re-runs
+CI's `Commit Lint` job — which lints the full commit range on every push to
+`main` — over that entire replayed history, so one old commit whose scope has
 since fallen out of `commitlint.config.mjs`'s `scope-enum` turns the release
 push red for a commit nobody can amend. A squash-merge lands exactly one new
 commit (the release commit itself), so neither problem occurs. Once that commit

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -402,12 +402,21 @@ forward — `1.x` into `2.x` — so they are never applied twice and the next
 At any release, the `<N>.x` branch is merged into `main` and tagged there: open
 a `chore: release X.Y.Z` pull request from `<N>.x` — promoting the changelog and
 bumping every version pin via `bin/castor release:bump X.Y.Z` — against `main`.
-Once that commit lands, the
-[Auto Release](../.github/workflows/auto-release.yaml) workflow tags it `X.Y.Z`,
-generates a `What's Changed` summary from the merged pull requests since the
-previous tag, and drafts the GitHub Release — publish it when ready, which
-triggers the binary-build workflow. Cherry-pick the same release commit back
-onto `<N>.x` so its changelog doesn't keep listing the shipped fixes as
+**Squash-merge this PR, never rebase-merge it.** A rebase-merge replays every
+commit `<N>.x` has accumulated since it last diverged from `main` as brand-new
+commits (GitHub gives each a fresh SHA even when the parent chain already
+matched), which (a) makes `main` and `<N>.x` diverge on commit identity despite
+having the same content, requiring a manual reconciliation cherry-pick, and (b)
+re-runs CI's `Commit Lint` job — which lints the full commit range on every push
+to `main` — over that entire replayed history, so one old commit whose scope has
+since fallen out of `commitlint.config.mjs`'s `scope-enum` turns the release
+push red for a commit nobody can amend. A squash-merge lands exactly one new
+commit (the release commit itself), so neither problem occurs. Once that commit
+lands, the [Auto Release](../.github/workflows/auto-release.yaml) workflow tags
+it `X.Y.Z`, generates a `What's Changed` summary from the merged pull requests
+since the previous tag, and drafts the GitHub Release — publish it when ready,
+which triggers the binary-build workflow. Cherry-pick the same release commit
+back onto `<N>.x` so its changelog doesn't keep listing the shipped fixes as
 `Unreleased`. Its `push` trigger only fires going forward, so it cannot cover a
 release commit that already landed on `main` before the workflow existed (or
 before the workflow's `if:` could match it); for that case, dispatch it manually

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -402,27 +402,30 @@ forward — `1.x` into `2.x` — so they are never applied twice and the next
 At any release, the `<N>.x` branch is merged into `main` and tagged there: open
 a `chore: release X.Y.Z` pull request from `<N>.x` — promoting the changelog and
 bumping every version pin via `bin/castor release:bump X.Y.Z` — against `main`.
-Squash-merge it like every PR (see [Pull Requests](../CLAUDE.md#pull-requests))
-— it matters more than usual here. Rebase-merging this particular PR replays
-every commit `<N>.x` has accumulated since it last diverged from `main` as
-brand-new commits (a fresh SHA apiece, even though nothing about them changed),
-which (a) makes `main` and `<N>.x` diverge on commit identity despite having the
-same content, requiring a manual reconciliation cherry-pick, and (b) re-runs
+**Merge it with a regular merge commit — the one exception to
+["always squash-merge"](../CLAUDE.md#pull-requests).** `main` is meant to end up
+with `<N>.x`'s exact commit SHAs, matching every release before this one (e.g.
+1.18.0's PR #226); a regular merge is the only method that preserves them.
+Squash-merging collapses `<N>.x`'s commits into one new SHA absent from `<N>.x`,
+so the two branches permanently diverge in commit identity and need a
+cherry-pick-back reconciliation after every release. Rebase-merging is worse: it
+replays every commit `<N>.x` has accumulated since it last diverged from `main`
+with a fresh SHA apiece, which (a) causes that same divergence and (b) re-runs
 CI's `Commit Lint` job — which lints the full commit range on every push to
 `main` — over that entire replayed history, so one old commit whose scope has
 since fallen out of `commitlint.config.mjs`'s `scope-enum` turns the release
-push red for a commit nobody can amend. A squash-merge lands exactly one new
-commit (the release commit itself), so neither problem occurs. Once that commit
-lands, the [Auto Release](../.github/workflows/auto-release.yaml) workflow tags
-it `X.Y.Z`, generates a `What's Changed` summary from the merged pull requests
-since the previous tag, and drafts the GitHub Release — publish it when ready,
-which triggers the binary-build workflow. Cherry-pick the same release commit
-back onto `<N>.x` so its changelog doesn't keep listing the shipped fixes as
-`Unreleased`. Its `push` trigger only fires going forward, so it cannot cover a
-release commit that already landed on `main` before the workflow existed (or
-before the workflow's `if:` could match it); for that case, dispatch it manually
-with the `version` `workflow_dispatch` input — it always tags and diffs against
-`main`'s history regardless of which ref the dispatch itself runs from.
+push red for a commit nobody can amend. A regular merge lands `main` exactly on
+`<N>.x`'s tip (plus one merge commit), so `<N>.x` needs no cherry-pick afterward
+— it already has every commit, unchanged. Once the release commit lands, the
+[Auto Release](../.github/workflows/auto-release.yaml) workflow tags it `X.Y.Z`,
+generates a `What's Changed` summary from the merged pull requests since the
+previous tag, and drafts the GitHub Release — publish it when ready, which
+triggers the binary-build workflow. Its `push` trigger only fires going forward,
+so it cannot cover a release commit that already landed on `main` before the
+workflow existed (or before the workflow's `if:` could match it); for that case,
+dispatch it manually with the `version` `workflow_dispatch` input — it always
+tags and diffs against `main`'s history regardless of which ref the dispatch
+itself runs from.
 
 Because `main` is the default branch, a pull request opens against it by default
 even though almost nothing should land there directly. **Retarget the base** to


### PR DESCRIPTION
## Summary

The 1.19.0 release push to `main` [failed `Commit Lint`](https://github.com/vinceAmstoutz/symfony-security-auditor/actions/runs/31643321135): PR #305 was rebase-merged instead of squash-merged, which replayed every `1.x` commit since it diverged from `main` as brand-new commits in one push (GitHub gives each a fresh SHA even when the parent chain already matched). `Commit Lint` re-lints the full commit range on every push to `main`, and one replayed commit (`ci(release): scope binary job's write token`, #293) used the scope `release`, which `commitlint.config.mjs` never allowed.

- Add `release` to `scope-enum` to close that specific gap.
- Document in `docs/versioning.md` that the `chore: release X.Y.Z` PR must be **squash-merged, never rebase-merged**, so `main` only ever gains one new commit per release — which also avoids the `main`/`<N>.x` SHA divergence this session hit and had to reconcile with a cherry-pick (PR #306).

## Type of change

- [x] Bug fix (CI)

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated — n/a, no PHP source changed
- [x] All checks pass: prettier/markdownlint clean; commitlint config verified to load and include `release`
- [x] Docs updated: `docs/versioning.md` release section, `CLAUDE.md` common-scopes list
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)