### PR TITLE
ci(release): add an optional publish input to Auto Release

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -158,3 +159,20 @@ jobs:
           name: ${{ steps.release-name.outputs.name }}
           body_path: release-notes.md
           draft: ${{ steps.publish-state.outputs.draft }}
+
+      - name: Trigger the binary build for a release this workflow published
+        if: steps.publish-state.outputs.draft == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # release.yaml listens for `release: published`, but an event
+          # produced by the default GITHUB_TOKEN never cascades into another
+          # workflow run (GitHub's anti-recursion guard) -- only a human
+          # publishing through the UI triggers it that way. Dispatch it
+          # explicitly instead; an API-triggered workflow_dispatch is not
+          # subject to that restriction.
+          gh workflow run release.yaml --repo "$REPO" --field tag="$VERSION"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -12,6 +12,14 @@ on:
           trigger missed, e.g. because this workflow did not exist yet on main"
         required: true
         type: string
+      publish:
+        description:
+          "Publish the release immediately instead of leaving it as a draft.
+          Rarely needed — normally review the drafted release notes and publish
+          manually in the GitHub UI."
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -130,10 +138,23 @@ jobs:
             echo "name=$VERSION" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve whether to publish immediately
+        id: publish-state
+        env:
+          PUBLISH: ${{ github.event.inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          if [ "$PUBLISH" = "true" ]; then
+            echo "draft=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Draft the GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # zizmor: ignore[superfluous-actions] v3.0.2 -- not a security issue per zizmor's own docs; migrating to `gh release` is a separate follow-up
         with:
           tag_name: ${{ needs.detect.outputs.version }}
           name: ${{ steps.release-name.outputs.name }}
           body_path: release-notes.md
-          draft: true
+          draft: ${{ steps.publish-state.outputs.draft }}


### PR DESCRIPTION
## Summary

Manually replaying a release via `workflow_dispatch` (e.g. for 1.19.0, which predates this workflow) always drafted the release, requiring a separate manual publish step. Adds an opt-in `publish` boolean input (default `false`, so the automatic push-triggered path is unaffected) that publishes immediately instead. Used once already, directly on `main`, to correct 1.19.0's release name (now `1.19.0 - Bulwark`) and publish it — this PR brings that same fix onto `1.x` so the workflow files stay in sync for the next real release.

## Type of change

- [x] New feature (CI automation)

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated — n/a, no PHP source changed
- [x] All checks pass: `zizmor --offline .github/` clean; YAML validated; prettier clean
- [x] Docs updated — n/a, behavior change is internal to the workflow's manual-replay path
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)