### PR TITLE
docs: fix inaccuracies in the 1.19.0 changelog on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [1.19.0] — 2026-08-12 — Bulwark
 
-A pre-release security hardening round. A fresh audit of the auditor's own trust
-boundaries found and closed nine gaps: secret-scrubbing now catches Azure
-Storage connection strings, `Authorization: Bearer` headers, OpenAI-style keys,
-and Slack incoming webhook URLs; five cache/dedup-key constructions that hashed
-a joined string instead of hashing each field first could collide two genuinely
-different inputs onto the same key, replaying a stale verdict or silently
-dropping a finding; and the audited project's own config could read an arbitrary
-file on the host via `scan.included_paths`, point the SARIF importer anywhere
-via `scan.import_sarif`, or stall the audit with an unvalidated
-catastrophic-backtracking `scan.custom_risk_patterns` regex. Alongside the
-security fixes, `RegexCodeSlicer` was decomposed into five focused collaborators
-behind a `LineRetentionDeciderInterface` decorator, replacing an inline
-three-way boolean OR with no behavior change.
+A release about seeing a result without leaving GitHub. `--format=github-comment`
+posts a run's summary straight to the pull request, an opt-in badge input
+reports a project's grade on shields.io, and every report now carries a
+normalized 0-100 score and `A`-`F` grade beside the existing risk level, with
+`--min-score` to gate CI on it directly. Alongside that: an audited project
+could execute code on the host via its own Composer scripts, or redirect the
+standalone binary's LLM connection — and the operator's API key — to an
+attacker's endpoint; both are now closed. Secret-scrubbing also catches several
+previously-missed credential shapes (Azure Storage keys,
+`Authorization: Bearer` headers, OpenAI-style keys, Slack webhooks), and a
+handful of cache/dedup-key hashing bugs that could replay a stale verdict or
+silently drop a finding are fixed.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,13 @@ A release about seeing a result without leaving GitHub. The attacker now also
 flags XSSI "JSON Hijacking": a `GET` endpoint returning a bare top-level JSON
 array instead of an object, exploitable via a cross-origin `<script src>`
 include. `--format=github-comment` posts a run's summary straight to the pull
-request, an opt-in badge input
-reports a project's grade on shields.io, and every report now carries a
-normalized 0-100 score and `A`-`F` grade beside the existing risk level, with
-`--min-score` to gate CI on it directly. Alongside that: an audited project
-could execute code on the host via its own Composer scripts, or redirect the
-standalone binary's LLM connection — and the operator's API key — to an
-attacker's endpoint; both are now closed. Secret-scrubbing also catches several
-previously-missed credential shapes (Azure Storage keys,
+request, an opt-in badge input reports a project's grade on shields.io, and
+every report now carries a normalized 0-100 score and `A`-`F` grade beside the
+existing risk level, with `--min-score` to gate CI on it directly. Alongside
+that: an audited project could execute code on the host via its own Composer
+scripts, or redirect the standalone binary's LLM connection — and the operator's
+API key — to an attacker's endpoint; both are now closed. Secret-scrubbing also
+catches several previously-missed credential shapes (Azure Storage keys,
 `Authorization: Bearer` headers, OpenAI-style keys, Slack webhooks), and a
 handful of cache/dedup-key hashing bugs that could replay a stale verdict or
 silently drop a finding are fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [1.19.0] — 2026-08-12 — Bulwark
 
-A release about seeing a result without leaving GitHub. `--format=github-comment`
-posts a run's summary straight to the pull request, an opt-in badge input
+A release about seeing a result without leaving GitHub. The attacker now also
+flags XSSI "JSON Hijacking": a `GET` endpoint returning a bare top-level JSON
+array instead of an object, exploitable via a cross-origin `<script src>`
+include. `--format=github-comment` posts a run's summary straight to the pull
+request, an opt-in badge input
 reports a project's grade on shields.io, and every report now carries a
 normalized 0-100 score and `A`-`F` grade beside the existing risk level, with
 `--min-score` to gate CI on it directly. Alongside that: an audited project


### PR DESCRIPTION
## Summary

Deliberate exception to "release merges only" on `main`: brings the same 1.19.0 changelog correction from #317 (already merged to `1.x`) onto `main`, since `main` currently documents the released 1.19.0 with the same inaccuracies. No release, no tag, no new version — same three commits, cherry-picked, touching only `CHANGELOG.md`.

Not a release commit, so `Auto Release` (`.github/workflows/auto-release.yaml`) will not tag or draft anything: its `detect` job only runs on `workflow_dispatch` or a head commit starting with `chore: release `, and none of these three do.

## Type of change

- [x] Documentation

## Target branch

- [x] `main`

## Checklist

- [x] All checks pass: `bin/castor lint` — verified `prettier --check` locally; no code touched
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)