### PR TITLE
chore(release): prepare 1.19.1

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -57,6 +57,38 @@ jobs:
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout code
+        if: github.event_name == 'push'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify the release commit is a genuine merge of 1.x
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+
+          # A push-triggered release commit is always meant to be the `chore:
+          # release X.Y.Z` merge of `<N>.x` into `main` — a regular merge
+          # commit with two parents (main's previous tip, then `<N>.x`'s tip).
+          # Squash- or rebase-merging that PR instead replays `<N>.x`'s
+          # commits under fresh SHAs, permanently duplicating them across both
+          # branches — exactly what happened in #305. Catch it here rather
+          # than let it land silently.
+          parents=($(git rev-list --parents -n1 HEAD))
+          if [ "${#parents[@]}" -ne 3 ]; then
+            echo "::error::This release commit has $(( ${#parents[@]} - 1 )) parent(s), expected 2 (a regular merge commit). Squash- or rebase-merging the release PR duplicates <N>.x's commits under new SHAs instead of sharing history with main — see docs/versioning.md#branches--maintenance. Re-open and merge it with a regular merge commit."
+            exit 1
+          fi
+
+          second_parent="${parents[2]}"
+          git fetch origin 1.x --quiet
+          if ! git merge-base --is-ancestor "$second_parent" origin/1.x; then
+            echo "::error::This release commit's second parent ($second_parent) is not part of 1.x's history, so it doesn't look like a genuine 1.x-into-main merge — see docs/versioning.md#branches--maintenance."
+            exit 1
+          fi
+
   tag-and-draft-release:
     name: Tag the release and draft its GitHub Release
     needs: detect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+## [1.19.1] — 2026-08-13 — Lineage
+
+A release about the release process itself. A past release (PR #305) merged
+`1.x` into `main` with a rebase instead of a regular merge commit, silently
+duplicating 41 commits under new SHAs and letting `auto-release.yaml` evolve
+differently on each branch afterward. This release reconciles the two branches
+properly and adds the CI check that would have caught the original mistake.
+
+### Fixed
+
+- **A rebase-merged release once duplicated `1.x`'s commits onto `main` under
+  new SHAs, and the divergence kept growing unnoticed.** `docs/versioning.md`
+  already names the cause: PR #305 rebase-merged a release instead of using a
+  regular merge commit, replaying `1.x`'s commits onto `main` with fresh hashes.
+  Comparing every commit since by content (`git patch-id`) confirms it: 41
+  commits on `1.x` and `main` are byte-identical changes under different SHAs.
+  Afterward, `.github/workflows/auto-release.yaml` was edited separately on each
+  branch rather than ported across — `main`'s copy fell behind `1.x`'s by a
+  manual-replay `workflow_dispatch` trigger, an optional `publish` input, and
+  the binary-build dispatch step, while `CLAUDE.md`, `docs/versioning.md`, and
+  `commitlint.config.mjs`'s `release` commit scope documenting the regular-merge
+  rule itself never reached `main` at all. This release merges `1.x` into `main`
+  with a proper merge commit, so both branches share the same history from here
+  on, and `auto-release.yaml`'s `detect` job now verifies any push-triggered
+  release commit is a genuine two-parent merge whose second parent is an
+  ancestor of `1.x` — failing the workflow loudly instead of silently accepting
+  a squash- or rebase-merge.
+
 ## [1.19.0] — 2026-08-12 — Bulwark
 
 A release about seeing a result without leaving GitHub. The attacker now also
@@ -3666,6 +3694,8 @@ CI test matrix: PHP 8.3 / 8.4 / 8.5 × Symfony 7.4 / 8.0 / 8.1.
 - Register bundle in `dev` and `test` environments only (per
   `config/bundles.php` guidance in the README).
 
+[1.19.1]:
+  https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.19.1
 [1.19.0]:
   https://github.com/vinceAmstoutz/symfony-security-auditor/releases/tag/1.19.0
 [1.18.0]:

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ bin/console audit:run --dry-run
   fingerprint, `audit:trend` tracks counts across a series of them.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
-  (`uses: vinceamstoutz/symfony-security-auditor@1.19.0`) plus GitLab CI
+  (`uses: vinceamstoutz/symfony-security-auditor@1.19.1`) plus GitLab CI
   templates, with SARIF upload to Code Scanning. See
   [CI Integration](docs/ci.md).
 - **Extensible** — strict DDD layering and a sole `LLMClientInterface` seam let

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -176,7 +176,7 @@ jobs:
           fetch-depth: 0 # full history so `since` can diff against the base branch
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.19.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -212,7 +212,7 @@ aggregate `risk_level`) and `grade` (its `A`-`F` letter).
 ```yaml
       - name: Symfony Security Audit
         id: audit
-        uses: vinceamstoutz/symfony-security-auditor@1.19.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -243,7 +243,7 @@ tradeoffs.
 
 ```yaml
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.19.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -432,7 +432,7 @@ permissions:
 # …
 
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.19.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required by comment-pr
@@ -467,7 +467,7 @@ default branch rather than whichever pull request ran last.
 
 ```yaml
       - name: Symfony Security Audit
-        uses: vinceamstoutz/symfony-security-auditor@1.19.0
+        uses: vinceamstoutz/symfony-security-auditor@1.19.1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -169,7 +169,7 @@ deprecated by the other.
   renaming or removing one is a `MAJOR`. The Marketplace `name`
   (`Symfony Security Auditor`) is also stable.
 - **Version pinning.** Consumers pin the action to an exact release tag —
-  `uses: vinceamstoutz/symfony-security-auditor@1.19.0` — matching the tag
+  `uses: vinceamstoutz/symfony-security-auditor@1.19.1` — matching the tag
   format used on Packagist. Bump the pin when upgrading. There is intentionally
   no floating `v1` tag: the `uses:` ref and the config-schema URL both point at
   the same release tag, so a given pin always resolves to one immutable release.

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.19.0/resources/schema.json",
+  "$id": "https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/1.19.1/resources/schema.json",
   "title": "symfony-security-auditor bundle configuration",
   "description": "Configuration for the symfony_security_auditor bundle (config/packages/symfony_security_auditor.yaml).",
   "type": "object",


### PR DESCRIPTION
## Summary

Prep for reconciling `1.x`/`main` (diverged since #305's rebase-merge — 41 of their commits since the common ancestor are byte-identical content under different SHAs, verified with `git patch-id`): a CI safeguard against it recurring, the 1.19.1 changelog entry, and the version-pin bump. The actual `1.x` → `main` merge follows as a separate `chore: release 1.19.1` PR with a regular merge commit, once this lands.

## Type of change

- [x] Documentation

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] All checks pass: `bin/castor lint` — no docker/castor in this environment; verified `prettier --check` and `markdownlint-cli2` pass on every touched file, and validated `auto-release.yaml` with `yaml.safe_load`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)