### PR TITLE
docs: fix staleness across files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ While the pipeline runs, the audit narrates itself live — an attack-surface
 overview, each finding streamed (color-coded by severity in a terminal) the
 moment the Attacker flags it, per-chunk timing, and a reviewer tally. In CI or
 any non-TTY output it degrades to clean, append-only lines (no bar, no ANSI
-codes). Progress is suppressed for `--format=json/sarif` to stdout and for
-`--dry-run`.
+codes). Progress is suppressed for any non-`console` `--format` to stdout and
+for `--dry-run`.
 
 The full report renders the same way in console, JSON, SARIF, HTML, and Markdown
 — see [CLI reference](docs/configuration.md#cli-reference) and
@@ -332,21 +332,23 @@ bin/console audit:run --dry-run
 - **Actionable findings** — optionally attach a copy-pasteable reproduction
   (curl/console/payload) and a suggested patch to every high-severity finding;
   each one also carries a heuristic CVSS v4.0 estimate.
-- **Eight output formats** — `console`, `executive` (stakeholder summary: risk
+- **Nine output formats** — `console`, `executive` (stakeholder summary: risk
   level, business impact, severity/type/hotspot distributions, no per-finding
   detail), `json`, `sarif` (GitHub Code Scanning / GitLab Security Dashboard),
   `html` (self-contained, shareable), `markdown` (PR-friendly), `junit` (CI
-  test-report panels), and `github` (inline PR annotations, no SARIF upload
-  step). Baseline suppression: `--generate-baseline` accepts known findings,
-  `--baseline` drops them from the report and exit code so only new findings
-  fail CI.
+  test-report panels), `github` (inline PR annotations, no SARIF upload step),
+  and `github-comment` (PR comment headlined by the grade and score,
+  self-updating on rerun). Baseline suppression: `--generate-baseline` accepts
+  known findings, `--baseline` drops them from the report and exit code so only
+  new findings fail CI; `--min-score` gates on the normalized score
+  independently of `--fail-on`.
 - **Findings over time** — `audit:diff` compares two JSON reports by finding
   fingerprint, `audit:trend` tracks counts across a series of them.
 - **CI-ready** — a reusable
   [GitHub Action](https://github.com/marketplace/actions/symfony-security-auditor)
   (`uses: vinceamstoutz/symfony-security-auditor@1.19.1`) plus GitLab CI
-  templates, with SARIF upload to Code Scanning. See
-  [CI Integration](docs/ci.md).
+  templates, with SARIF upload to Code Scanning and an optional shields.io badge
+  tracking the report's letter grade. See [CI Integration](docs/ci.md).
 - **Extensible** — strict DDD layering and a sole `LLMClientInterface` seam let
   you plug in custom providers, agents, stages, advisory feeds, or report
   formats; project-specific attacker skills need only configuration, no PHP.
@@ -393,20 +395,20 @@ then override individual keys as needed.
 
 ## Supported Platforms
 
-| Platform             | Bridge package                       | Key env var            |
-| -------------------- | ------------------------------------ | ---------------------- |
-| Anthropic (Claude)   | `symfony/ai-anthropic-platform`      | `ANTHROPIC_API_KEY`    |
-| OpenAI               | `symfony/ai-open-ai-platform`        | `OPENAI_API_KEY`       |
-| OpenAI Responses API | `symfony/ai-open-responses-platform` | `OPENAI_API_KEY`       |
-| Azure OpenAI         | `symfony/ai-azure-platform`          | `AZURE_OPENAI_API_KEY` |
-| Google Gemini        | `symfony/ai-gemini-platform`         | `GEMINI_API_KEY`       |
-| Google Vertex AI     | `symfony/ai-vertex-ai-platform`      | GCP credentials        |
-| AWS Bedrock          | `symfony/ai-bedrock-platform`        | AWS credentials        |
-| DeepSeek             | `symfony/ai-deep-seek-platform`      | `DEEPSEEK_API_KEY`     |
-| Mistral              | `symfony/ai-mistral-platform`        | `MISTRAL_API_KEY`      |
-| Meta (Llama)         | `symfony/ai-meta-platform`           | `META_API_KEY`         |
-| MiniMax              | `symfony/ai-mini-max-platform`       | `MINIMAX_API_KEY`      |
-| Ollama (local)       | `symfony/ai-ollama-platform`         | _(none)_               |
+| Platform             | Bridge package                       | Key env var(s)                                 |
+| -------------------- | ------------------------------------ | ---------------------------------------------- |
+| Anthropic (Claude)   | `symfony/ai-anthropic-platform`      | `ANTHROPIC_API_KEY`                            |
+| OpenAI               | `symfony/ai-open-ai-platform`        | `OPENAI_API_KEY`                               |
+| OpenAI Responses API | `symfony/ai-open-responses-platform` | `OPENAI_API_KEY`                               |
+| Azure OpenAI         | `symfony/ai-azure-platform`          | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_BASEURL` |
+| Google Gemini        | `symfony/ai-gemini-platform`         | `GEMINI_API_KEY`                               |
+| Google Vertex AI     | `symfony/ai-vertex-ai-platform`      | GCP credentials                                |
+| AWS Bedrock          | `symfony/ai-bedrock-platform`        | AWS credentials                                |
+| DeepSeek             | `symfony/ai-deep-seek-platform`      | `DEEPSEEK_API_KEY`                             |
+| Mistral              | `symfony/ai-mistral-platform`        | `MISTRAL_API_KEY`                              |
+| Meta (Llama)         | `symfony/ai-meta-platform`           | `META_API_KEY`                                 |
+| MiniMax              | `symfony/ai-mini-max-platform`       | `MINIMAX_API_KEY`                              |
+| Ollama (local)       | `symfony/ai-ollama-platform`         | _(none)_                                       |
 
 Swapping providers requires only a `config/packages/ai.yaml` change — no PHP
 edits.

--- a/docs/cost-and-performance.md
+++ b/docs/cost-and-performance.md
@@ -31,24 +31,27 @@ Each key a profile sets is documented in
 ## Speed & cost levers
 
 - **Split-model** — pairing a powerful attacker with a cheap reviewer
-  (`attacker_model` + `reviewer_model`) is the single biggest cost lever, often
-  ~20× cheaper than one large model for both roles. See
+  (`attacker_model` + `reviewer_model`) is the single biggest cost lever: the
+  Reviewer phase alone often runs ~20× cheaper than on the attacker's model. See
   [Split-Model Setup](configuration.md#split-model-setup).
 - **Concurrency** — `audit.attacker_max_concurrent` and
   `audit.reviewer_max_concurrent` resolve several LLM calls at once on platforms
   with an async transport; `4`–`8` (within your rate limits) cuts each phase's
   wall-clock roughly proportionally. Cache hits short-circuit, so only the
   misses are dispatched.
-- **Caching** — content-hash caching skips identical chunks across runs, and
-  Anthropic prompt caching (`cache_retention` in `ai.yaml`) gives a ~90%
-  input-token discount on cache hits. Both are on by default; see
+- **Caching** — content-hash caching skips identical attacker chunks and
+  reviewer verdicts across runs, and Anthropic prompt caching (`cache_retention`
+  in `ai.yaml`) gives a ~90% input-token discount on cache hits. Both are on by
+  default; see
   [Configuration → `cache.*`](configuration.md#cache--caching-layers).
 - **Lean pre-scan & code slicing** — `audit.static_prescan.lean_mode` drops
   marker-free files and `audit.code_slicing.enabled` trims large files to
   security-relevant lines; both cut tokens and are on under the `fast` profile.
 - **Budget guards** — cap a run with `audit.budget.max_tokens` /
   `audit.budget.max_cost_usd`, and preview spend with `audit:run --dry-run`
-  before committing to a full run.
+  before committing to a full run. The preview's token counts are a heuristic
+  projection from file size, not the real per-call usage a completed run
+  reports.
 
 ## Avoiding rate limits (`429`)
 

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -18,7 +18,7 @@ flowchart LR
         PHP["Setup PHP 8.3\ncomposer install"]:::step
         AUDIT["audit:run\n--format sarif"]:::step
         UPLOAD["upload-sarif\n→ Code Scanning"]:::step
-        ARTIFACT["Upload artifact\n.sarif · .json · 90 days"]:::step
+        ARTIFACT["Upload artifact\n.sarif · .json · 30 days"]:::step
         PHP --> AUDIT --> UPLOAD --> ARTIFACT
     end
 
@@ -48,9 +48,12 @@ flowchart LR
     subgraph PIPE["  Pipeline  "]
         ING["Ingest\nPHP · Twig · YAML · XML\n(--since git diff filter)"]:::stage
         MAP["Map\nRoutes · Firewalls · Roles"]:::stage
+        DEP["Dependency Expansion\n(--since, opt-in)"]:::stage
         AUD["Audit"]:::stage
         POC["PoC Synthesis\n(opt-in)"]:::stage
-        ING --> MAP --> AUD --> POC
+        FIX["Fix Synthesis\n(opt-in)"]:::stage
+        ING --> MAP --> DEP --> AUD
+        POC --> FIX
     end
 
     subgraph LOOP["  Dual-Agent Loop — max 3 iterations  "]
@@ -59,14 +62,15 @@ flowchart LR
         REV["Reviewer Agent\nper-finding · LLM call\nvalidate + score (opt. concurrent)"]:::agent
         PRE --> ATK
         ATK -- "confidence ≥ 0.6" --> REV
-        REV -. "iterate: feed back confirmed findings" .-> ATK
+        REV -. "iterate: feed back validated + rejected findings" .-> ATK
     end
 
     RPT(["AuditReport\nrisk level · JSON · SARIF · console"]):::report
 
     CLI --> PIPE
     AUD --> PRE
-    REV -- "validated findings" --> RPT
+    REV -- "validated findings" --> POC
+    FIX --> RPT
 ```
 
 ## Attacker vs Reviewer — Dual-Agent Loop
@@ -85,15 +89,15 @@ sequenceDiagram
         O->>A: analyze(files, mapping)
         loop chunk of 10 files
             A->>L1: system prompt + source code
-            L1-->>A: JSON vulnerabilities[]
+            L1-->>A: record_vulnerability() calls
         end
-        A->>A: filter confidence ≥ 0.6
-        A-->>O: candidate findings
+        A-->>O: raw findings
+        O->>O: filter confidence ≥ 0.6
 
         O->>R: review(findings, files)
         loop per vulnerability
             R->>L2: system prompt + finding
-            L2-->>R: accepted · adjusted_severity
+            L2-->>R: record_review() calls
         end
         R-->>O: validated findings
 
@@ -102,7 +106,7 @@ sequenceDiagram
     end
 
     O->>C: write metadata
-    note over C: iterations · total_findings · risk_score
+    note over C: iterations · total_findings · validated · risk_score
 ```
 
 ## Multi-Provider LLM Support

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -7,10 +7,9 @@ All extension points are PHP interfaces. Wire your implementations via
 
 - [1. Custom LLM Client](#1-custom-llm-client)
 - [2. Custom Pipeline Stage](#2-custom-pipeline-stage)
-- [3. Custom Agent (Attacker or Reviewer)](#3-custom-agent-attacker-or-reviewer)
-- [4. Custom Report Output](#4-custom-report-output)
-- [5. Other Pluggable Ports](#5-other-pluggable-ports)
-- [6. Schema-Enforced Collection (`audit.structured_collection`)](#6-schema-enforced-collection-auditstructured_collection)
+- [3. Custom Report Output](#3-custom-report-output)
+- [4. Other Pluggable Ports](#4-other-pluggable-ports)
+- [5. Schema-Enforced Collection (`audit.structured_collection`)](#5-schema-enforced-collection-auditstructured_collection)
 
 > See also: [Architecture](architecture.md) · [Configuration](configuration.md)
 > · [FAQ](faq.md) · [Troubleshooting](troubleshooting.md)
@@ -132,25 +131,28 @@ and override those two arguments:
 
 ```yaml
 # config/services.yaml
-App\Llm\AcmeLlmClient:
-    arguments:
-        $apiKey: '%env(ACME_API_KEY)%'
+services:
+    App\Llm\AcmeLlmClient:
+        arguments:
+            $apiKey: '%env(ACME_API_KEY)%'
 
-security_auditor.attacker_client:
-    alias: App\Llm\AcmeLlmClient
-    public: true
+    security_auditor.attacker_client:
+        alias: App\Llm\AcmeLlmClient
+        public: true
 
-security_auditor.reviewer_client:
-    alias: App\Llm\AcmeLlmClient
-    public: true
+    security_auditor.reviewer_client:
+        alias: App\Llm\AcmeLlmClient
+        public: true
 ```
 
 To replace the client for every consumer that type-hints `LLMClientInterface`
 directly:
 
 ```yaml
-VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface:
-    alias: App\Llm\AcmeLlmClient
+# config/services.yaml
+services:
+    VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface:
+        alias: App\Llm\AcmeLlmClient
 ```
 
 ## 2. Custom Pipeline Stage
@@ -250,175 +252,7 @@ services:
             - { name: symfony_security_auditor.pipeline_stage, priority: -100 }
 ```
 
-## 3. Custom Agent (Attacker or Reviewer)
-
-### AttackerAgentInterface
-
-**Interface**:
-`VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgentInterface`
-
-```php
-interface AttackerAgentInterface
-{
-    /** @param ProjectFile[] $files */
-    public function analyze(array $files, SymfonyMapping $mapping): array; // Vulnerability[]
-}
-```
-
-The attacker receives all ingested `ProjectFile` objects and the Symfony
-route/controller mapping, then returns raw `Vulnerability` instances. Use
-`VulnerabilityFactory` to convert LLM JSON arrays into validated domain objects
-— invalid or incomplete shapes are silently dropped.
-
-```php
-// src/Agent/RuleBasedAttackerAgent.php
-namespace App\Agent;
-
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgentInterface;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\VulnerabilityFactory;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\LLMClientInterface;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\SymfonyMapping;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
-
-final class RuleBasedAttackerAgent implements AttackerAgentInterface
-{
-    public function __construct(
-        private readonly LLMClientInterface $llmClient,
-        private readonly VulnerabilityFactory $factory,
-    ) {}
-
-    public function analyze(array $files, SymfonyMapping $mapping): array
-    {
-        $combined = implode("\n\n", array_map(
-            static fn(ProjectFile $f): string => "// {$f->relativePath()}\n{$f->content()}",
-            $files,
-        ));
-
-        $response = $this->llmClient->complete(
-            systemPrompt: $this->systemPrompt(),
-            userMessage: $combined,
-        );
-
-        if ($response->isEmpty()) {
-            return [];
-        }
-
-        return $this->factory->fromList($response->parseJson())->vulnerabilities();
-    }
-
-    private function systemPrompt(): string
-    {
-        return <<<PROMPT
-            You are a security auditor. Return a JSON array of vulnerability objects.
-            Each object must have: type, severity, title, description, file_path,
-            line_start, line_end, vulnerable_code, attack_vector, proof, remediation, confidence.
-            Valid type values: sql_injection, command_injection, broken_access_control, ...
-            Valid severity values: critical, high, medium, low, info.
-            Confidence is a float between 0.0 and 1.0.
-            PROMPT;
-    }
-}
-```
-
-Wire:
-
-```yaml
-# config/services.yaml
-App\Agent\RuleBasedAttackerAgent: ~
-
-VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\AttackerAgentInterface:
-    alias: App\Agent\RuleBasedAttackerAgent
-```
-
-### ReviewerAgentInterface
-
-**Interface**:
-`VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgentInterface`
-
-```php
-interface ReviewerAgentInterface
-{
-    /** @param Vulnerability[] $vulnerabilities  @param ProjectFile[] $projectFiles */
-    public function review(array $vulnerabilities, array $projectFiles): array; // Vulnerability[]
-}
-```
-
-The reviewer receives findings from the attacker plus the full file list for
-cross-referencing. Return the same or modified `Vulnerability` objects. Use
-`$vulnerability->withReviewerValidation(true)` to mark a finding as confirmed —
-only validated findings appear in the final `AuditReport`. Use
-`$vulnerability->withElevatedSeverity(VulnerabilitySeverity::CRITICAL)` to
-adjust severity before returning.
-
-```php
-// src/Agent/StrictReviewerAgent.php
-namespace App\Agent;
-
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgentInterface;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\Vulnerability;
-use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\VulnerabilitySeverity;
-
-final class StrictReviewerAgent implements ReviewerAgentInterface
-{
-    public function review(array $vulnerabilities, array $projectFiles): array
-    {
-        $reviewed = [];
-
-        foreach ($vulnerabilities as $vuln) {
-            // Only validate findings with confidence >= 0.7.
-            if ($vuln->confidence() < 0.7) {
-                $reviewed[] = $vuln->withReviewerValidation(false);
-                continue;
-            }
-
-            $validated = $vuln->withReviewerValidation(true);
-
-            // Escalate any unreviewed HIGH to CRITICAL when confidence is perfect.
-            if ($vuln->severity() === VulnerabilitySeverity::HIGH && $vuln->confidence() === 1.0) {
-                $validated = $validated->withElevatedSeverity(VulnerabilitySeverity::CRITICAL);
-            }
-
-            $reviewed[] = $validated;
-        }
-
-        return $reviewed;
-    }
-}
-```
-
-Wire:
-
-```yaml
-VinceAmstoutz\SymfonySecurityAuditor\Audit\Application\Agent\ReviewerAgentInterface:
-    alias: App\Agent\StrictReviewerAgent
-```
-
-### VulnerabilityFactory
-
-`VulnerabilityFactory` is a service (autowired). Inject it wherever you need to
-convert raw LLM arrays into domain objects.
-
-```php
-// $rawList is the decoded JSON array from the LLM.
-$result = $this->factory->fromList($rawList); // VulnerabilityHydrationResult
-
-$vulnerabilities = $result->vulnerabilities(); // list<Vulnerability>
-$result->totalDropped();                       // int — entries the factory dropped
-$result->droppedBy(VulnerabilityDropReason::HYDRATION_FAILED); // per-reason count
-```
-
-`fromList()` calls `fromArray()` per item and drops any entry that fails
-validation (unknown `type`/`severity` enum value, empty `title`,
-`line_end < line_start`, `confidence` outside `[0.0, 1.0]`). Each drop is logged
-at `warning` level with a structured `reason` code
-(`VulnerabilityDropReason::NON_ARRAY_ENTRY` for non-array entries,
-`VulnerabilityDropReason::HYDRATION_FAILED` for invalid shapes) and aggregated
-in the returned `VulnerabilityHydrationResult` so callers can surface drop
-counts in their reports or metrics.
-
-## 4. Custom Report Output
+## 3. Custom Report Output
 
 `AuditReport` is produced by `AuditReport::fromContext(AuditContext $context)`
 at the end of the pipeline. It contains only reviewer-validated vulnerabilities.
@@ -452,10 +286,13 @@ $report->toArray(): array<string, mixed>             // fully serializable; incl
 
 Every format is its own class implementing `ReportRendererInterface`
 (`format(): string` + `render(AuditReport): string`). One class per format keeps
-each renderer small and independently testable. The bundle ships seven:
+each renderer small and independently testable. The bundle ships nine:
 
 - `ConsoleReportRenderer` (`console`) — human-readable terminal output
   (templates in `Report/Template/*.txt`).
+- `ExecutiveSummaryReportRenderer` (`executive`) — stakeholder-facing view: risk
+  level and severity/type/hotspot distributions, without the per-finding
+  technical detail the `console` format carries.
 - `JsonReportRenderer` (`json`) — pretty-printed `AuditReport::toArray()`.
 - `SarifReportRenderer` (`sarif`) — SARIF 2.1.0, consumable by GitHub Code
   Scanning and GitLab Security Dashboard. The only renderer implementing
@@ -471,6 +308,10 @@ each renderer small and independently testable. The bundle ships seven:
 - `GithubAnnotationsReportRenderer` (`github`) — one GitHub Actions
   `::error`/`::warning`/`::notice` workflow-command annotation per finding, for
   inline findings on a pull request's Files Changed view.
+- `GithubCommentReportRenderer` (`github-comment`) — the grade, normalized
+  score, and most severe findings (capped at 10 rows) as a pull-request comment
+  body, with a hidden marker so a workflow can find and update its own previous
+  comment instead of piling up new ones.
 
 Each renderer is tagged `symfony_security_auditor.report_renderer` (via the
 `ReportRendererInterface` `instanceof` autoconfiguration in
@@ -484,7 +325,7 @@ instead of `render()`, so that format can mark specific findings as suppressed
 rather than relying on the caller to drop them beforehand.
 
 Trigger them via
-`audit:run --format=console|json|sarif|html|markdown|junit|github|github-comment`
+`audit:run --format=console|executive|json|sarif|html|markdown|junit|github|github-comment`
 (see [`ci.md`](ci.md) for SARIF upload and GitHub annotation workflows).
 
 ### Adding a new format
@@ -501,7 +342,7 @@ inject it directly into any consumer (custom command, controller, event
 listener) and serialize it however fits your output target without going through
 a renderer.
 
-## 5. Other Pluggable Ports
+## 4. Other Pluggable Ports
 
 Beyond the seams above, these Domain ports can each be implemented and aliased
 in `config/services.yaml` to override the bundled behaviour (see
@@ -532,11 +373,12 @@ in `config/services.yaml` to override the bundled behaviour (see
   it for redaction the bundled patterns cannot express — e.g. calling out to a
   dedicated secret-detection engine. Extra PCRE patterns alone do not need a
   class: use `scan.secret_scrubbing.additional_patterns`.
-- `AdvisoryDatabaseInterface` — `lookup(string $package, string $version)`
-  backing the attacker's `lookup_advisory` tool (default:
-  `ComposerAuditAdvisoryDatabase` running `composer audit`;
-  `InMemoryAdvisoryDatabase` is the offline fallback). Implement it to query an
-  internal vulnerability feed or a commercial advisory service.
+- `AdvisoryDatabaseInterface` —
+  `lookup(string $packageName, string $installedVersion): array` backing the
+  attacker's `lookup_advisory` tool (default: `ComposerAuditAdvisoryDatabase`
+  running `composer audit`; `InMemoryAdvisoryDatabase` is the offline fallback).
+  Implement it to query an internal vulnerability feed or a commercial advisory
+  service.
 - `PricingProviderInterface` — per-model USD prices for cost estimation
   (default: `ModelsDevPricingProvider` reading the `symfony/models-dev`
   catalog). Also implement `CacheAwarePricingProviderInterface` if your source
@@ -579,7 +421,7 @@ in `config/services.yaml` to override the bundled behaviour (see
   `audit.triage_memory: true`). Implement it to source feedback from elsewhere —
   a shared team knowledge base, a ticketing system's "won't fix" list.
 - `TriageMemoryRecorderInterface` —
-  `record(string $type, string $file, string $title, string $reason): void`
+  `record(string $type, string $file, string $title, int $line, string $reason)`
   called whenever the reviewer rejects a finding with a non-empty
   `reviewer_notes` explanation (default: `NullTriageMemoryRecorder`, or
   `FilesystemTriageMemoryStore` when `audit.triage_memory: true`). Implement it
@@ -587,7 +429,7 @@ in `config/services.yaml` to override the bundled behaviour (see
   cache reachable by every CI runner, for example — so the cross-run memory
   survives across ephemeral containers.
 
-## 6. Schema-Enforced Collection (`audit.structured_collection`)
+## 5. Schema-Enforced Collection (`audit.structured_collection`)
 
 By default (`audit.structured_collection: true`), the attacker is given a
 `record_vulnerability` tool with a strict JSON-Schema input and the prompt

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,7 +27,7 @@ It feeds your Symfony project through a three-stage AI pipeline:
 1. **Ingestion** — scans `.php`, `.twig`, `.yaml`, `.yml`, `.xml` files
    recursively.
 2. **Mapping** — classifies files as Controllers, Entities, Voters, Forms,
-   Repositories, Templates, Config, Services; builds a route/firewall map.
+   Repositories, Templates, Config; builds a route/firewall map.
 3. **Audit** — an adversarial Attacker agent hunts for vulnerabilities; a
    skeptical Reviewer agent validates each finding. Up to 3 iterations, stops
    earlier when no new findings emerge.
@@ -37,7 +37,7 @@ for GitHub Code Scanning / GitLab Security Dashboard.
 
 ### What kinds of vulnerabilities does it catch?
 
-32 types across six categories (OWASP-aligned):
+49 types across six categories (OWASP-aligned):
 
 - **Injection** — SQL, command, LDAP, XPath, Twig, header.
 - **Broken Access Control** — missing Voter, Voter bypass, role escalation,
@@ -67,10 +67,13 @@ output and a per-run LLM cost.
 
 ### Is it ready for production use?
 
-The bundle is actively developed. Output is validated by a Reviewer agent before
-being included in the final report. We recommend running it as a **scheduled
-nightly CI job** alongside existing tools (PHPStan / Psalm / Dependabot), not as
-a blocking PR gate. See [CI Integration](ci.md).
+The auditor is actively developed. Output is validated by a Reviewer agent
+before being included in the final report. A **scheduled nightly CI job**
+alongside existing tools (PHPStan / Psalm / Dependabot) is the lowest-friction
+default, but gating pull requests directly is also supported: scope the run to
+changed files with `--since`, then gate on `--fail-on` / `--min-score`, with
+baseline suppression (`--baseline`/`--generate-baseline`) so previously-accepted
+findings don't fail CI. See [CI Integration](ci.md).
 
 ## Comparisons
 
@@ -172,11 +175,14 @@ That's a harder problem — LLMs miss things. Options:
 
 ### Is the output deterministic?
 
-**No.** LLM output is nondeterministic by default. Set `temperature: 0.0` (or
-low like `0.1`) in your model options to reduce variation, but identical input
-may still produce different findings across runs. The cache
-(`cache.enabled: true`) makes a _repeated_ run on identical code deterministic —
-chunks with the same content hash are short-circuited.
+**No.** LLM output is nondeterministic by default. On models that accept it, set
+`temperature: 0.0` (or low like `0.1`) in your model options to reduce variation
+— the current Claude generation (Opus 5, Sonnet 5, Fable 5) rejects
+`temperature` outright and is steered via `effort`/`thinking` instead (see Model
+Selection below) — but identical input may still produce different findings
+across runs. The cache (`cache.enabled: true`) makes a _repeated_ run on
+identical code deterministic — chunks with the same content hash are
+short-circuited.
 
 ## Cost & Performance
 
@@ -208,16 +214,19 @@ the risk of cross-talk between findings in the prompt.
 
 ### Why is the cache so important?
 
-The Attacker chunks files in groups of 10 and computes a content hash. Identical
-chunks (same files, same content) skip the LLM entirely — `cache.enabled: true`
-(the default) gives ~80% cost reduction on repeated CI runs of unchanged code.
+By default, the Attacker groups files by feature
+(`audit.chunking.strategy: feature`) — a controller together with its related
+entity/repository/form/voter/templates, capped at 10 files per chunk — and
+computes a content hash per chunk. Identical chunks (same files, same content)
+skip the LLM entirely — `cache.enabled: true` (the default) gives ~80% cost
+reduction on repeated CI runs of unchanged code.
 
 Provider-side **prompt caching** stacks on top of that for a ~90%
 **input-token** discount on prompts that share a long system message. It is
-configured on the `symfony/ai` platform, not in this bundle: set
+configured on the `symfony/ai` platform, not by the auditor itself: set
 `cache_retention` (`short`/`long`) on the `anthropic` platform in `ai.yaml`
 (default `short` already enables it); OpenAI and Gemini cache automatically. The
-old `cache.prompt_caching` bundle flag is deprecated since 1.7 and ignored.
+old `cache.prompt_caching` flag is deprecated since 1.7 and ignored.
 
 ## Privacy & Data Handling
 
@@ -354,14 +363,14 @@ class of issue this tool exists to find.
 
 > Which option keys are accepted (`effort`, `thinking`, …) depends on the
 > provider and model behind `symfony/ai`. Unknown options are passed straight
-> through to the provider, so check your provider's documentation; this bundle
+> through to the provider, so check your provider's documentation; the auditor
 > does not validate them.
 
 ### Can I tune model parameters (temperature, max_tokens)?
 
-Yes. For `max_tokens`, use the dedicated bundle key — it defaults to `4096` and
-avoids `symfony/ai`'s built-in ~1000-token cap. This key currently only takes
-effect for Claude/Anthropic-dialect models — see
+Yes. For `max_tokens`, use the dedicated `max_output_tokens` key — it defaults
+to `4096` and avoids `symfony/ai`'s built-in ~1000-token cap. This key currently
+only takes effect for Claude/Anthropic-dialect models — see
 [Configuration → Top-level](configuration.md#top-level):
 
 ```yaml
@@ -454,14 +463,19 @@ symfony_security_auditor:
 
 ### How do I run it in CI?
 
-Schedule it nightly — the multi-agent loop takes minutes, so blocking PRs hurts
-productivity. See [CI Integration](ci.md) for ready-to-copy GitHub Actions and
-GitLab CI templates with SARIF upload.
+Nightly scheduling is simplest — the multi-agent loop can take minutes, so a
+full audit on every push adds latency. See [CI Integration](ci.md) for
+ready-to-copy GitHub Actions and GitLab CI templates, including scheduled SARIF
+upload and a `--since`-scoped, `--fail-on`-gated pattern for teams that want the
+audit to block pull requests directly.
 
 ### Can I run it on every PR?
 
-You **can** (with `audit.max_iterations: 1` + split-model to keep latency low)
-but the cost-vs-value usually favors nightly scheduled runs.
+You **can** — this is now a well-supported pattern. Scope the run to changed
+files with `--since` (fast, and the cache stays warm) and gate on `--fail-on` /
+`--min-score`, with `--baseline` to keep already-accepted findings from failing
+the check. A full (non-`--since`) audit on every PR is still costlier and slower
+than a nightly run — reserve that for the scheduled job.
 
 ### How do I get findings into GitHub Code Scanning?
 
@@ -492,9 +506,9 @@ notification-only (Slack/email), and storage in a private repo via PAT.
 
 ### Can I add custom vulnerability types?
 
-Yes. Add a case to `Audit/Domain/Model/VulnerabilityType`, extend `category()`
-and `owaspReference()`, then update `AttackerPromptBuilder` to mention the new
-type. See
+Yes. Add a case to `Audit/Domain/Model/VulnerabilityType`, extend `category()`,
+`owaspReference()`, `owaspReferenceUrl()`, and `cwe()`, then update
+`AttackerPromptBuilder` to mention the new type. See
 [Contributing → Common Tasks](../CONTRIBUTING.md#add-a-new-vulnerability-type).
 
 ### Can I add custom pipeline stages?
@@ -516,6 +530,7 @@ alias in `config/services.yaml`. See
 
 ### Can I add a new output format?
 
-Yes. Add a case to `Command/OutputFormat`, a `render<Name>()` method to
-`ReportRenderer`, and a `match` arm in `ReportWriter::write()`. See
-[Extending → Custom Report Output](extending.md#4-custom-report-output).
+Yes. Add a case to `Command/OutputFormat`, then a `<Name>ReportRenderer` class
+implementing `ReportRendererInterface` and register it in `config/services.php`
+— autoconfiguration wires it into `ReportWriter`, no `match` arm to edit. See
+[Extending → Custom Report Output](extending.md#3-custom-report-output).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,6 +8,7 @@ so we can document it.
 ## Table of Contents
 
 - [Installation & Setup](#installation--setup)
+- [Standalone Binary Issues](#standalone-binary-issues)
 - [Running the Audit](#running-the-audit)
 - [LLM & Provider Errors](#llm--provider-errors)
 - [Empty / Surprising Reports](#empty--surprising-reports)
@@ -48,7 +49,7 @@ VinceAmstoutz\SymfonySecurityAuditor\SymfonySecurityAuditorBundle::class => ['de
 commented out** — uncomment one (e.g. `anthropic`) and set its API key. See
 [Configuration → Platform Configuration](configuration.md#platform-configuration).
 
-### `The service "VinceAmstoutz\..." has a dependency on a non-existent service "Symfony\AI\Platform\PlatformInterface"`
+### `The service "security_auditor.attacker_client" has a dependency on a non-existent service "Symfony\AI\Platform\PlatformInterface"`
 
 Same root cause as above, surfaced at container compile time (`cache:clear`,
 `cache:warmup`) by versions **≤ 1.7.0**. Upgrade to `1.7.1` or later — the
@@ -57,8 +58,153 @@ raised only when an audit actually runs.
 
 ### `Argument #1 ... must be of type Symfony\AI\Platform\PlatformInterface, NULL given`
 
-Same root cause as above. Verify `ai.yaml` has a `platform:` block and the
-corresponding `symfony/ai-*-platform` package is installed.
+Same root cause as above — another **≤ 1.7.0** symptom. Since `1.7.1`,
+`PlatformBinding`'s platform property (and every collaborator built from it) is
+typed `?PlatformInterface`, so a missing platform can no longer reach a
+constructor as a hard type error. Upgrade to `1.7.1` or later, or verify
+`ai.yaml` has a `platform:` block and the corresponding `symfony/ai-*-platform`
+package is installed.
+
+## Standalone Binary Issues
+
+Entries in this section apply only to the standalone binary (`init`,
+`self-update`, `doctor`) — not to the Symfony bundle, which has no equivalent
+commands.
+
+### `doctor` reports a Configuration or API key failure
+
+`doctor`'s "Configuration" and "API key" lines surface
+`StandaloneConfigLoader::load()` failures directly:
+
+- **`No provider is configured — run "init".`** — no `platform:` block in
+  `config.yaml`; run `init`.
+- **`The environment variable "<VAR>", referenced by your config, is not set.`**
+  (reported under the `API key` label) — export the `%env(VAR)%` variable your
+  `platform:` block references.
+- **`Config file "<path>" is not valid YAML: <detail>`** — fix the malformed
+  `config.yaml` or `.symfony-security-auditor.yaml` at `<path>`.
+- **Cannot resolve the user configuration directory** — set `$HOME`, or set
+  `SYMFONY_SECURITY_AUDITOR_HOME` to a writable directory:
+
+  ```text
+  Cannot resolve the user configuration directory: neither the relevant XDG
+  base-directory variable nor $HOME is set.
+  ```
+
+Running `audit`/`init` directly without `doctor` first hits the same underlying
+failures.
+
+### `doctor` reports the provider bridge as not installed or unbootable
+
+Two distinct "Provider bridge" failures:
+
+- **`Not installed — run "init" to download it.`** —
+  `<data-dir>/vendor/autoload.php` does not exist yet.
+- **`Installed, but the audit cannot start with it: <reason>`** — the autoloader
+  exists, but `doctor` also builds the container to confirm it actually boots,
+  not just that the file is present. A bridge left over from a previously
+  configured provider passes the file check but fails here, since the container
+  needs the _currently_ configured provider's classes, not whichever bridge
+  happens to be installed. Re-run `init` for the current provider (`--force`
+  skips the overwrite prompt) to install the matching bridge.
+
+### `.symfony-security-auditor.yaml` cannot override `platform`, `provider`, or `scan.import_sarif`
+
+Fixed as a security issue in `1.19.0`. A per-project
+`.symfony-security-auditor.yaml` ships with the audited repository, so letting
+it contribute these keys allowed a malicious or compromised repository to
+redirect your resolved API key — and every prompt, i.e. the source code — to an
+endpoint of its choosing via `platform:`/`provider:`, or to point the SARIF
+importer at an arbitrary file via `scan.import_sarif`. Both are now rejected
+outright before the audit starts:
+
+- Declaring `platform` and/or `provider` aborts with
+  `ProjectConfigPlatformOverrideException`:
+
+  ```text
+  The project config "<path>" declares "platform", but LLM connection
+  settings are read from your user config only — a repository you audit
+  must not be able to point your API credentials at another endpoint.
+  Configure the platform in your user config instead.
+  ```
+
+- Declaring `scan.import_sarif` aborts with `ProjectConfigScanOverrideException`
+  carrying the equivalent message for that key.
+
+`doctor` reports the same message under a failed `Configuration` check.
+Per-project overrides of audit settings (chunking strategy, `fail_on`, excluded
+paths, …) are unaffected — move only `platform`/`provider`/`scan.import_sarif`
+to your user `config.yaml`.
+
+### `self-update` fails
+
+`self-update` exists only in the standalone binary. Failures:
+
+- **Any platform other than Linux or macOS** —
+  `UnsupportedSelfUpdatePlatformException`. There is no Windows `self-update`;
+  reinstall with `install.ps1` or download the new release asset directly:
+
+  ```text
+  Self-update does not support the "Windows" / "<machine>" platform;
+  download the binary for your platform from the releases page instead.
+  ```
+
+- **Cannot reach GitHub** — `SelfUpdateFailedException`:
+  `Failed to download "<url>".` (curl itself failed — offline, DNS, TLS) or
+  `Could not determine the latest released version from "<url>".` (GitHub
+  answered but without a usable `tag_name` — an API outage or rate limit).
+- **Checksum mismatch** — the downloaded file is deleted and nothing is
+  replaced; retry, or download the asset manually and verify its `.sha256`
+  yourself:
+
+  ```text
+  Checksum verification failed for "<asset>"; the download was not trusted
+  and has been discarded.
+  ```
+
+- **Binary not writable**:
+
+  ```text
+  The binary at "<path>" is not writable; re-run the update with the
+  necessary permissions (e.g. sudo) or reinstall with the install script.
+  ```
+
+- **Replacement failed mid-swap** —
+  `Failed to replace the binary at "<path>": <reason>.`
+
+### `init` fails to install the provider bridge
+
+`init` always runs `composer require symfony/ai-<slug>-platform` under the data
+directory before it writes the config file. `BridgeInstallationFailedException`:
+
+- **No `composer` binary reachable**:
+
+  ```text
+  Could not run composer to install the "<package>" provider bridge; is
+  composer on the PATH?
+  ```
+
+- **`composer require` ran but exited non-zero** (no network, or the package
+  does not exist for a misspelled `--provider`):
+
+  ```text
+  Installing the "<package>" provider bridge failed: <composer's error output>
+  ```
+
+- **`Could not initialize a composer project in "<dir>": <reason>`** — the data
+  directory has no `composer.json` yet and one could not be written there
+  (permissions).
+- **The data directory or its `composer.json` is a symlink** — `init` refuses to
+  write through it:
+
+  ```text
+  Refusing to initialize a composer project in "<dir>": the target or its
+  manifest path is a symlink.
+  ```
+
+These surface directly from `init` itself — `doctor`'s "Provider bridge" check
+only inspects the _result_ of a previous `init` run, so a failed installation
+never shows up there.
 
 ## Running the Audit
 
@@ -77,7 +223,7 @@ To enable in `prod`, change `config/bundles.php`:
 VinceAmstoutz\SymfonySecurityAuditor\SymfonySecurityAuditorBundle::class => ['all' => true],
 ```
 
-### `[ERROR] Path "/x" is not a valid directory`
+### `[ERROR] Project path "/x" is not a valid directory`
 
 The `project-path` argument must point to a directory that exists. Use an
 absolute path, or omit the argument to default to the current working directory.
@@ -97,9 +243,14 @@ resolved to nothing.
 Exit code `1` is also used for:
 
 - Invalid `project-path` argument.
+- The scan discovered no file to audit at all — a mistyped path, a
+  `scan.included_paths` entry matching nothing, or an over-narrow `--path` —
+  fails rather than reporting a hollow SAFE result. A `--since` run that finds
+  no _changed_ files still exits `0`.
+- The normalized score fell below `--min-score`, if set.
 - Unhandled exception during pipeline execution (check stderr).
-- Validator errors on the input (e.g. `--format` not one of
-  `console|json|sarif`).
+- Validator errors on the input (e.g. `--format` set to a value it does not
+  support — see [Configuration → Options](configuration.md#options)).
 
 Re-run with `-v` or `-vv` to see the underlying error.
 
@@ -121,7 +272,10 @@ docker compose exec -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" php bin/console au
 
 ### `Rate limit exceeded` / `429`
 
-Reduce concurrent load:
+Configure `audit.rate_limit.requests_per_minute` / `input_tokens_per_minute` /
+`output_tokens_per_minute` to your provider tier's limits so the auditor
+throttles proactively instead of hitting a `429`. Otherwise, reduce concurrent
+load:
 
 - Lower `audit.max_iterations` (default `3`) to `1`.
 - Raise `reviewer_batch_size` from `1` to `5` (fewer reviewer calls).
@@ -157,10 +311,13 @@ If it happens for **every** chunk, the model is unsuitable. Switch model.
 
 ### `Tool-using loop ended with empty content response` warnings
 
-Logged at `warning` level when the attacker's tool loop ends with an empty final
-content block. Look at the `output_tokens` field: if it sits near a multiple of
-~1000 (e.g. `1971`, `2000`), the model is being truncated by `symfony/ai`'s
-default `max_tokens = 1000` that ships with the Anthropic bridge. Set
+Logged at `warning` level when the empty response is the very first LLM call in
+the loop (no tool round happened yet); once at least one tool round has run, a
+later empty response logs the same message at `debug` instead — grep by message
+text rather than filtering on `warning` alone if the loop used tools first. Look
+at the `output_tokens` field: if it sits near a multiple of ~1000 (e.g. `1971`,
+`2000`), the model is being truncated by `symfony/ai`'s default
+`max_tokens = 1000` that ships with the Anthropic bridge. Set
 `max_output_tokens` in the bundle config (default `4096` since this fix) — or
 `attacker_max_output_tokens` / `reviewer_max_output_tokens` for per-agent
 tuning:
@@ -219,8 +376,9 @@ Diagnostic order:
 - Raise `audit.min_confidence` from `0.6` to `0.8`.
 - Switch Reviewer to a **stronger** model (counterintuitive — Reviewer needs
   accuracy, not speed).
-- Inspect the LLM's `reviewer_notes` (logged at `info` level) — the Reviewer
-  often explains why it accepted weak findings.
+- Inspect the LLM's `reviewer_notes` (logged at `debug` level in the
+  `Vulnerability reviewed` entry) — the Reviewer often explains why it accepted
+  weak findings.
 
 ### Same code, different findings on each run
 
@@ -334,6 +492,13 @@ USD figure is unavailable. Run `composer update symfony/models-dev` to pull a
 fresher catalog, or alias your own `PricingProviderInterface` implementation to
 supply prices (see [Extending](extending.md)).
 
+**Standalone binary:** `composer update` does not apply — there is no
+user-facing `vendor/` or `composer.json`; the catalog is baked into the binary
+at release-build time from whatever `symfony/models-dev` version that release's
+CI resolved. The only way to get a newer catalog is `self-update` to a newer
+release, and even that only carries whatever was current when that release was
+built — there is no way to refresh the catalog independently of a release yet.
+
 ## Cache Issues
 
 ### Cache seems stale — old findings persist after fixing code
@@ -373,30 +538,38 @@ symfony_security_auditor:
         enabled: false
 ```
 
-`AttackerCacheInterface` is aliased to `NullAttackerCache` — every chunk hits
-the LLM.
+`AttackerCacheInterface` is aliased to `NullAttackerCache` (and
+`ReviewerCacheInterface` to `NullReviewerCache`) — every chunk, and every
+reviewer verdict, hits the LLM.
 
 ## Advisory (`composer audit`) Issues
 
 ### `lookup_advisory` always returns empty results
 
-Causes (each logs a `warning` via `LoggerInterface`):
+Causes (each logs a `warning` via `LoggerInterface`, except the deliberate
+`offline_only` case below):
 
 - **`composer` not in `PATH`** — install Composer 2.4+ on the audit host.
 - **`composer.lock` missing** — run `composer install` first; advisory data
   comes from the lockfile.
 - **Malformed JSON output** — corrupted `composer.lock`. Regenerate it.
 - **Process error** — network failure to Packagist. Retry.
+- **`privacy.offline_only: true`** — the advisory feed is intentionally replaced
+  by an empty in-memory database, so `composer audit` never runs; no warning is
+  logged since this is configured behavior, not a failure.
 
 When `lookup_advisory` returns empty, the audit continues without CVE data — no
 audit failure.
 
 ### `composer audit` is slow
 
-It runs **once** per audit and the result is cached for the lifetime of the
-request. If it's the bottleneck, you can pre-warm it before the audit or
-override `AdvisoryDatabaseInterface` with `InMemoryAdvisoryDatabase` containing
-a baked snapshot.
+Within a run it executes **once** and the result is cached for the lifetime of
+the request. Across runs, with `cache.enabled: true` (default),
+`LockfileHashedAdvisoryCache` also persists the JSON payload to disk for 24h,
+keyed by a SHA-256 hash of `composer.lock` — an unchanged lockfile skips
+`composer audit` entirely on the next run. If it's still the bottleneck, you can
+pre-warm it before the audit or override `AdvisoryDatabaseInterface` with
+`InMemoryAdvisoryDatabase` containing a baked snapshot.
 
 ### Override the advisory source
 
@@ -435,9 +608,21 @@ See [Advisory (`composer audit`) Issues](#advisory-composer-audit-issues) above.
 
 ### `read_file` / `grep` returns nothing for files I know exist
 
-The tools are scoped to the project path passed to `audit:run`. Symlinks outside
-that path are not followed. Use absolute paths only when the file is under the
-project root.
+Both tools only search the files `ProjectFileScanner` already loaded into memory
+during ingestion — neither touches the filesystem live. Causes:
+
+- The file falls outside `scan.included_paths`, is excluded by
+  `scan.respect_gitignore`, or exceeds `scan.max_file_size_kb`.
+- The file, or one of its `scan.included_paths` ancestors, is a symlink.
+  `ProjectFileScanner` skips symlinks unconditionally regardless of where they
+  point (logged as `Skipped symlinked file` / `Skipped symlinked included path`)
+  — a symlink pointing back inside the project is skipped too, not just one
+  pointing outside it.
+- `read_file`'s `relative_path` argument must match
+  `ProjectFile::relativePath()` exactly (e.g.
+  `src/Controller/UserController.php`). It has no absolute-path fallback — an
+  absolute path never matches and returns
+  `Error: file "..." is not part of the audited project.`
 
 ## CI Failures
 
@@ -485,9 +670,9 @@ tracking issue and a justification in the PR description.
 
 ### Infection MSI is below 100%
 
-A mutation survived your tests. Read the Infection log (`var/infection.log`) to
-see which mutator and which line. Add a test that distinguishes the mutated
-behavior. Suppression annotations are forbidden.
+A mutation survived your tests. Read the Infection log
+(`infection/infection.log`) to see which mutator and which line. Add a test that
+distinguishes the mutated behavior. Suppression annotations are forbidden.
 
 ### PHP CS Fixer / Rector wants to change code I deliberately wrote that way
 
@@ -499,5 +684,6 @@ document the reason in the PR.
 
 - Different PHP version — CI matrix runs 8.3, 8.4, 8.5; pin locally with Docker.
 - Filesystem case sensitivity — Linux CI is case-sensitive; macOS is not.
-- Random test order — Infection runs with random order; reproduce locally with
-  `--order=random --random-order-seed=<seed>`.
+- Random test order — Infection rewrites `phpunit.dist.xml` to force
+  `executionOrder="defects,random"` for its own runs; reproduce locally with
+  `--order-by=defects,random --random-order-seed=<seed>`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,8 +7,8 @@ so we can document it.
 
 ## Table of Contents
 
-- [Installation & Setup](#installation--setup)
 - [Standalone Binary Issues](#standalone-binary-issues)
+- [Installation & Setup](#installation--setup)
 - [Running the Audit](#running-the-audit)
 - [LLM & Provider Errors](#llm--provider-errors)
 - [Empty / Surprising Reports](#empty--surprising-reports)
@@ -21,49 +21,6 @@ so we can document it.
 
 > See also: [FAQ](faq.md) · [Configuration](configuration.md) ·
 > [CI Integration](ci.md)
-
-## Installation & Setup
-
-### `Class "Symfony\AI\AiBundle\AiBundle" not found`
-
-`symfony/ai-bundle` isn't installed, or Composer's autoloader hasn't picked it
-up yet. This is a Composer/autoload issue, not a `config/bundles.php` ordering
-problem — `AiBundle` and `SymfonySecurityAuditorBundle` can be registered in
-either order.
-
-```bash
-composer require symfony/ai-anthropic-platform  # or any other bridge
-```
-
-```php
-// config/bundles.php — either order works
-Symfony\AI\AiBundle\AiBundle::class => ['all' => true],
-VinceAmstoutz\SymfonySecurityAuditor\SymfonySecurityAuditorBundle::class => ['dev' => true, 'test' => true],
-```
-
-### `No AI platform is configured`
-
-`audit:run` aborts with this message when no
-`Symfony\AI\Platform\PlatformInterface` service exists in the container. The
-`symfony/ai-bundle` recipe ships `config/packages/ai.yaml` with **every platform
-commented out** — uncomment one (e.g. `anthropic`) and set its API key. See
-[Configuration → Platform Configuration](configuration.md#platform-configuration).
-
-### `The service "security_auditor.attacker_client" has a dependency on a non-existent service "Symfony\AI\Platform\PlatformInterface"`
-
-Same root cause as above, surfaced at container compile time (`cache:clear`,
-`cache:warmup`) by versions **≤ 1.7.0**. Upgrade to `1.7.1` or later — the
-container then compiles without a platform and the actionable error above is
-raised only when an audit actually runs.
-
-### `Argument #1 ... must be of type Symfony\AI\Platform\PlatformInterface, NULL given`
-
-Same root cause as above — another **≤ 1.7.0** symptom. Since `1.7.1`,
-`PlatformBinding`'s platform property (and every collaborator built from it) is
-typed `?PlatformInterface`, so a missing platform can no longer reach a
-constructor as a hard type error. Upgrade to `1.7.1` or later, or verify
-`ai.yaml` has a `platform:` block and the corresponding `symfony/ai-*-platform`
-package is installed.
 
 ## Standalone Binary Issues
 
@@ -205,6 +162,49 @@ directory before it writes the config file. `BridgeInstallationFailedException`:
 These surface directly from `init` itself — `doctor`'s "Provider bridge" check
 only inspects the _result_ of a previous `init` run, so a failed installation
 never shows up there.
+
+## Installation & Setup
+
+### `Class "Symfony\AI\AiBundle\AiBundle" not found`
+
+`symfony/ai-bundle` isn't installed, or Composer's autoloader hasn't picked it
+up yet. This is a Composer/autoload issue, not a `config/bundles.php` ordering
+problem — `AiBundle` and `SymfonySecurityAuditorBundle` can be registered in
+either order.
+
+```bash
+composer require symfony/ai-anthropic-platform  # or any other bridge
+```
+
+```php
+// config/bundles.php — either order works
+Symfony\AI\AiBundle\AiBundle::class => ['all' => true],
+VinceAmstoutz\SymfonySecurityAuditor\SymfonySecurityAuditorBundle::class => ['dev' => true, 'test' => true],
+```
+
+### `No AI platform is configured`
+
+`audit:run` aborts with this message when no
+`Symfony\AI\Platform\PlatformInterface` service exists in the container. The
+`symfony/ai-bundle` recipe ships `config/packages/ai.yaml` with **every platform
+commented out** — uncomment one (e.g. `anthropic`) and set its API key. See
+[Configuration → Platform Configuration](configuration.md#platform-configuration).
+
+### `The service "security_auditor.attacker_client" has a dependency on a non-existent service "Symfony\AI\Platform\PlatformInterface"`
+
+Same root cause as above, surfaced at container compile time (`cache:clear`,
+`cache:warmup`) by versions **≤ 1.7.0**. Upgrade to `1.7.1` or later — the
+container then compiles without a platform and the actionable error above is
+raised only when an audit actually runs.
+
+### `Argument #1 ... must be of type Symfony\AI\Platform\PlatformInterface, NULL given`
+
+Same root cause as above — another **≤ 1.7.0** symptom. Since `1.7.1`,
+`PlatformBinding`'s platform property (and every collaborator built from it) is
+typed `?PlatformInterface`, so a missing platform can no longer reach a
+constructor as a hard type error. Upgrade to `1.7.1` or later, or verify
+`ai.yaml` has a `platform:` block and the corresponding `symfony/ai-*-platform`
+package is installed.
 
 ## Running the Audit
 


### PR DESCRIPTION
## Summary

Audits and fixes documentation staleness against the current codebase across
six files:

- `docs/faq.md` — generic "this bundle" wording, outdated "32 types across six
  categories" count (now 49), CI recommendation reconciled with `docs/ci.md`,
  chunking-strategy description, custom-vulnerability-type steps, output-format
  steps, broken anchor to `extending.md`.
- `README.md` — progress-suppression scope, output-format count ("Eight" →
  "Nine", `github-comment` was missing), missing `AZURE_OPENAI_BASEURL` in the
  Azure OpenAI row.
- `docs/cost-and-performance.md` — scoped the "~20x cheaper" split-model claim
  to the Reviewer phase specifically (was overstating whole-run savings),
  reviewer-verdict caching, dry-run heuristic-vs-real-usage caveat.
- `docs/diagrams.md` — 30-day (not 90-day) artifact retention, missing
  DependencyExpansion/FixSynthesis pipeline nodes and corrected topology,
  sequence diagram updated to `record_vulnerability()`/`record_review()` tool
  calls (structured collection is default).
- `docs/extending.md` — removed the stale "Custom Agent" section
  (`AttackerAgentInterface`/`ReviewerAgentInterface` are `@internal` since
  1.4.0, not extension points, and the documented signatures no longer match),
  fixed two YAML samples missing a `services:` root key, corrected the
  report-renderer count and an interface signature.
- `docs/troubleshooting.md` — corrected several entries (service ID, log
  levels, Infection log path, PHPUnit flag), added a new "Standalone Binary
  Issues" section.

No code or tests changed.

## Type of change

- [x] Documentation

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features
- [ ] `2.x` — breaking changes, for the next major release
- [ ] `main` — release merges only, nothing else
- [ ] `stacked` — based on another open PR; retarget to the release branch
      ticked above once that PR merges

## Checklist

- [x] All checks pass: `bin/castor lint` (docs subset: Prettier +markdownlint-cli2 verified locally)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)