### PR TITLE
ci: build release binaries against the draft

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -200,16 +200,5 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Dispatched unconditionally, draft or not: softprops/action-gh-release
-          # finds a release by tag regardless of its draft state, so building
-          # here means the binaries are already attached by the time a human
-          # publishes the draft -- otherwise releases/latest/download/<asset>
-          # 404s for however long the matrix takes to finish after publish.
-          # release.yaml also still listens for `release: published`, as a
-          # safety net for a release created outside this workflow -- but an
-          # event produced by the default GITHUB_TOKEN (the draft step above)
-          # never cascades into another workflow run (GitHub's anti-recursion
-          # guard), so it would not have fired for this release anyway.
-          # Dispatch it explicitly instead; an API-triggered workflow_dispatch
-          # is not subject to that restriction.
+          # GITHUB_TOKEN-authored events don't cascade into other workflows (GitHub's anti-recursion guard), so dispatch explicitly rather than rely on release:published.
           gh workflow run release.yaml --repo "$REPO" --field tag="$VERSION"

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -192,8 +192,7 @@ jobs:
           body_path: release-notes.md
           draft: ${{ steps.publish-state.outputs.draft }}
 
-      - name: Trigger the binary build for a release this workflow published
-        if: steps.publish-state.outputs.draft == 'false'
+      - name: Trigger the binary build against the drafted release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -201,10 +200,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          # release.yaml listens for `release: published`, but an event
-          # produced by the default GITHUB_TOKEN never cascades into another
-          # workflow run (GitHub's anti-recursion guard) -- only a human
-          # publishing through the UI triggers it that way. Dispatch it
-          # explicitly instead; an API-triggered workflow_dispatch is not
-          # subject to that restriction.
+          # Dispatched unconditionally, draft or not: softprops/action-gh-release
+          # finds a release by tag regardless of its draft state, so building
+          # here means the binaries are already attached by the time a human
+          # publishes the draft -- otherwise releases/latest/download/<asset>
+          # 404s for however long the matrix takes to finish after publish.
+          # release.yaml also still listens for `release: published`, as a
+          # safety net for a release created outside this workflow -- but an
+          # event produced by the default GITHUB_TOKEN (the draft step above)
+          # never cascades into another workflow run (GitHub's anti-recursion
+          # guard), so it would not have fired for this release anyway.
+          # Dispatch it explicitly instead; an API-triggered workflow_dispatch
+          # is not subject to that restriction.
           gh workflow run release.yaml --repo "$REPO" --field tag="$VERSION"

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -419,13 +419,14 @@ push red for a commit nobody can amend. A regular merge lands `main` exactly on
 — it already has every commit, unchanged. Once the release commit lands, the
 [Auto Release](../.github/workflows/auto-release.yaml) workflow tags it `X.Y.Z`,
 generates a `What's Changed` summary from the merged pull requests since the
-previous tag, and drafts the GitHub Release — publish it when ready, which
-triggers the binary-build workflow. Its `push` trigger only fires going forward,
-so it cannot cover a release commit that already landed on `main` before the
-workflow existed (or before the workflow's `if:` could match it); for that case,
-dispatch it manually with the `version` `workflow_dispatch` input — it always
-tags and diffs against `main`'s history regardless of which ref the dispatch
-itself runs from.
+previous tag, and drafts the GitHub Release, dispatching the binary-build
+workflow immediately against that draft — every binary is already attached by
+the time you publish it, so publishing is just a visibility flip, not a trigger.
+Its `push` trigger only fires going forward, so it cannot cover a release commit
+that already landed on `main` before the workflow existed (or before the
+workflow's `if:` could match it); for that case, dispatch it manually with the
+`version` `workflow_dispatch` input — it always tags and diffs against `main`'s
+history regardless of which ref the dispatch itself runs from.
 
 Because `main` is the default branch, a pull request opens against it by default
 even though almost nothing should land there directly. **Retarget the base** to


### PR DESCRIPTION
## Summary

Release binaries now build against the draft immediately, not after a human
publishes it — closing the window where `releases/latest/download/<asset>`
404s while the build matrix finishes post-publish. `release.yaml` still
listens for `release: published` as a safety net for releases created outside
this workflow. `docs/versioning.md` updated to match.

## Details

`auto-release.yaml` only dispatched the binary build when a release was
published immediately (`publish: true`). The normal path — draft, then
publish manually once the notes look right — never triggered a build until
the `release: published` webhook fired on manual publish. Now the dispatch is
unconditional: `softprops/action-gh-release` attaches assets by tag regardless
of draft state, so binaries are ready by the time a human publishes. No
behavior change for the `publish: true` path (already built immediately).

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] All checks pass: `bin/castor lint` (YAML validated locally; no PHP changed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

CI-only change — exempt from the changelog rule (no user-visible behavior/API change).
