### PR TITLE
feat: print copy-pasteable export line after init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Changed
+
+- **`init`'s success message now prints a copy-pasteable `export` line instead
+  of naming the variable in prose.** `InitCommand::__invoke()`
+  (`src/Command/InitCommand.php`) used to say `Export ANTHROPIC_API_KEY, then
+  run "audit <path>".`, leaving the user to know their shell's export syntax
+  and retype the variable name. It now prints `Run: export
+  ANTHROPIC_API_KEY=, then "audit <path>".`, a line that can be pasted as-is.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 - **`init`'s success message now prints a copy-pasteable `export` line instead
   of naming the variable in prose.** `InitCommand::__invoke()`
-  (`src/Command/InitCommand.php`) used to say `Export ANTHROPIC_API_KEY, then
-  run "audit <path>".`, leaving the user to know their shell's export syntax
-  and retype the variable name. It now prints `Run: export
-  ANTHROPIC_API_KEY=, then "audit <path>".`, a line that can be pasted as-is.
+  (`src/Command/InitCommand.php`) used to say
+  `Export ANTHROPIC_API_KEY, then run "audit <path>".`, leaving the user to know
+  their shell's export syntax and retype the variable name. It now prints
+  `Run: export ANTHROPIC_API_KEY=, then "audit <path>".`, a line that can be
+  pasted as-is.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -93,7 +93,7 @@ final readonly class InitCommand
         $this->bridgeInstaller->install($provider, $this->xdgConfigPathResolver->dataDir());
         $this->standaloneConfigWriter->write($configFile, $this->standaloneConfigFactory->create($provider, $model, $envVar));
 
-        $symfonyStyle->success(\sprintf('Configuration written to %s. Export %s, then run "audit <path>".', $configFile, $envVar));
+        $symfonyStyle->success(\sprintf('Configuration written to %s. Run: export %s=, then "audit <path>".', $configFile, $envVar));
 
         return Command::SUCCESS;
     }

--- a/tests/Phpunit/Integration/Command/InitCommandTest.php
+++ b/tests/Phpunit/Integration/Command/InitCommandTest.php
@@ -369,6 +369,16 @@ final class InitCommandTest extends TestCase
         self::assertStringContainsString('Configuration written to', $commandTester->getDisplay());
     }
 
+    public function test_it_prints_a_copy_pasteable_export_command_for_the_api_key_variable(): void
+    {
+        $commandTester = $this->commandTester();
+        $commandTester->setInputs(['openai', 'gpt-5.4', 'MY_CUSTOM_KEY']);
+
+        $commandTester->execute([]);
+
+        self::assertStringContainsString('export MY_CUSTOM_KEY=', $commandTester->getDisplay());
+    }
+
     public function test_it_treats_an_empty_answer_as_declining_the_overwrite(): void
     {
         (new Filesystem())->dumpFile($this->configFile(), "model: keep-me\n");


### PR DESCRIPTION
## Summary

`init`'s success message now prints `export ANTHROPIC_API_KEY=` verbatim instead of naming the variable in prose, so it can be pasted as-is instead of retyped.

Closes #311

## Type of change

- [x] New feature

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPStan, PHP CS Fixer, Deptrac, PHPUnit (100% coverage)
- [x] 100% MSI maintained: `bin/infection` (scoped to the touched file)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)