### PR TITLE
feat: use light lines for intermediate confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `AuditPresenter::dryRunResult()` (`src/Command/AuditPresenter.php`) used
   `SymfonyStyle::success()` for the files-in-scope count and the
   dry-run-complete message, so `--show-scanned --dry-run` printed two `[OK]`
-  boxes and a `[NOTE]` block within a few lines. Both now print a single light
-  `✅` line, matching the style the console report already uses for its own
-  success line — the boxed block is reserved for a command's true final
-  pass/fail outcome (`AuditPresenter::result()`).
+  boxes and a `[NOTE]` block within a few lines. Both now go through a shared
+  `lightConfirmation()` helper printing a single light line, matching the style
+  the console report already uses for its own success line — the boxed block is
+  reserved for a command's true final pass/fail outcome
+  (`AuditPresenter::result()`). The `✅` marker is gated on `isDecorated()`, so
+  a redirected or CI log gets the plain text without it, matching the pattern
+  the branded identity banner already uses; and the line keeps the trailing
+  blank line `success()` used to add, so it doesn't abut whatever prints next.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Changed
+
+- **`--show-scanned` and `--dry-run` no longer close with a heavy `[OK]` block
+  for an intermediate confirmation.** `AuditPresenter::scannedFiles()` and
+  `AuditPresenter::dryRunResult()` (`src/Command/AuditPresenter.php`) used
+  `SymfonyStyle::success()` for the files-in-scope count and the
+  dry-run-complete message, so `--show-scanned --dry-run` printed two `[OK]`
+  boxes and a `[NOTE]` block within a few lines. Both now print a single light
+  `✅` line, matching the style the console report already uses for its own
+  success line — the boxed block is reserved for a command's true final
+  pass/fail outcome (`AuditPresenter::result()`).
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -140,7 +140,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         }
 
         $symfonyStyle->note('Dry run — no LLM calls were made. This is a cost estimate only. It excludes provider prompt-cache discounts and warm attacker/reviewer caches, so a real run typically costs less than shown.');
-        $symfonyStyle->success('Dry run complete.');
+        $symfonyStyle->writeln('  ✅ Dry run complete.');
     }
 
     #[Override]
@@ -159,7 +159,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
             $symfonyStyle->listing(array_map($this->sanitizePathForListing(...), $relativePaths));
         }
 
-        $symfonyStyle->success(\sprintf('%d file(s) in scope.', \count($projectFiles)));
+        $symfonyStyle->writeln(\sprintf('  ✅ %d file(s) in scope.', \count($projectFiles)));
     }
 
     #[Override]

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -140,7 +140,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         }
 
         $symfonyStyle->note('Dry run — no LLM calls were made. This is a cost estimate only. It excludes provider prompt-cache discounts and warm attacker/reviewer caches, so a real run typically costs less than shown.');
-        $symfonyStyle->writeln('  ✅ Dry run complete.');
+        $this->lightConfirmation($symfonyStyle, 'Dry run complete.');
     }
 
     #[Override]
@@ -159,7 +159,20 @@ final readonly class AuditPresenter implements AuditPresenterInterface
             $symfonyStyle->listing(array_map($this->sanitizePathForListing(...), $relativePaths));
         }
 
-        $symfonyStyle->writeln(\sprintf('  ✅ %d file(s) in scope.', \count($projectFiles)));
+        $this->lightConfirmation($symfonyStyle, \sprintf('%d file(s) in scope.', \count($projectFiles)));
+    }
+
+    /**
+     * A lighter-weight replacement for `SymfonyStyle::success()` on
+     * intermediate confirmations — no boxed `[OK]` block, just a short line —
+     * but keeping its leading marker (gated on `isDecorated()`, since a
+     * redirected/CI log has no use for an emoji) and its trailing blank line,
+     * so it doesn't abut whatever prints next.
+     */
+    private function lightConfirmation(SymfonyStyle $symfonyStyle, string $message): void
+    {
+        $symfonyStyle->writeln(\sprintf($symfonyStyle->isDecorated() ? '  ✅ %s' : '  %s', $message));
+        $symfonyStyle->newLine();
     }
 
     #[Override]

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -312,7 +312,7 @@ final class AuditPresenterTest extends TestCase
      */
     public function test_dry_run_result_reports_completion_as_a_light_line_not_a_boxed_block(): void
     {
-        $bufferedOutput = new BufferedOutput();
+        $bufferedOutput = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
         $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
 
         $this->auditPresenter->dryRunResult($symfonyStyle, AuditReport::fromContext(AuditContext::forProject($this->tmpDir)));
@@ -320,6 +320,34 @@ final class AuditPresenterTest extends TestCase
         $display = $bufferedOutput->fetch();
         self::assertStringContainsString('✅ Dry run complete.', $display);
         self::assertStringNotContainsString('[OK]', $display);
+    }
+
+    /**
+     * @throws InvalidAuditContextException
+     */
+    public function test_dry_run_result_omits_the_emoji_when_not_decorated(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->dryRunResult($symfonyStyle, AuditReport::fromContext(AuditContext::forProject($this->tmpDir)));
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('Dry run complete.', $display);
+        self::assertStringNotContainsString('✅', $display);
+    }
+
+    /**
+     * @throws InvalidAuditContextException
+     */
+    public function test_dry_run_result_leaves_a_blank_line_after_the_completion_line(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->dryRunResult($symfonyStyle, AuditReport::fromContext(AuditContext::forProject($this->tmpDir)));
+
+        self::assertStringEndsWith("Dry run complete.\n\n", $bufferedOutput->fetch());
     }
 
     /**
@@ -452,7 +480,7 @@ final class AuditPresenterTest extends TestCase
      */
     public function test_scanned_files_reports_the_file_count_as_a_light_line_not_a_boxed_block(): void
     {
-        $bufferedOutput = new BufferedOutput();
+        $bufferedOutput = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
         $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
 
         $this->auditPresenter->scannedFiles($symfonyStyle, [
@@ -462,6 +490,38 @@ final class AuditPresenterTest extends TestCase
         $display = $bufferedOutput->fetch();
         self::assertStringContainsString('✅ 1 file(s) in scope.', $display);
         self::assertStringNotContainsString('[OK]', $display);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     */
+    public function test_scanned_files_omits_the_emoji_when_not_decorated(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->scannedFiles($symfonyStyle, [
+            ProjectFile::create('src/Controller/HomeController.php', '/p/src/Controller/HomeController.php', '<?php class HomeController {}'),
+        ]);
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('1 file(s) in scope.', $display);
+        self::assertStringNotContainsString('✅', $display);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     */
+    public function test_scanned_files_leaves_a_blank_line_after_the_file_count_line(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->scannedFiles($symfonyStyle, [
+            ProjectFile::create('src/Controller/HomeController.php', '/p/src/Controller/HomeController.php', '<?php class HomeController {}'),
+        ]);
+
+        self::assertStringEndsWith("1 file(s) in scope.\n\n", $bufferedOutput->fetch());
     }
 
     public function test_scanned_files_warns_when_nothing_matched(): void

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -309,6 +309,21 @@ final class AuditPresenterTest extends TestCase
 
     /**
      * @throws InvalidAuditContextException
+     */
+    public function test_dry_run_result_reports_completion_as_a_light_line_not_a_boxed_block(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->dryRunResult($symfonyStyle, AuditReport::fromContext(AuditContext::forProject($this->tmpDir)));
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('✅ Dry run complete.', $display);
+        self::assertStringNotContainsString('[OK]', $display);
+    }
+
+    /**
+     * @throws InvalidAuditContextException
      * @throws InvalidAuditCostException
      */
     public function test_dry_run_result_shows_cost_breakdown_when_cost_present(): void
@@ -430,6 +445,23 @@ final class AuditPresenterTest extends TestCase
         self::assertStringNotContainsString("\x1b", $output);
         self::assertStringNotContainsString("\u{202E}", $output);
         self::assertDoesNotMatchRegularExpression('/\n\s*\* \[CRITICAL] forged/', $output);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     */
+    public function test_scanned_files_reports_the_file_count_as_a_light_line_not_a_boxed_block(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->scannedFiles($symfonyStyle, [
+            ProjectFile::create('src/Controller/HomeController.php', '/p/src/Controller/HomeController.php', '<?php class HomeController {}'),
+        ]);
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('✅ 1 file(s) in scope.', $display);
+        self::assertStringNotContainsString('[OK]', $display);
     }
 
     public function test_scanned_files_warns_when_nothing_matched(): void


### PR DESCRIPTION
## Summary

`--show-scanned` and `--dry-run` each closed with their own heavy `[OK]` block, so `--show-scanned --dry-run` printed two boxes and a `[NOTE]` within a few lines. Both intermediate confirmations now print a single light `✅` line instead, matching the style the console report already uses. The boxed block stays reserved for a command's true final pass/fail outcome.

Closes #312

## Type of change

- [x] New feature

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPStan, PHP CS Fixer, Deptrac, PHPUnit (100% coverage)
- [x] 100% MSI maintained: `bin/infection` (scoped to the touched file)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)