### PR TITLE
feat: label and reorder the uncategorized php bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 ### Changed
 
 - **`--show-scanned`'s generic `php` bucket no longer reads as "every PHP
-  file."** `AuditPresenter::scannedFiles()`
-  (`src/Command/AuditPresenter.php`) printed the fallback `ProjectFileType::PHP`
-  bucket — the catch-all for `.php` files matching no specific archetype — as
-  a plain `php (N)` sibling of `entity`/`voter`/`event_subscriber`/etc., with
-  nothing marking it as the leftover bucket it is. It's now labeled
-  `php · uncategorized` and, along with `other`, always renders last, after
-  every specific archetype. Presentation only — `ProjectFileType::PHP`'s
-  backed value (`'php'`, used by `included_types`/`excluded_types` config) is
-  unchanged.
+  file."** `AuditPresenter::scannedFiles()` (`src/Command/AuditPresenter.php`)
+  printed the fallback `ProjectFileType::PHP` bucket — the catch-all for `.php`
+  files matching no specific archetype — as a plain `php (N)` sibling of
+  `entity`/`voter`/`event_subscriber`/etc., with nothing marking it as the
+  leftover bucket it is. It's now labeled `php · uncategorized` and, along with
+  `other`, always renders last, after every specific archetype. Presentation
+  only — `ProjectFileType::PHP`'s backed value (`'php'`, used by
+  `included_types`/`excluded_types` config) is unchanged.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Changed
+
+- **`--show-scanned`'s generic `php` bucket no longer reads as "every PHP
+  file."** `AuditPresenter::scannedFiles()`
+  (`src/Command/AuditPresenter.php`) printed the fallback `ProjectFileType::PHP`
+  bucket — the catch-all for `.php` files matching no specific archetype — as
+  a plain `php (N)` sibling of `entity`/`voter`/`event_subscriber`/etc., with
+  nothing marking it as the leftover bucket it is. It's now labeled
+  `php · uncategorized` and, along with `other`, always renders last, after
+  every specific archetype. Presentation only — `ProjectFileType::PHP`'s
+  backed value (`'php'`, used by `included_types`/`excluded_types` config) is
+  unchanged.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Changed
 
-- **`--show-scanned`'s generic `php` bucket no longer reads as "every PHP
-  file."** `AuditPresenter::scannedFiles()` (`src/Command/AuditPresenter.php`)
-  printed the fallback `ProjectFileType::PHP` bucket — the catch-all for `.php`
-  files matching no specific archetype — as a plain `php (N)` sibling of
-  `entity`/`voter`/`event_subscriber`/etc., with nothing marking it as the
-  leftover bucket it is. It's now labeled `php · uncategorized` and, along with
-  `other`, always renders last, after every specific archetype. Presentation
-  only — `ProjectFileType::PHP`'s backed value (`'php'`, used by
-  `included_types`/`excluded_types` config) is unchanged.
+- **`--show-scanned`'s generic `php` and `other` buckets no longer read as
+  "every PHP file"/"every other file."** `AuditPresenter::scannedFiles()`
+  (`src/Command/AuditPresenter.php`) printed the fallback `ProjectFileType::PHP`
+  and `::OTHER` buckets — the catch-all for files matching no specific archetype
+  — as plain `php (N)`/`other (N)` siblings of
+  `entity`/`voter`/`event_subscriber`/etc., with nothing marking them as the
+  leftover buckets they are. Both are now labeled `php · uncategorized`/
+  `other · uncategorized` and always render last, after every specific
+  archetype. Presentation only — the underlying `ProjectFileType` backed values
+  (`'php'`/`'other'`, used by `included_types`/`excluded_types` config) are
+  unchanged.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -201,12 +201,6 @@ final readonly class AuditPresenter implements AuditPresenterInterface
     }
 
     /**
-     * `ProjectFileType::PHP`/`::OTHER` are the fallback buckets a file lands
-     * in only when nothing more specific matched, so — unlike `controller`,
-     * `voter`, etc. — they read as "every PHP file" if they appear as just
-     * another sibling in scan order. Moving them after every specific
-     * archetype marks them as the leftovers they are.
-     *
      * @param array<string, list<string>> $byType
      *
      * @return array<string, list<string>>
@@ -226,7 +220,11 @@ final readonly class AuditPresenter implements AuditPresenterInterface
 
     private function bucketLabel(string $type): string
     {
-        return ProjectFileType::PHP->value === $type ? 'php · uncategorized' : $type;
+        return match ($type) {
+            ProjectFileType::PHP->value => 'php · uncategorized',
+            ProjectFileType::OTHER->value => 'other · uncategorized',
+            default => $type,
+        };
     }
 
     #[Override]

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -22,6 +22,7 @@ use Throwable;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditCost;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\AuditReport;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFile;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model\ProjectFileType;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\PricingProviderInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\TerminalTextSanitizer;
 
@@ -155,7 +156,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         $symfonyStyle->section(\sprintf('Scanned files (%d)', \count($projectFiles)));
 
         foreach ($this->relativePathsByType($projectFiles) as $type => $relativePaths) {
-            $symfonyStyle->writeln(\sprintf(' <info>%s</info> (%d)', $type, \count($relativePaths)));
+            $symfonyStyle->writeln(\sprintf(' <info>%s</info> (%d)', $this->bucketLabel($type), \count($relativePaths)));
             $symfonyStyle->listing(array_map($this->sanitizePathForListing(...), $relativePaths));
         }
 
@@ -196,7 +197,36 @@ final readonly class AuditPresenter implements AuditPresenterInterface
             $byType[$projectFile->type()][] = $projectFile->relativePath();
         }
 
-        return $byType;
+        return $this->withUncategorizedBucketsLast($byType);
+    }
+
+    /**
+     * `ProjectFileType::PHP`/`::OTHER` are the fallback buckets a file lands
+     * in only when nothing more specific matched, so — unlike `controller`,
+     * `voter`, etc. — they read as "every PHP file" if they appear as just
+     * another sibling in scan order. Moving them after every specific
+     * archetype marks them as the leftovers they are.
+     *
+     * @param array<string, list<string>> $byType
+     *
+     * @return array<string, list<string>>
+     */
+    private function withUncategorizedBucketsLast(array $byType): array
+    {
+        $trailing = [];
+        foreach ([ProjectFileType::PHP->value, ProjectFileType::OTHER->value] as $trailingType) {
+            if (\array_key_exists($trailingType, $byType)) {
+                $trailing[$trailingType] = $byType[$trailingType];
+                unset($byType[$trailingType]);
+            }
+        }
+
+        return $byType + $trailing;
+    }
+
+    private function bucketLabel(string $type): string
+    {
+        return ProjectFileType::PHP->value === $type ? 'php · uncategorized' : $type;
     }
 
     #[Override]

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -418,6 +418,22 @@ final class AuditPresenterTest extends TestCase
     /**
      * @throws InvalidProjectFileException
      */
+    public function test_scanned_files_labels_the_generic_other_bucket_as_uncategorized(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->scannedFiles($symfonyStyle, [
+            ProjectFile::create('README.md', '/p/README.md', '# readme'),
+        ]);
+
+        $flattened = preg_replace('/\s+/', ' ', $bufferedOutput->fetch()) ?? '';
+        self::assertStringContainsString('other · uncategorized (1)', $flattened);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     */
     public function test_scanned_files_renders_the_uncategorized_php_and_other_buckets_last(): void
     {
         $bufferedOutput = new BufferedOutput();
@@ -432,7 +448,7 @@ final class AuditPresenterTest extends TestCase
         $flattened = $bufferedOutput->fetch();
         $controllerPosition = mb_strpos($flattened, 'controller (1)');
         $phpPosition = mb_strpos($flattened, 'php · uncategorized (1)');
-        $otherPosition = mb_strpos($flattened, 'other (1)');
+        $otherPosition = mb_strpos($flattened, 'other · uncategorized (1)');
 
         self::assertIsInt($controllerPosition);
         self::assertIsInt($phpPosition);

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -402,6 +402,48 @@ final class AuditPresenterTest extends TestCase
     /**
      * @throws InvalidProjectFileException
      */
+    public function test_scanned_files_labels_the_generic_php_bucket_as_uncategorized(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->scannedFiles($symfonyStyle, [
+            ProjectFile::create('src/Utility/Helper.php', '/p/src/Utility/Helper.php', '<?php class Helper {}'),
+        ]);
+
+        $flattened = preg_replace('/\s+/', ' ', $bufferedOutput->fetch()) ?? '';
+        self::assertStringContainsString('php · uncategorized (1)', $flattened);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     */
+    public function test_scanned_files_renders_the_uncategorized_php_and_other_buckets_last(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->scannedFiles($symfonyStyle, [
+            ProjectFile::create('src/Utility/Helper.php', '/p/src/Utility/Helper.php', '<?php class Helper {}'),
+            ProjectFile::create('README.md', '/p/README.md', '# readme'),
+            ProjectFile::create('src/Controller/HomeController.php', '/p/src/Controller/HomeController.php', '<?php class HomeController {}'),
+        ]);
+
+        $flattened = $bufferedOutput->fetch();
+        $controllerPosition = mb_strpos($flattened, 'controller (1)');
+        $phpPosition = mb_strpos($flattened, 'php · uncategorized (1)');
+        $otherPosition = mb_strpos($flattened, 'other (1)');
+
+        self::assertIsInt($controllerPosition);
+        self::assertIsInt($phpPosition);
+        self::assertIsInt($otherPosition);
+        self::assertLessThan($phpPosition, $controllerPosition);
+        self::assertLessThan($otherPosition, $phpPosition);
+    }
+
+    /**
+     * @throws InvalidProjectFileException
+     */
     public function test_scanned_files_does_not_render_a_crafted_file_path_as_console_markup(): void
     {
         $bufferedOutput = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);


### PR DESCRIPTION
## Summary

`--show-scanned`'s generic `php` bucket printed as a plain sibling of `entity`/`voter`/`event_subscriber`, reading as if it meant "every PHP file." It's now labeled `php · uncategorized` and, along with `other`, always renders last. Presentation only — `ProjectFileType::PHP`'s backed value is unchanged.

Closes #313

## Type of change

- [x] New feature

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPStan, PHP CS Fixer, Deptrac, PHPUnit (100% coverage)
- [x] 100% MSI maintained: `bin/infection` (scoped to the touched file)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)