### PR TITLE
feat(command): brand the CLI header, portably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Added
+
+- **The CLI now shows a branded identity banner instead of a plain
+  underlined header.** `AuditPresenter::header()`
+  (`src/Command/AuditPresenter.php`) used to print
+  `$symfonyStyle->title('Symfony LLM Security Auditor')` — a plain line with
+  no visual identity. On a decorated (color-capable) terminal it now prints a
+  small banner combining a circular glyph with the wordmark, colored with the
+  pink/navy palette sampled from `assets/banner.webp` (`#e71c55`/`#242d5c`).
+  Non-decorated output (CI, redirected output, `NO_COLOR`) keeps the original
+  plain title line.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,11 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
-- **The CLI now shows a branded identity banner instead of a plain
-  underlined header.** `AuditPresenter::header()`
-  (`src/Command/AuditPresenter.php`) used to print
-  `$symfonyStyle->title('Symfony LLM Security Auditor')` — a plain line with
-  no visual identity. On a decorated (color-capable) terminal it now prints a
-  small banner combining a circular glyph with the wordmark, colored with the
+- **The CLI now shows a branded identity banner instead of a plain underlined
+  header.** `AuditPresenter::header()` (`src/Command/AuditPresenter.php`) used
+  to print `$symfonyStyle->title('Symfony LLM Security Auditor')` — a plain line
+  with no visual identity. On a decorated (color-capable) terminal it now prints
+  a small banner combining a circular glyph with the wordmark, colored with the
   pink/navy palette sampled from `assets/banner.webp` (`#e71c55`/`#242d5c`).
   Non-decorated output (CI, redirected output, `NO_COLOR`) keeps the original
   plain title line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,26 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
-- **The CLI now shows a branded identity banner instead of a plain underlined
-  header.** `AuditPresenter::header()` (`src/Command/AuditPresenter.php`) used
-  to print `$symfonyStyle->title('Symfony LLM Security Auditor')` — a plain line
-  with no visual identity. On a decorated (color-capable) terminal it now prints
-  a small banner combining a circular glyph with the wordmark, colored with the
-  pink/navy palette sampled from `assets/banner.webp` (`#e71c55`/`#5b6fd6`) and
-  underlined to the wordmark's own width rather than a fixed column count.
-  Non-decorated output (CI, redirected output, `NO_COLOR`) keeps the original
-  plain title line. The navy is brightened from the `#242d5c` sampled off the
-  banner image — that value sits on the image's light background, but as
-  terminal foreground text it degrades toward black on a 16-colour palette and
-  disappears on the dark background most terminals default to.
+- **The CLI header now carries the project's identity, and renders the same way
+  everywhere.** `AuditPresenter::header()` (`src/Command/AuditPresenter.php`)
+  printed `$symfonyStyle->title('Symfony LLM Security Auditor')` — a plain
+  underlined line with no visual identity. It now prints `◉ >> SECURITY AUDITOR`
+  with the mark and `SECURITY` in the logo's pink (`#e71c55`) and `AUDITOR` in
+  its navy (`#5b6fd6`), over a `Symfony - multi-agent LLM audit` tagline whose
+  indent is derived from the lead string rather than hardcoded, so it always
+  starts under the wordmark.
+
+  Colour is the only thing that varies by terminal. A single `writeln()`
+  produces every state, because `OutputFormatter` strips the style tags when the
+  output is not decorated — so a CI log shows the identical layout rather than a
+  different header, instead of the previous `title()` fallback.
+
+  `◉` (U+25C9) is outside CP437, CP850 and CP1252, so a console left on a legacy
+  code page would substitute it. `AuditPresenter::scanMark()` drops the mark
+  unless `LC_ALL`, `LC_CTYPE` or `LANG` announces UTF-8, leaving the coloured
+  wordmark, which carries the identity on its own. A Windows console sets none
+  of those unless the shell is UTF-8 aware, so it lands on the ASCII wordmark.
+  Every other character in the header is ASCII.
 
 ### Changed
 
@@ -37,6 +45,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **The pipeline line printed two characters a Windows console cannot show.**
+  `AuditPresenter::header()` emitted
+  `Pipeline: Ingestion → Mapping → Audit (Attacker ⚔ Reviewer)`. `→` (U+2192)
+  and `⚔` (U+2694) are both outside CP437/CP850/CP1252, and `⚔` is frequently
+  rendered double-width, which shifts every column after it. The line now reads
+  `Pipeline: Ingestion -> Mapping -> Audit (Attacker vs Reviewer)`.
 - **`self-update` could corrupt the installed binary and leave no readable error
   behind.** `SelfUpdater::assertChecksumMatches()`
   (`src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php`) guarded a failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   to print `$symfonyStyle->title('Symfony LLM Security Auditor')` — a plain line
   with no visual identity. On a decorated (color-capable) terminal it now prints
   a small banner combining a circular glyph with the wordmark, colored with the
-  pink/navy palette sampled from `assets/banner.webp` (`#e71c55`/`#242d5c`).
+  pink/navy palette sampled from `assets/banner.webp` (`#e71c55`/`#5b6fd6`) and
+  underlined to the wordmark's own width rather than a fixed column count.
   Non-decorated output (CI, redirected output, `NO_COLOR`) keeps the original
-  plain title line.
+  plain title line. The navy is brightened from the `#242d5c` sampled off the
+  banner image — that value sits on the image's light background, but as
+  terminal foreground text it degrades toward black on a 16-colour palette and
+  disappears on the dark background most terminals default to.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -73,6 +73,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
         $ruleWidth = mb_strlen(self::BANNER_GLYPH) + 1 + mb_strlen(self::WORDMARK);
 
         $symfonyStyle->writeln([
+            '',
             \sprintf('<fg=%s>%s</> <fg=%s;options=bold>%s</>', self::BANNER_PINK, self::BANNER_GLYPH, self::BANNER_NAVY, self::WORDMARK),
             \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', $ruleWidth)),
             '',

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -28,9 +28,15 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\TerminalTex
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditPresenter implements AuditPresenterInterface
 {
-    private const string WORDMARK = 'Symfony LLM Security Auditor';
+    private const string SCAN_MARK = '◉ >>';
 
-    private const string BANNER_GLYPH = '◉';
+    private const string SCAN_MARK_PORTABLE = '';
+
+    private const string WORDMARK_LEAD = 'SECURITY';
+
+    private const string WORDMARK_TAIL = 'AUDITOR';
+
+    private const string TAGLINE = 'Symfony - multi-agent LLM audit';
 
     /** Sampled from the circular bug glyph in `assets/banner.webp`. */
     private const string BANNER_PINK = '#e71c55';
@@ -52,32 +58,71 @@ final readonly class AuditPresenter implements AuditPresenterInterface
 
         $symfonyStyle->text([
             \sprintf('Project: <info>%s</info>', OutputFormatter::escape($projectPath)),
-            'Pipeline: Ingestion → Mapping → Audit (Attacker ⚔ Reviewer)',
+            'Pipeline: Ingestion -> Mapping -> Audit (Attacker vs Reviewer)',
             '',
         ]);
     }
 
+    /**
+     * One code path for both terminal states: `OutputFormatter` drops the
+     * style tags when the output is not decorated, so CI logs and a colour
+     * terminal show the same layout rather than two different headers. Every
+     * character is ASCII, so a Windows console on a legacy code page renders
+     * it without substitution and without the double-width cells that break
+     * column alignment.
+     */
     private function wordmark(SymfonyStyle $symfonyStyle): void
     {
-        if ($symfonyStyle->isDecorated()) {
-            $this->identityBanner($symfonyStyle);
-
-            return;
-        }
-
-        $symfonyStyle->title(self::WORDMARK);
-    }
-
-    private function identityBanner(SymfonyStyle $symfonyStyle): void
-    {
-        $wordmarkLine = \sprintf('%s %s', self::BANNER_GLYPH, self::WORDMARK);
+        $scanMark = $this->scanMark();
+        $lead = '' === $scanMark ? self::WORDMARK_LEAD : \sprintf('%s %s', $scanMark, self::WORDMARK_LEAD);
 
         $symfonyStyle->writeln([
             '',
-            \sprintf('<fg=%s>%s</> <fg=%s;options=bold>%s</>', self::BANNER_PINK, self::BANNER_GLYPH, self::BANNER_NAVY, self::WORDMARK),
-            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', mb_strlen($wordmarkLine))),
+            \sprintf(
+                ' <fg=%s;options=bold>%s</> <fg=%s;options=bold>%s</>',
+                self::BANNER_PINK,
+                $lead,
+                self::BANNER_NAVY,
+                self::WORDMARK_TAIL,
+            ),
+            \sprintf(' %s%s', str_repeat(' ', mb_strlen($lead) - mb_strlen(self::WORDMARK_LEAD)), self::TAGLINE),
             '',
         ]);
+    }
+
+    /**
+     * `◉` is outside CP437/CP850/CP1252, so a console on a legacy code page
+     * substitutes it. Dropping the mark there keeps the colour and the
+     * wordmark, which carry the identity on their own.
+     */
+    private function scanMark(): string
+    {
+        return $this->consoleRendersUtf8() ? self::SCAN_MARK : self::SCAN_MARK_PORTABLE;
+    }
+
+    /**
+     * The locale variables are the portable signal, and a Windows console
+     * sets none of them unless the shell is UTF-8 aware — so Windows lands on
+     * the ASCII wordmark without this needing a platform branch, which could
+     * only ever be exercised on one platform's CI leg.
+     */
+    private function consoleRendersUtf8(): bool
+    {
+        $locale = strtoupper($this->localeSetting());
+
+        return str_contains($locale, 'UTF-8') || str_contains($locale, 'UTF8');
+    }
+
+    private function localeSetting(): string
+    {
+        foreach (['LC_ALL', 'LC_CTYPE', 'LANG'] as $variable) {
+            $value = getenv($variable);
+            if (\is_string($value) && '' !== $value) {
+                return $value;
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -33,8 +33,13 @@ final readonly class AuditPresenter implements AuditPresenterInterface
     /** Sampled from the circular bug glyph in `assets/banner.webp`. */
     private const string BANNER_PINK = '#e71c55';
 
-    /** Sampled from the wordmark in `assets/banner.webp`. */
-    private const string BANNER_NAVY = '#242d5c';
+    /**
+     * Brightened from the wordmark's `#242d5c` in `assets/banner.webp` — that
+     * navy sits on the banner image's light background, but as terminal
+     * foreground text it degrades toward black on a 16-colour palette and
+     * disappears on the dark background most terminals default to.
+     */
+    private const string BANNER_NAVY = '#5b6fd6';
 
     public function __construct(private PricingProviderInterface $pricingProvider) {}
 
@@ -65,7 +70,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
     {
         $symfonyStyle->writeln([
             \sprintf('<fg=%s>◉</> <fg=%s;options=bold>%s</>', self::BANNER_PINK, self::BANNER_NAVY, self::WORDMARK),
-            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', 70)),
+            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', \strlen(self::WORDMARK))),
             '',
         ]);
     }

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -28,15 +28,44 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\TerminalTex
 /** @internal not part of the BC promise — see docs/versioning.md */
 final readonly class AuditPresenter implements AuditPresenterInterface
 {
+    private const string WORDMARK = 'Symfony LLM Security Auditor';
+
+    /** Sampled from the circular bug glyph in `assets/banner.webp`. */
+    private const string BANNER_PINK = '#e71c55';
+
+    /** Sampled from the wordmark in `assets/banner.webp`. */
+    private const string BANNER_NAVY = '#242d5c';
+
     public function __construct(private PricingProviderInterface $pricingProvider) {}
 
     #[Override]
     public function header(SymfonyStyle $symfonyStyle, string $projectPath): void
     {
-        $symfonyStyle->title('Symfony LLM Security Auditor');
+        $this->wordmark($symfonyStyle);
+
         $symfonyStyle->text([
             \sprintf('Project: <info>%s</info>', OutputFormatter::escape($projectPath)),
             'Pipeline: Ingestion → Mapping → Audit (Attacker ⚔ Reviewer)',
+            '',
+        ]);
+    }
+
+    private function wordmark(SymfonyStyle $symfonyStyle): void
+    {
+        if ($symfonyStyle->isDecorated()) {
+            $this->identityBanner($symfonyStyle);
+
+            return;
+        }
+
+        $symfonyStyle->title(self::WORDMARK);
+    }
+
+    private function identityBanner(SymfonyStyle $symfonyStyle): void
+    {
+        $symfonyStyle->writeln([
+            \sprintf('<fg=%s>◉</> <fg=%s;options=bold>%s</>', self::BANNER_PINK, self::BANNER_NAVY, self::WORDMARK),
+            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', 70)),
             '',
         ]);
     }

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -70,12 +70,12 @@ final readonly class AuditPresenter implements AuditPresenterInterface
 
     private function identityBanner(SymfonyStyle $symfonyStyle): void
     {
-        $ruleWidth = mb_strlen(self::BANNER_GLYPH) + 1 + mb_strlen(self::WORDMARK);
+        $wordmarkLine = \sprintf('%s %s', self::BANNER_GLYPH, self::WORDMARK);
 
         $symfonyStyle->writeln([
             '',
             \sprintf('<fg=%s>%s</> <fg=%s;options=bold>%s</>', self::BANNER_PINK, self::BANNER_GLYPH, self::BANNER_NAVY, self::WORDMARK),
-            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', $ruleWidth)),
+            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', mb_strlen($wordmarkLine))),
             '',
         ]);
     }

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -74,18 +74,19 @@ final readonly class AuditPresenter implements AuditPresenterInterface
     private function wordmark(SymfonyStyle $symfonyStyle): void
     {
         $scanMark = $this->scanMark();
-        $lead = '' === $scanMark ? self::WORDMARK_LEAD : \sprintf('%s %s', $scanMark, self::WORDMARK_LEAD);
+        $markedLead = '' === $scanMark ? '' : \sprintf('%s ', $scanMark);
 
         $symfonyStyle->writeln([
             '',
             \sprintf(
-                ' <fg=%s;options=bold>%s</> <fg=%s;options=bold>%s</>',
+                ' <fg=%s;options=bold>%s%s</> <fg=%s;options=bold>%s</>',
                 self::BANNER_PINK,
-                $lead,
+                $markedLead,
+                self::WORDMARK_LEAD,
                 self::BANNER_NAVY,
                 self::WORDMARK_TAIL,
             ),
-            \sprintf(' %s%s', str_repeat(' ', mb_strlen($lead) - mb_strlen(self::WORDMARK_LEAD)), self::TAGLINE),
+            \sprintf(' %s%s', str_repeat(' ', mb_strlen($markedLead)), self::TAGLINE),
             '',
         ]);
     }

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -70,7 +70,7 @@ final readonly class AuditPresenter implements AuditPresenterInterface
     {
         $symfonyStyle->writeln([
             \sprintf('<fg=%s>◉</> <fg=%s;options=bold>%s</>', self::BANNER_PINK, self::BANNER_NAVY, self::WORDMARK),
-            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', \strlen(self::WORDMARK))),
+            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', mb_strlen(\sprintf('◉ %s', self::WORDMARK)))),
             '',
         ]);
     }

--- a/src/Command/AuditPresenter.php
+++ b/src/Command/AuditPresenter.php
@@ -30,6 +30,8 @@ final readonly class AuditPresenter implements AuditPresenterInterface
 {
     private const string WORDMARK = 'Symfony LLM Security Auditor';
 
+    private const string BANNER_GLYPH = '◉';
+
     /** Sampled from the circular bug glyph in `assets/banner.webp`. */
     private const string BANNER_PINK = '#e71c55';
 
@@ -68,9 +70,11 @@ final readonly class AuditPresenter implements AuditPresenterInterface
 
     private function identityBanner(SymfonyStyle $symfonyStyle): void
     {
+        $ruleWidth = mb_strlen(self::BANNER_GLYPH) + 1 + mb_strlen(self::WORDMARK);
+
         $symfonyStyle->writeln([
-            \sprintf('<fg=%s>◉</> <fg=%s;options=bold>%s</>', self::BANNER_PINK, self::BANNER_NAVY, self::WORDMARK),
-            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', mb_strlen(\sprintf('◉ %s', self::WORDMARK)))),
+            \sprintf('<fg=%s>%s</> <fg=%s;options=bold>%s</>', self::BANNER_PINK, self::BANNER_GLYPH, self::BANNER_NAVY, self::WORDMARK),
+            \sprintf('<fg=%s>%s</>', self::BANNER_PINK, str_repeat('─', $ruleWidth)),
             '',
         ]);
     }

--- a/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/AuditCommandEndToEndTest.php
@@ -660,7 +660,7 @@ final class AuditCommandEndToEndTest extends TestCase
         $commandTester->execute(['project-path' => $this->fixtureDir]);
 
         $output = $commandTester->getDisplay();
-        self::assertStringContainsString('Symfony LLM Security Auditor', $output);
+        self::assertStringContainsString('SECURITY AUDITOR', $output);
         self::assertStringContainsString('Pipeline:', $output);
     }
 

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -143,7 +143,7 @@ final class AuditPresenterTest extends TestCase
         $outputFormatter = $bufferedOutput->getFormatter();
         self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#e71c55>◉</>'), $display);
         self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#5b6fd6;options=bold>Symfony LLM Security Auditor</>'), $display);
-        self::assertStringContainsString($this->formatted($outputFormatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', \strlen('Symfony LLM Security Auditor')))), $display);
+        self::assertStringContainsString($this->formatted($outputFormatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', mb_strlen('◉ Symfony LLM Security Auditor')))), $display);
         self::assertSame(1, substr_count($display, 'Symfony LLM Security Auditor'), 'the plain title() fallback must not also run once the banner has printed');
     }
 

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -142,8 +142,8 @@ final class AuditPresenterTest extends TestCase
         $display = $bufferedOutput->fetch();
         $outputFormatter = $bufferedOutput->getFormatter();
         self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#e71c55>◉</>'), $display);
-        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#242d5c;options=bold>Symfony LLM Security Auditor</>'), $display);
-        self::assertStringContainsString($this->formatted($outputFormatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', 70))), $display);
+        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#5b6fd6;options=bold>Symfony LLM Security Auditor</>'), $display);
+        self::assertStringContainsString($this->formatted($outputFormatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', \strlen('Symfony LLM Security Auditor')))), $display);
         self::assertSame(1, substr_count($display, 'Symfony LLM Security Auditor'), 'the plain title() fallback must not also run once the banner has printed');
     }
 

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Command;
 
 use InvalidArgumentException;
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
@@ -120,32 +121,82 @@ final class AuditPresenterTest extends TestCase
         self::assertStringContainsString('/var/www/<fg=grey>oops</>', $display);
     }
 
-    public function test_header_falls_back_to_the_plain_title_when_not_decorated(): void
+    public function test_header_shows_the_mark_and_wordmark_in_the_brand_palette_when_decorated(): void
     {
-        $bufferedOutput = new BufferedOutput();
-        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+        $display = $this->headerIn('en_US.UTF-8', true);
+        $outputFormatter = (new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true))->getFormatter();
 
-        $this->auditPresenter->header($symfonyStyle, '/path/to/project');
-
-        $display = $bufferedOutput->fetch();
-        self::assertStringContainsString('Symfony LLM Security Auditor', $display);
-        self::assertStringNotContainsString('◉', $display);
+        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#e71c55;options=bold>◉ >> SECURITY</>'), $display);
+        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#5b6fd6;options=bold>AUDITOR</>'), $display);
+        self::assertStringStartsWith(\PHP_EOL, $display, 'the header must not abut whatever printed before it');
     }
 
-    public function test_header_shows_a_branded_banner_when_decorated(): void
+    public function test_header_keeps_the_same_layout_without_colour_when_not_decorated(): void
     {
-        $bufferedOutput = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
-        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+        $display = $this->headerIn('en_US.UTF-8', false);
 
-        $this->auditPresenter->header($symfonyStyle, '/path/to/project');
+        self::assertStringContainsString(' ◉ >> SECURITY AUDITOR', $display);
+        self::assertStringContainsString('Symfony - multi-agent LLM audit', $display);
+        self::assertStringNotContainsString("\033[", $display, 'CI output must carry no escape sequences');
+    }
 
-        $display = $bufferedOutput->fetch();
-        $outputFormatter = $bufferedOutput->getFormatter();
-        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#e71c55>◉</>'), $display);
-        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#5b6fd6;options=bold>Symfony LLM Security Auditor</>'), $display);
-        self::assertStringContainsString($this->formatted($outputFormatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', mb_strlen('◉ Symfony LLM Security Auditor')))), $display);
-        self::assertSame(1, substr_count($display, 'Symfony LLM Security Auditor'), 'the plain title() fallback must not also run once the banner has printed');
-        self::assertStringStartsWith(\PHP_EOL, $display, 'SymfonyStyle::title() opens with a blank line; the banner path must not abut whatever printed before it');
+    public function test_the_tagline_starts_under_the_wordmark_not_under_the_mark(): void
+    {
+        $lines = explode(\PHP_EOL, $this->headerIn('en_US.UTF-8', false));
+
+        self::assertSame(
+            mb_strpos($lines[1], 'SECURITY'),
+            mb_strpos($lines[2], 'Symfony'),
+            'the tagline offset is derived from the lead string, so it tracks the mark width',
+        );
+    }
+
+    public function test_a_console_without_utf8_drops_the_mark_and_keeps_the_wordmark(): void
+    {
+        $display = $this->headerIn('C', false);
+
+        self::assertStringNotContainsString('◉', $display, 'the mark is outside CP437/CP850/CP1252 and would be substituted');
+        self::assertStringContainsString(' SECURITY AUDITOR', $display);
+        self::assertStringContainsString('Symfony - multi-agent LLM audit', $display);
+    }
+
+    public function test_a_console_without_utf8_still_gets_the_brand_palette(): void
+    {
+        $display = $this->headerIn('C', true);
+        $outputFormatter = (new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true))->getFormatter();
+
+        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#e71c55;options=bold>SECURITY</>'), $display);
+        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#5b6fd6;options=bold>AUDITOR</>'), $display);
+    }
+
+    #[DataProvider('consoleModes')]
+    public function test_the_header_is_pure_ascii_without_utf8_support(bool $decorated): void
+    {
+        $withoutEscapes = (string) preg_replace('/\033\[[0-9;]*m/', '', $this->headerIn('C', $decorated));
+
+        self::assertSame(1, preg_match('/^[\x00-\x7F]*$/', $withoutEscapes));
+    }
+
+    /** @return iterable<string, array{bool}> */
+    public static function consoleModes(): iterable
+    {
+        yield 'decorated' => [true];
+        yield 'plain' => [false];
+    }
+
+    private function headerIn(string $locale, bool $decorated): string
+    {
+        $previous = getenv('LC_ALL');
+        putenv(\sprintf('LC_ALL=%s', $locale));
+
+        try {
+            $bufferedOutput = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, $decorated);
+            $this->auditPresenter->header(new SymfonyStyle(new StringInput(''), $bufferedOutput), '/path/to/project');
+
+            return $bufferedOutput->fetch();
+        } finally {
+            putenv(false === $previous ? 'LC_ALL' : \sprintf('LC_ALL=%s', $previous));
+        }
     }
 
     private function formatted(OutputFormatterInterface $outputFormatter, string $tag): string

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -123,7 +123,7 @@ final class AuditPresenterTest extends TestCase
 
     public function test_header_shows_the_mark_and_wordmark_in_the_brand_palette_when_decorated(): void
     {
-        $display = $this->headerIn('en_US.UTF-8', true);
+        $display = $this->headerIn(['LC_ALL' => 'en_US.UTF-8'], true);
         $outputFormatter = (new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true))->getFormatter();
 
         self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#e71c55;options=bold>◉ >> SECURITY</>'), $display);
@@ -133,7 +133,7 @@ final class AuditPresenterTest extends TestCase
 
     public function test_header_keeps_the_same_layout_without_colour_when_not_decorated(): void
     {
-        $display = $this->headerIn('en_US.UTF-8', false);
+        $display = $this->headerIn(['LC_ALL' => 'en_US.UTF-8'], false);
 
         self::assertStringContainsString(' ◉ >> SECURITY AUDITOR', $display);
         self::assertStringContainsString('Symfony - multi-agent LLM audit', $display);
@@ -142,7 +142,7 @@ final class AuditPresenterTest extends TestCase
 
     public function test_the_tagline_starts_under_the_wordmark_not_under_the_mark(): void
     {
-        $lines = explode(\PHP_EOL, $this->headerIn('en_US.UTF-8', false));
+        $lines = explode(\PHP_EOL, $this->headerIn(['LC_ALL' => 'en_US.UTF-8'], false));
 
         self::assertSame(
             mb_strpos($lines[1], 'SECURITY'),
@@ -153,7 +153,7 @@ final class AuditPresenterTest extends TestCase
 
     public function test_a_console_without_utf8_drops_the_mark_and_keeps_the_wordmark(): void
     {
-        $display = $this->headerIn('C', false);
+        $display = $this->headerIn(['LC_ALL' => 'C'], false);
 
         self::assertStringNotContainsString('◉', $display, 'the mark is outside CP437/CP850/CP1252 and would be substituted');
         self::assertStringContainsString(' SECURITY AUDITOR', $display);
@@ -162,16 +162,35 @@ final class AuditPresenterTest extends TestCase
 
     public function test_a_console_without_utf8_still_gets_the_brand_palette(): void
     {
-        $display = $this->headerIn('C', true);
+        $display = $this->headerIn(['LC_ALL' => 'C'], true);
         $outputFormatter = (new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true))->getFormatter();
 
         self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#e71c55;options=bold>SECURITY</>'), $display);
         self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#5b6fd6;options=bold>AUDITOR</>'), $display);
     }
 
+    /**
+     * @param array<string, string> $locale
+     */
+    #[DataProvider('utf8Announcements')]
+    public function test_any_locale_variable_announcing_utf8_earns_the_mark(array $locale): void
+    {
+        self::assertStringContainsString('◉', $this->headerIn($locale, false));
+    }
+
+    /** @return iterable<string, array{array<string, string>}> */
+    public static function utf8Announcements(): iterable
+    {
+        yield 'LC_ALL' => [['LC_ALL' => 'en_US.UTF-8']];
+        yield 'LC_CTYPE only' => [['LC_CTYPE' => 'en_US.UTF-8']];
+        yield 'LANG only' => [['LANG' => 'en_US.UTF-8']];
+        yield 'lowercase spelling' => [['LANG' => 'en_us.utf-8']];
+        yield 'unhyphenated spelling' => [['LANG' => 'en_US.utf8']];
+    }
+
     public function test_a_console_that_announces_no_locale_at_all_drops_the_mark(): void
     {
-        $display = $this->headerIn(null, false);
+        $display = $this->headerIn([], false);
 
         self::assertStringNotContainsString('◉', $display);
         self::assertStringContainsString(' SECURITY AUDITOR', $display);
@@ -180,7 +199,7 @@ final class AuditPresenterTest extends TestCase
     #[DataProvider('consoleModes')]
     public function test_the_header_is_pure_ascii_without_utf8_support(bool $decorated): void
     {
-        $withoutEscapes = (string) preg_replace('/\033\[[0-9;]*m/', '', $this->headerIn('C', $decorated));
+        $withoutEscapes = (string) preg_replace('/\033\[[0-9;]*m/', '', $this->headerIn(['LC_ALL' => 'C'], $decorated));
 
         self::assertMatchesRegularExpression('/^[\x00-\x7F]*$/', $withoutEscapes);
     }
@@ -193,18 +212,21 @@ final class AuditPresenterTest extends TestCase
     }
 
     /**
-     * All three variables are pinned, not just `LC_ALL`: leaving the others to
-     * the runner makes which branch of `localeSetting()` executes depend on
-     * the machine, which is how this drifted between a local run and CI.
+     * Every locale variable is pinned individually, and any not named is
+     * cleared: setting all three to one value hides which of them
+     * `localeSetting()` actually read.
+     *
+     * @param array<string, string> $locale
      */
-    private function headerIn(?string $locale, bool $decorated): string
+    private function headerIn(array $locale, bool $decorated): string
     {
         $variables = ['LC_ALL', 'LC_CTYPE', 'LANG'];
         $previous = [];
 
         foreach ($variables as $variable) {
             $previous[$variable] = getenv($variable);
-            putenv(null === $locale ? $variable : \sprintf('%s=%s', $variable, $locale));
+            $value = $locale[$variable] ?? null;
+            putenv(null === $value ? $variable : \sprintf('%s=%s', $variable, $value));
         }
 
         try {

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -145,6 +145,7 @@ final class AuditPresenterTest extends TestCase
         self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#5b6fd6;options=bold>Symfony LLM Security Auditor</>'), $display);
         self::assertStringContainsString($this->formatted($outputFormatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', mb_strlen('◉ Symfony LLM Security Auditor')))), $display);
         self::assertSame(1, substr_count($display, 'Symfony LLM Security Auditor'), 'the plain title() fallback must not also run once the banner has printed');
+        self::assertStringStartsWith(\PHP_EOL, $display, 'SymfonyStyle::title() opens with a blank line; the banner path must not abut whatever printed before it');
     }
 
     private function formatted(OutputFormatterInterface $outputFormatter, string $tag): string

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -18,6 +18,7 @@ use Override;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -117,6 +118,41 @@ final class AuditPresenterTest extends TestCase
 
         $display = $bufferedOutput->fetch();
         self::assertStringContainsString('/var/www/<fg=grey>oops</>', $display);
+    }
+
+    public function test_header_falls_back_to_the_plain_title_when_not_decorated(): void
+    {
+        $bufferedOutput = new BufferedOutput();
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->header($symfonyStyle, '/path/to/project');
+
+        $display = $bufferedOutput->fetch();
+        self::assertStringContainsString('Symfony LLM Security Auditor', $display);
+        self::assertStringNotContainsString('◉', $display);
+    }
+
+    public function test_header_shows_a_branded_banner_when_decorated(): void
+    {
+        $bufferedOutput = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $symfonyStyle = new SymfonyStyle(new StringInput(''), $bufferedOutput);
+
+        $this->auditPresenter->header($symfonyStyle, '/path/to/project');
+
+        $display = $bufferedOutput->fetch();
+        $formatter = $bufferedOutput->getFormatter();
+        self::assertStringContainsString($this->formatted($formatter, '<fg=#e71c55>◉</>'), $display);
+        self::assertStringContainsString($this->formatted($formatter, '<fg=#242d5c;options=bold>Symfony LLM Security Auditor</>'), $display);
+        self::assertStringContainsString($this->formatted($formatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', 70))), $display);
+        self::assertSame(1, substr_count($display, 'Symfony LLM Security Auditor'), 'the plain title() fallback must not also run once the banner has printed');
+    }
+
+    private function formatted(OutputFormatterInterface $outputFormatterInterface, string $tag): string
+    {
+        $formatted = $outputFormatterInterface->format($tag);
+        self::assertNotNull($formatted);
+
+        return $formatted;
     }
 
     /**

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -169,12 +169,20 @@ final class AuditPresenterTest extends TestCase
         self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#5b6fd6;options=bold>AUDITOR</>'), $display);
     }
 
+    public function test_a_console_that_announces_no_locale_at_all_drops_the_mark(): void
+    {
+        $display = $this->headerIn(null, false);
+
+        self::assertStringNotContainsString('◉', $display);
+        self::assertStringContainsString(' SECURITY AUDITOR', $display);
+    }
+
     #[DataProvider('consoleModes')]
     public function test_the_header_is_pure_ascii_without_utf8_support(bool $decorated): void
     {
         $withoutEscapes = (string) preg_replace('/\033\[[0-9;]*m/', '', $this->headerIn('C', $decorated));
 
-        self::assertSame(1, preg_match('/^[\x00-\x7F]*$/', $withoutEscapes));
+        self::assertMatchesRegularExpression('/^[\x00-\x7F]*$/', $withoutEscapes);
     }
 
     /** @return iterable<string, array{bool}> */
@@ -184,10 +192,20 @@ final class AuditPresenterTest extends TestCase
         yield 'plain' => [false];
     }
 
-    private function headerIn(string $locale, bool $decorated): string
+    /**
+     * All three variables are pinned, not just `LC_ALL`: leaving the others to
+     * the runner makes which branch of `localeSetting()` executes depend on
+     * the machine, which is how this drifted between a local run and CI.
+     */
+    private function headerIn(?string $locale, bool $decorated): string
     {
-        $previous = getenv('LC_ALL');
-        putenv(\sprintf('LC_ALL=%s', $locale));
+        $variables = ['LC_ALL', 'LC_CTYPE', 'LANG'];
+        $previous = [];
+
+        foreach ($variables as $variable) {
+            $previous[$variable] = getenv($variable);
+            putenv(null === $locale ? $variable : \sprintf('%s=%s', $variable, $locale));
+        }
 
         try {
             $bufferedOutput = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, $decorated);
@@ -195,7 +213,10 @@ final class AuditPresenterTest extends TestCase
 
             return $bufferedOutput->fetch();
         } finally {
-            putenv(false === $previous ? 'LC_ALL' : \sprintf('LC_ALL=%s', $previous));
+            foreach ($variables as $variable) {
+                $restored = $previous[$variable];
+                putenv(false === $restored ? $variable : \sprintf('%s=%s', $variable, $restored));
+            }
         }
     }
 

--- a/tests/Phpunit/Unit/Command/AuditPresenterTest.php
+++ b/tests/Phpunit/Unit/Command/AuditPresenterTest.php
@@ -140,16 +140,16 @@ final class AuditPresenterTest extends TestCase
         $this->auditPresenter->header($symfonyStyle, '/path/to/project');
 
         $display = $bufferedOutput->fetch();
-        $formatter = $bufferedOutput->getFormatter();
-        self::assertStringContainsString($this->formatted($formatter, '<fg=#e71c55>◉</>'), $display);
-        self::assertStringContainsString($this->formatted($formatter, '<fg=#242d5c;options=bold>Symfony LLM Security Auditor</>'), $display);
-        self::assertStringContainsString($this->formatted($formatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', 70))), $display);
+        $outputFormatter = $bufferedOutput->getFormatter();
+        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#e71c55>◉</>'), $display);
+        self::assertStringContainsString($this->formatted($outputFormatter, '<fg=#242d5c;options=bold>Symfony LLM Security Auditor</>'), $display);
+        self::assertStringContainsString($this->formatted($outputFormatter, \sprintf('<fg=#e71c55>%s</>', str_repeat('─', 70))), $display);
         self::assertSame(1, substr_count($display, 'Symfony LLM Security Auditor'), 'the plain title() fallback must not also run once the banner has printed');
     }
 
-    private function formatted(OutputFormatterInterface $outputFormatterInterface, string $tag): string
+    private function formatted(OutputFormatterInterface $outputFormatter, string $tag): string
     {
-        $formatted = $outputFormatterInterface->format($tag);
+        $formatted = $outputFormatter->format($tag);
         self::assertNotNull($formatted);
 
         return $formatted;


### PR DESCRIPTION
## Summary

`AuditPresenter::header()` printed `title('Symfony LLM Security Auditor')` — a
plain underlined line with no visual identity. It now prints
`◉ >> SECURITY AUDITOR` with the mark and `SECURITY` in the logo's pink and
`AUDITOR` in its navy, over a tagline. Colour is the only thing that varies by
terminal: CI gets the identical layout, and a console that cannot render `◉`
drops the mark and keeps the coloured wordmark.

Closes #314

## Type of change

- [x] New feature

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint` — Rector and Deptrac are not runnable in my environment; everything else was run, see Verification
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)