### PR TITLE
feat: show the real audit cost in text/html reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   it were a genuinely free run — the same caveat `--dry-run` already gives via
   `AuditPresenter::unsupportedModelWarnings()`.
 
+  One gap is documented rather than closed: `hasPublishedPricing()` checks each
+  role separately when a per-role breakdown is present, but only
+  `EstimateAuditCostUseCase` (`--dry-run`) supplies one. A real run builds its
+  `AuditCost` from a `TokenUsageSnapshot`, which carries no per-role usage, so a
+  split attacker/reviewer setup pairing a priced cloud attacker with an unpriced
+  local reviewer prices nonzero in aggregate and is still labeled "published
+  rates". Closing it needs per-role token accounting on the real-run path.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,24 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   it were a genuinely free run — the same caveat `--dry-run` already gives via
   `AuditPresenter::unsupportedModelWarnings()`.
 
-  One gap is documented rather than closed: `hasPublishedPricing()` checks each
-  role separately when a per-role breakdown is present, but only
-  `EstimateAuditCostUseCase` (`--dry-run`) supplies one. A real run builds its
-  `AuditCost` from a `TokenUsageSnapshot`, which carries no per-role usage, so a
-  split attacker/reviewer setup pairing a priced cloud attacker with an unpriced
-  local reviewer prices nonzero in aggregate and is still labeled "published
-  rates". Closing it needs per-role token accounting on the real-run path.
+  The label is decided per model, not from the aggregate. A split
+  attacker/reviewer setup pairing a priced cloud attacker with an unpriced local
+  reviewer sums to a nonzero total, so the aggregate alone would report
+  "published rates" for a run that is half unpriced — the case this feature
+  exists to catch. `BudgetTracker` already prices every call at that call's own
+  model, so it now accumulates per-model totals alongside the running cost and
+  `RunAuditUseCase` attaches them to the `AuditCost` via the new
+  `AuditCost::withUsageByModel()`. `hasPublishedPricing()` checks whichever
+  breakdown it has — per model for a real run, per role for `--dry-run` — and
+  falls back to the aggregate only when there is none, which is correct on its
+  own terms because a single-model run has nothing to disaggregate.
+
+  Per-model rather than per-role because that is what a real run can honestly
+  attribute: it records the model of every call but not the agent that made it,
+  and it also covers models neither role owns — `EscalatingAttackerAgent`'s
+  cheap first pass, PoC and fix synthesis. The JSON report gains a `by_model`
+  object alongside the existing `by_role`; both are additive, and
+  `AuditCost::of()` is unchanged, so existing callers are unaffected.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Added
 
-- **The console, Markdown, and HTML reports now show the audit's real cost,
-  not just token counts.** `RunAuditUseCase::buildCost()` already assembled
-  an `AuditCost` from the LLM provider's own per-call token usage, but
+- **The console, Markdown, and HTML reports now show the audit's real cost, not
+  just token counts.** `RunAuditUseCase::buildCost()` already assembled an
+  `AuditCost` from the LLM provider's own per-call token usage, but
   `ConsoleReportRenderer`, `MarkdownReportRenderer`, and `HtmlReportRenderer`
   (`src/Audit/Infrastructure/Report/`) only ever rendered
   `inputTokens()`/`outputTokens()`/`primaryModel()` — `estimatedCostUsd()` was
   computed but never shown outside `--format=json`/`--format=sarif` or
-  `--dry-run`. All three renderers now show a `Cost` line labeled
-  "published rates" — the token counts are the provider's exact figures, but
-  the USD conversion comes from `symfony/models-dev`'s published pricing
-  snapshot, which can drift from a negotiated rate or an unpriced model.
+  `--dry-run`. All three renderers now show a `Cost` line labeled "published
+  rates" — the token counts are the provider's exact figures, but the USD
+  conversion comes from `symfony/models-dev`'s published pricing snapshot, which
+  can drift from a negotiated rate or an unpriced model.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `--dry-run`. All three renderers now show a `Cost` line labeled "published
   rates" — the token counts are the provider's exact figures, but the USD
   conversion comes from `symfony/models-dev`'s published pricing snapshot, which
-  can drift from a negotiated rate or an unpriced model.
+  can drift from a negotiated rate or an unpriced model. When tokens were
+  actually spent but the model has no published rate (a self-hosted or unlisted
+  model), the new `AuditCost::hasPublishedPricing()` flips the label to "no
+  published pricing, or a self-hosted model" instead of showing `$0.0000` as if
+  it were a genuinely free run — the same caveat `--dry-run` already gives via
+  `AuditPresenter::unsupportedModelWarnings()`.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   and it also covers models neither role owns — `EscalatingAttackerAgent`'s
   cheap first pass, PoC and fix synthesis. The JSON report gains a `by_model`
   object alongside the existing `by_role`; both are additive, and
-  `AuditCost::of()` is unchanged, so existing callers are unaffected.
+  `AuditCost::of()` is unchanged, so existing callers are unaffected. Each
+  `by_model` entry also carries `cache_read_tokens` and `cache_creation_tokens`,
+  because `CostCalculator::costForCall()` bills cached prompt traffic: without
+  them a cached run reported a cost its own token counts could not account for.
+  `AuditCost::hasPublishedPricing()` counts that traffic as spend too, so a
+  model whose whole run arrived from the prompt cache and priced to zero is
+  still reported as a pricing gap instead of passing as free. Both keys are
+  optional in the accepted shape, keeping `withUsageByModel()` callers valid.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Added
+
+- **The console, Markdown, and HTML reports now show the audit's real cost,
+  not just token counts.** `RunAuditUseCase::buildCost()` already assembled
+  an `AuditCost` from the LLM provider's own per-call token usage, but
+  `ConsoleReportRenderer`, `MarkdownReportRenderer`, and `HtmlReportRenderer`
+  (`src/Audit/Infrastructure/Report/`) only ever rendered
+  `inputTokens()`/`outputTokens()`/`primaryModel()` — `estimatedCostUsd()` was
+  computed but never shown outside `--format=json`/`--format=sarif` or
+  `--dry-run`. All three renderers now show a `Cost` line labeled
+  "published rates" — the token counts are the provider's exact figures, but
+  the USD conversion comes from `symfony/models-dev`'s published pricing
+  snapshot, which can drift from a negotiated rate or an unpriced model.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/src/Audit/Application/Budget/BudgetTracker.php
+++ b/src/Audit/Application/Budget/BudgetTracker.php
@@ -34,7 +34,7 @@ final class BudgetTracker
 
     private float $costUsdUsed = 0.0;
 
-    /** @var array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}> */
+    /** @var array<string, array{model: string, input_tokens: int, output_tokens: int, cache_read_tokens: int, cache_creation_tokens: int, estimated_cost_usd: float}> */
     private array $usageByModel = [];
 
     public function __construct(
@@ -60,12 +60,14 @@ final class BudgetTracker
     private function accumulateModelUsage(LLMResponse $llmResponse, float $costUsd): void
     {
         $model = $llmResponse->model();
-        $existing = $this->usageByModel[$model] ?? ['input_tokens' => 0, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0];
+        $existing = $this->usageByModel[$model] ?? ['input_tokens' => 0, 'output_tokens' => 0, 'cache_read_tokens' => 0, 'cache_creation_tokens' => 0, 'estimated_cost_usd' => 0.0];
 
         $this->usageByModel[$model] = [
             'model' => $model,
             'input_tokens' => $existing['input_tokens'] + $llmResponse->inputTokens(),
             'output_tokens' => $existing['output_tokens'] + $llmResponse->outputTokens(),
+            'cache_read_tokens' => $existing['cache_read_tokens'] + $llmResponse->cacheReadTokens(),
+            'cache_creation_tokens' => $existing['cache_creation_tokens'] + $llmResponse->cacheCreationTokens(),
             'estimated_cost_usd' => $existing['estimated_cost_usd'] + $costUsd,
         ];
     }
@@ -76,7 +78,7 @@ final class BudgetTracker
      * aggregate cannot: a priced attacker paired with an unpriced reviewer
      * still sums to a nonzero total.
      *
-     * @return array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}>
+     * @return array<string, array{model: string, input_tokens: int, output_tokens: int, cache_read_tokens: int, cache_creation_tokens: int, estimated_cost_usd: float}>
      */
     public function usageByModel(): array
     {

--- a/src/Audit/Application/Budget/BudgetTracker.php
+++ b/src/Audit/Application/Budget/BudgetTracker.php
@@ -60,7 +60,7 @@ final class BudgetTracker
     private function accumulateModelUsage(LLMResponse $llmResponse, float $costUsd): void
     {
         $model = $llmResponse->model();
-        $existing = $this->usageByModel[$model] ?? ['model' => $model, 'input_tokens' => 0, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0];
+        $existing = $this->usageByModel[$model] ?? ['input_tokens' => 0, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0];
 
         $this->usageByModel[$model] = [
             'model' => $model,

--- a/src/Audit/Application/Budget/BudgetTracker.php
+++ b/src/Audit/Application/Budget/BudgetTracker.php
@@ -34,6 +34,9 @@ final class BudgetTracker
 
     private float $costUsdUsed = 0.0;
 
+    /** @var array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}> */
+    private array $usageByModel = [];
+
     public function __construct(
         private readonly AuditBudget $auditBudget,
         private readonly CostCalculator $costCalculator,
@@ -41,14 +44,43 @@ final class BudgetTracker
 
     public function recordCall(LLMResponse $llmResponse): void
     {
-        $this->tokensUsed += $llmResponse->totalTokens();
-        $this->costUsdUsed += $this->costCalculator->costForCall(
+        $costUsd = $this->costCalculator->costForCall(
             $llmResponse->inputTokens(),
             $llmResponse->outputTokens(),
             $llmResponse->model(),
             $llmResponse->cacheReadTokens(),
             $llmResponse->cacheCreationTokens(),
         );
+
+        $this->tokensUsed += $llmResponse->totalTokens();
+        $this->costUsdUsed += $costUsd;
+        $this->accumulateModelUsage($llmResponse, $costUsd);
+    }
+
+    private function accumulateModelUsage(LLMResponse $llmResponse, float $costUsd): void
+    {
+        $model = $llmResponse->model();
+        $existing = $this->usageByModel[$model] ?? ['model' => $model, 'input_tokens' => 0, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0];
+
+        $this->usageByModel[$model] = [
+            'model' => $model,
+            'input_tokens' => $existing['input_tokens'] + $llmResponse->inputTokens(),
+            'output_tokens' => $existing['output_tokens'] + $llmResponse->outputTokens(),
+            'estimated_cost_usd' => $existing['estimated_cost_usd'] + $costUsd,
+        ];
+    }
+
+    /**
+     * Per-model totals for the run, so a report can tell a model that priced
+     * to zero because it is unlisted from one that simply went unused. The
+     * aggregate cannot: a priced attacker paired with an unpriced reviewer
+     * still sums to a nonzero total.
+     *
+     * @return array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}>
+     */
+    public function usageByModel(): array
+    {
+        return $this->usageByModel;
     }
 
     /**
@@ -82,5 +114,6 @@ final class BudgetTracker
     {
         $this->tokensUsed = 0;
         $this->costUsdUsed = 0.0;
+        $this->usageByModel = [];
     }
 }

--- a/src/Audit/Application/UseCase/RunAuditUseCase.php
+++ b/src/Audit/Application/UseCase/RunAuditUseCase.php
@@ -124,8 +124,9 @@ final readonly class RunAuditUseCase
         }
 
         $snapshot = $this->tokenUsageRecorder->snapshot();
+        $auditCost = AuditCost::of($snapshot->inputTokens(), $snapshot->outputTokens(), $this->resolveEstimatedCost($snapshot), $this->primaryModel);
 
-        return AuditCost::of($snapshot->inputTokens(), $snapshot->outputTokens(), $this->resolveEstimatedCost($snapshot), $this->primaryModel);
+        return $auditCost->withUsageByModel($this->budgetTracker?->usageByModel() ?? []);
     }
 
     private function resolveEstimatedCost(TokenUsageSnapshot $tokenUsageSnapshot): float

--- a/src/Audit/Domain/Model/AuditCost.php
+++ b/src/Audit/Domain/Model/AuditCost.php
@@ -120,7 +120,7 @@ final readonly class AuditCost
         }
 
         foreach ($breakdown as $entry) {
-            if (0.0 === $entry['estimated_cost_usd'] && 0 !== self::billableTokens($entry)) {
+            if (0.0 === $entry['estimated_cost_usd'] && 0 !== $this->billableTokens($entry)) {
                 return false;
             }
         }
@@ -137,7 +137,7 @@ final readonly class AuditCost
      *
      * @param array{input_tokens: int, output_tokens: int, cache_read_tokens?: int, cache_creation_tokens?: int} $entry
      */
-    private static function billableTokens(array $entry): int
+    private function billableTokens(array $entry): int
     {
         return $entry['input_tokens']
             + $entry['output_tokens']

--- a/src/Audit/Domain/Model/AuditCost.php
+++ b/src/Audit/Domain/Model/AuditCost.php
@@ -100,10 +100,27 @@ final readonly class AuditCost
      * to zero — the model has no published rate in the pricing catalog, or is
      * a free local/self-hosted model. Zero tokens (nothing tracked yet) is
      * not treated as a pricing gap.
+     *
+     * With a split attacker/reviewer configuration, the aggregate total can
+     * price out nonzero even when one role's own model is unpriced — e.g. a
+     * priced cloud attacker paired with an unpriced local reviewer. `byRole()`
+     * carries each role's own tokens and cost, so each role is checked on its
+     * own terms instead of the misleading total.
      */
     public function hasPublishedPricing(): bool
     {
-        return 0.0 !== $this->estimatedCostUsd || 0 === $this->totalTokens();
+        if ([] === $this->byRole) {
+            return 0.0 !== $this->estimatedCostUsd || 0 === $this->totalTokens();
+        }
+
+        foreach ($this->byRole as $entry) {
+            $roleTokens = $entry['input_tokens'] + $entry['output_tokens'];
+            if (0.0 === $entry['estimated_cost_usd'] && 0 !== $roleTokens) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Audit/Domain/Model/AuditCost.php
+++ b/src/Audit/Domain/Model/AuditCost.php
@@ -168,7 +168,10 @@ final readonly class AuditCost
             'estimated_cost_usd' => $this->estimatedCostUsd,
             'primary_model' => $this->primaryModel,
             'by_role' => (object) $this->byRole,
-            'by_model' => (object) $this->byModel,
+            'by_model' => (object) array_map(
+                static fn (array $usage): array => [...$usage, 'estimated_cost_usd' => round($usage['estimated_cost_usd'], 6)],
+                $this->byModel,
+            ),
         ];
     }
 }

--- a/src/Audit/Domain/Model/AuditCost.php
+++ b/src/Audit/Domain/Model/AuditCost.php
@@ -101,11 +101,17 @@ final readonly class AuditCost
      * a free local/self-hosted model. Zero tokens (nothing tracked yet) is
      * not treated as a pricing gap.
      *
-     * With a split attacker/reviewer configuration, the aggregate total can
-     * price out nonzero even when one role's own model is unpriced — e.g. a
-     * priced cloud attacker paired with an unpriced local reviewer. `byRole()`
-     * carries each role's own tokens and cost, so each role is checked on its
-     * own terms instead of the misleading total.
+     * When a per-role breakdown is present each role is checked on its own
+     * terms, because a split attacker/reviewer configuration can price out
+     * nonzero in aggregate while one role's own model is unpriced — a priced
+     * cloud attacker paired with an unpriced local reviewer, say.
+     *
+     * Only `EstimateAuditCostUseCase` (`--dry-run`) supplies that breakdown.
+     * `RunAuditUseCase` builds its `AuditCost` from a `TokenUsageSnapshot`,
+     * which carries no per-role usage, so a real run falls back to the
+     * aggregate and cannot spot that split-model gap: it reports published
+     * pricing whenever the total is nonzero. Closing that needs per-role token
+     * accounting on the real-run path, not a change here.
      */
     public function hasPublishedPricing(): bool
     {

--- a/src/Audit/Domain/Model/AuditCost.php
+++ b/src/Audit/Domain/Model/AuditCost.php
@@ -28,8 +28,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCost
 final readonly class AuditCost
 {
     /**
-     * @param array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}> $byRole
-     * @param array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}> $byModel
+     * @param array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}>                                                       $byRole
+     * @param array<string, array{model: string, input_tokens: int, output_tokens: int, cache_read_tokens?: int, cache_creation_tokens?: int, estimated_cost_usd: float}> $byModel
      */
     private function __construct(
         private int $inputTokens,
@@ -120,12 +120,29 @@ final readonly class AuditCost
         }
 
         foreach ($breakdown as $entry) {
-            if (0.0 === $entry['estimated_cost_usd'] && 0 !== $entry['input_tokens'] + $entry['output_tokens']) {
+            if (0.0 === $entry['estimated_cost_usd'] && 0 !== self::billableTokens($entry)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    /**
+     * Cache reads and cache writes are billed, so a model whose whole spend
+     * arrived as cached prompt tokens has still been charged for. Counting
+     * only fresh input/output would read that as "nothing spent" and hide a
+     * pricing gap. The per-role dry-run breakdown projects no cache traffic,
+     * so those keys are absent there.
+     *
+     * @param array{input_tokens: int, output_tokens: int, cache_read_tokens?: int, cache_creation_tokens?: int} $entry
+     */
+    private static function billableTokens(array $entry): int
+    {
+        return $entry['input_tokens']
+            + $entry['output_tokens']
+            + ($entry['cache_read_tokens'] ?? 0)
+            + ($entry['cache_creation_tokens'] ?? 0);
     }
 
     /**
@@ -142,7 +159,7 @@ final readonly class AuditCost
      * copy-on-write rather than through `of()`, which is already at the
      * project's five-parameter ceiling.
      *
-     * @param array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}> $byModel keyed by model name
+     * @param array<string, array{model: string, input_tokens: int, output_tokens: int, cache_read_tokens?: int, cache_creation_tokens?: int, estimated_cost_usd: float}> $byModel keyed by model name
      */
     public function withUsageByModel(array $byModel): self
     {
@@ -169,7 +186,12 @@ final readonly class AuditCost
             'primary_model' => $this->primaryModel,
             'by_role' => (object) $this->byRole,
             'by_model' => (object) array_map(
-                static fn (array $usage): array => [...$usage, 'estimated_cost_usd' => round($usage['estimated_cost_usd'], 6)],
+                static fn (array $usage): array => [
+                    ...$usage,
+                    'cache_read_tokens' => $usage['cache_read_tokens'] ?? 0,
+                    'cache_creation_tokens' => $usage['cache_creation_tokens'] ?? 0,
+                    'estimated_cost_usd' => round($usage['estimated_cost_usd'], 6),
+                ],
                 $this->byModel,
             ),
         ];

--- a/src/Audit/Domain/Model/AuditCost.php
+++ b/src/Audit/Domain/Model/AuditCost.php
@@ -96,6 +96,17 @@ final readonly class AuditCost
     }
 
     /**
+     * `false` when tokens were actually spent but the total still priced out
+     * to zero — the model has no published rate in the pricing catalog, or is
+     * a free local/self-hosted model. Zero tokens (nothing tracked yet) is
+     * not treated as a pricing gap.
+     */
+    public function hasPublishedPricing(): bool
+    {
+        return 0.0 !== $this->estimatedCostUsd || 0 === $this->totalTokens();
+    }
+
+    /**
      * @return array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}>
      */
     public function byRole(): array

--- a/src/Audit/Domain/Model/AuditCost.php
+++ b/src/Audit/Domain/Model/AuditCost.php
@@ -29,6 +29,7 @@ final readonly class AuditCost
 {
     /**
      * @param array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}> $byRole
+     * @param array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}> $byModel
      */
     private function __construct(
         private int $inputTokens,
@@ -36,6 +37,7 @@ final readonly class AuditCost
         private float $estimatedCostUsd,
         private string $primaryModel,
         private array $byRole = [],
+        private array $byModel = [],
     ) {}
 
     /**
@@ -96,32 +98,29 @@ final readonly class AuditCost
     }
 
     /**
-     * `false` when tokens were actually spent but the total still priced out
-     * to zero — the model has no published rate in the pricing catalog, or is
-     * a free local/self-hosted model. Zero tokens (nothing tracked yet) is
-     * not treated as a pricing gap.
+     * `false` when tokens were actually spent but they priced out to zero —
+     * the model has no published rate in the pricing catalog, or is a free
+     * local/self-hosted model. Zero tokens (nothing tracked yet) is not
+     * treated as a pricing gap.
      *
-     * When a per-role breakdown is present each role is checked on its own
-     * terms, because a split attacker/reviewer configuration can price out
-     * nonzero in aggregate while one role's own model is unpriced — a priced
-     * cloud attacker paired with an unpriced local reviewer, say.
-     *
-     * Only `EstimateAuditCostUseCase` (`--dry-run`) supplies that breakdown.
-     * `RunAuditUseCase` builds its `AuditCost` from a `TokenUsageSnapshot`,
-     * which carries no per-role usage, so a real run falls back to the
-     * aggregate and cannot spot that split-model gap: it reports published
-     * pricing whenever the total is nonzero. Closing that needs per-role token
-     * accounting on the real-run path, not a change here.
+     * The aggregate total cannot answer this for a split configuration: a
+     * priced cloud attacker paired with an unpriced local reviewer still sums
+     * to something nonzero. So each breakdown is checked on its own terms
+     * where one exists — the per-model map for a real run, which records the model
+     * of every call, and `byRole()` for the `--dry-run` estimate, which
+     * projects per role. The aggregate is the last resort, correct on its own
+     * terms because a single-model run has nothing to disaggregate.
      */
     public function hasPublishedPricing(): bool
     {
-        if ([] === $this->byRole) {
+        $breakdown = [] !== $this->byModel ? $this->byModel : $this->byRole;
+
+        if ([] === $breakdown) {
             return 0.0 !== $this->estimatedCostUsd || 0 === $this->totalTokens();
         }
 
-        foreach ($this->byRole as $entry) {
-            $roleTokens = $entry['input_tokens'] + $entry['output_tokens'];
-            if (0.0 === $entry['estimated_cost_usd'] && 0 !== $roleTokens) {
+        foreach ($breakdown as $entry) {
+            if (0.0 === $entry['estimated_cost_usd'] && 0 !== $entry['input_tokens'] + $entry['output_tokens']) {
                 return false;
             }
         }
@@ -135,6 +134,19 @@ final readonly class AuditCost
     public function byRole(): array
     {
         return $this->byRole;
+    }
+
+    /**
+     * A real run records the model of every call but not the agent that made
+     * it, so per-model is the finest attribution it can offer. Applied
+     * copy-on-write rather than through `of()`, which is already at the
+     * project's five-parameter ceiling.
+     *
+     * @param array<string, array{model: string, input_tokens: int, output_tokens: int, estimated_cost_usd: float}> $byModel keyed by model name
+     */
+    public function withUsageByModel(array $byModel): self
+    {
+        return new self($this->inputTokens, $this->outputTokens, $this->estimatedCostUsd, $this->primaryModel, $this->byRole, $byModel);
     }
 
     /**
@@ -156,6 +168,7 @@ final readonly class AuditCost
             'estimated_cost_usd' => $this->estimatedCostUsd,
             'primary_model' => $this->primaryModel,
             'by_role' => (object) $this->byRole,
+            'by_model' => (object) $this->byModel,
         ];
     }
 }

--- a/src/Audit/Infrastructure/Report/ConsoleReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/ConsoleReportRenderer.php
@@ -49,6 +49,7 @@ final readonly class ConsoleReportRenderer implements ReportRendererInterface
             '{{tokens}}' => \sprintf('%s in / %s out', number_format($cost->inputTokens()), number_format($cost->outputTokens())),
             '{{primaryModel}}' => '' === $cost->primaryModel() ? 'unknown model' : $cost->primaryModel(),
             '{{cost}}' => number_format($cost->estimatedCostUsd(), 4, '.', ''),
+            '{{costRateLabel}}' => $cost->hasPublishedPricing() ? 'published rates' : 'no published pricing, or a self-hosted model',
             '{{riskLevel}}' => $auditReport->riskLevel(),
             '{{riskScore}}' => $auditReport->riskScore(),
             '{{body}}' => $this->body($auditReport),

--- a/src/Audit/Infrastructure/Report/ConsoleReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/ConsoleReportRenderer.php
@@ -48,6 +48,7 @@ final readonly class ConsoleReportRenderer implements ReportRendererInterface
             '{{filesScanned}}' => $auditReport->filesScanned(),
             '{{tokens}}' => \sprintf('%s in / %s out', number_format($cost->inputTokens()), number_format($cost->outputTokens())),
             '{{primaryModel}}' => '' === $cost->primaryModel() ? 'unknown model' : $cost->primaryModel(),
+            '{{cost}}' => number_format($cost->estimatedCostUsd(), 4, '.', ''),
             '{{riskLevel}}' => $auditReport->riskLevel(),
             '{{riskScore}}' => $auditReport->riskScore(),
             '{{body}}' => $this->body($auditReport),

--- a/src/Audit/Infrastructure/Report/HtmlReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/HtmlReportRenderer.php
@@ -52,6 +52,7 @@ final readonly class HtmlReportRenderer implements ReportRendererInterface
             '{{tokens}}' => $this->escape(\sprintf('%s in / %s out', number_format($cost->inputTokens()), number_format($cost->outputTokens()))),
             '{{primaryModel}}' => $this->escape('' === $cost->primaryModel() ? 'unknown model' : $cost->primaryModel()),
             '{{cost}}' => $this->escape(number_format($cost->estimatedCostUsd(), 4, '.', '')),
+            '{{costRateLabel}}' => $this->escape($cost->hasPublishedPricing() ? 'published rates' : 'no published pricing, or a self-hosted model'),
             '{{riskLevel}}' => $this->escape($riskLevel),
             '{{riskLevelClass}}' => $this->escape(strtolower($riskLevel)),
             '{{riskScore}}' => $auditReport->riskScore(),

--- a/src/Audit/Infrastructure/Report/HtmlReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/HtmlReportRenderer.php
@@ -51,6 +51,7 @@ final readonly class HtmlReportRenderer implements ReportRendererInterface
             '{{filesScanned}}' => $auditReport->filesScanned(),
             '{{tokens}}' => $this->escape(\sprintf('%s in / %s out', number_format($cost->inputTokens()), number_format($cost->outputTokens()))),
             '{{primaryModel}}' => $this->escape('' === $cost->primaryModel() ? 'unknown model' : $cost->primaryModel()),
+            '{{cost}}' => $this->escape(number_format($cost->estimatedCostUsd(), 4, '.', '')),
             '{{riskLevel}}' => $this->escape($riskLevel),
             '{{riskLevelClass}}' => $this->escape(strtolower($riskLevel)),
             '{{riskScore}}' => $auditReport->riskScore(),

--- a/src/Audit/Infrastructure/Report/MarkdownReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/MarkdownReportRenderer.php
@@ -43,10 +43,11 @@ final readonly class MarkdownReportRenderer implements ReportRendererInterface
                 number_format($auditReport->durationSeconds(), 1, '.', ''),
             ),
             \sprintf(
-                '**Tokens:** %s in / %s out · **Model:** %s',
+                '**Tokens:** %s in / %s out · **Model:** %s · **Cost:** $%s (published rates)',
                 number_format($cost->inputTokens()),
                 number_format($cost->outputTokens()),
                 '' === $cost->primaryModel() ? 'unknown model' : $cost->primaryModel(),
+                number_format($cost->estimatedCostUsd(), 4, '.', ''),
             ),
             '',
             \sprintf(

--- a/src/Audit/Infrastructure/Report/MarkdownReportRenderer.php
+++ b/src/Audit/Infrastructure/Report/MarkdownReportRenderer.php
@@ -43,11 +43,12 @@ final readonly class MarkdownReportRenderer implements ReportRendererInterface
                 number_format($auditReport->durationSeconds(), 1, '.', ''),
             ),
             \sprintf(
-                '**Tokens:** %s in / %s out · **Model:** %s · **Cost:** $%s (published rates)',
+                '**Tokens:** %s in / %s out · **Model:** %s · **Cost:** $%s (%s)',
                 number_format($cost->inputTokens()),
                 number_format($cost->outputTokens()),
                 '' === $cost->primaryModel() ? 'unknown model' : $cost->primaryModel(),
                 number_format($cost->estimatedCostUsd(), 4, '.', ''),
+                $cost->hasPublishedPricing() ? 'published rates' : 'no published pricing, or a self-hosted model',
             ),
             '',
             \sprintf(

--- a/src/Audit/Infrastructure/Report/Template/console.txt
+++ b/src/Audit/Infrastructure/Report/Template/console.txt
@@ -10,6 +10,7 @@
   Duration: {{duration}}
   Files   : {{filesScanned}} scanned
   Tokens  : {{tokens}} ({{primaryModel}})
+  Cost    : ${{cost}} (published rates)
 
 ──────────────────────────────────────────────────────────────────────
   RISK LEVEL: {{riskLevel}}  (Score: {{riskScore}})

--- a/src/Audit/Infrastructure/Report/Template/console.txt
+++ b/src/Audit/Infrastructure/Report/Template/console.txt
@@ -10,7 +10,7 @@
   Duration: {{duration}}
   Files   : {{filesScanned}} scanned
   Tokens  : {{tokens}} ({{primaryModel}})
-  Cost    : ${{cost}} (published rates)
+  Cost    : ${{cost}} ({{costRateLabel}})
 
 ──────────────────────────────────────────────────────────────────────
   RISK LEVEL: {{riskLevel}}  (Score: {{riskScore}})

--- a/src/Audit/Infrastructure/Report/Template/report.html
+++ b/src/Audit/Infrastructure/Report/Template/report.html
@@ -154,7 +154,7 @@
       <dt>Model</dt>
       <dd>{{primaryModel}}</dd>
       <dt>Cost</dt>
-      <dd>${{cost}} (published rates)</dd>
+      <dd>${{cost}} ({{costRateLabel}})</dd>
     </dl>
     {{summary}} {{charts}} {{body}}
     <footer>

--- a/src/Audit/Infrastructure/Report/Template/report.html
+++ b/src/Audit/Infrastructure/Report/Template/report.html
@@ -153,6 +153,8 @@
       <dd>{{tokens}}</dd>
       <dt>Model</dt>
       <dd>{{primaryModel}}</dd>
+      <dt>Cost</dt>
+      <dd>${{cost}} (published rates)</dd>
     </dl>
     {{summary}} {{charts}} {{body}}
     <footer>

--- a/tests/Phpunit/EndToEnd/__snapshots__/default-audit.console.txt
+++ b/tests/Phpunit/EndToEnd/__snapshots__/default-audit.console.txt
@@ -10,6 +10,7 @@
   Duration: DURATIONs
   Files   : 3 scanned
   Tokens  : 0 in / 0 out (gpt-4o)
+  Cost    : $0.0000 (published rates)
 
 ──────────────────────────────────────────────────────────────────────
   RISK LEVEL: LOW  (Score: 10)

--- a/tests/Phpunit/EndToEnd/__snapshots__/default-audit.html
+++ b/tests/Phpunit/EndToEnd/__snapshots__/default-audit.html
@@ -153,6 +153,8 @@
       <dd>0 in / 0 out</dd>
       <dt>Model</dt>
       <dd>gpt-4o</dd>
+      <dt>Cost</dt>
+      <dd>$0.0000 (published rates)</dd>
     </dl>
      <section class="charts"><h2>Distribution</h2><h3>By severity</h3><svg class="chart" viewBox="0 0 600 24" role="img" aria-label="Findings by severity"><text class="bar-label" x="0" y="16">🔴 CRITICAL</text><rect class="bar bar-critical" x="250" y="5" width="290.0" height="14" rx="2" /><text class="bar-count" x="548.0" y="16">1</text></svg><h3>By type</h3><svg class="chart" viewBox="0 0 600 24" role="img" aria-label="Findings by vulnerability type"><text class="bar-label" x="0" y="16">broken_access_control</text><rect class="bar bar-type" x="250" y="5" width="290.0" height="14" rx="2" /><text class="bar-count" x="548.0" y="16">1</text></svg></section> <h2>Vulnerabilities (1 total)</h2><article class="finding severity-critical">
   <h3>

--- a/tests/Phpunit/EndToEnd/__snapshots__/default-audit.json
+++ b/tests/Phpunit/EndToEnd/__snapshots__/default-audit.json
@@ -60,6 +60,8 @@
                 "model": "gpt-4o",
                 "input_tokens": 0,
                 "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_creation_tokens": 0,
                 "estimated_cost_usd": 0.0
             }
         }

--- a/tests/Phpunit/EndToEnd/__snapshots__/default-audit.json
+++ b/tests/Phpunit/EndToEnd/__snapshots__/default-audit.json
@@ -54,7 +54,15 @@
         "total_tokens": 0,
         "estimated_cost_usd": 0.0,
         "primary_model": "gpt-4o",
-        "by_role": []
+        "by_role": [],
+        "by_model": {
+            "gpt-4o": {
+                "model": "gpt-4o",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "estimated_cost_usd": 0.0
+            }
+        }
     },
     "coverage": [
         {

--- a/tests/Phpunit/EndToEnd/__snapshots__/default-audit.markdown.txt
+++ b/tests/Phpunit/EndToEnd/__snapshots__/default-audit.markdown.txt
@@ -1,7 +1,7 @@
 # Security Audit Report
 
 **Audit ID:** AUDIT-XXXXXXXX · **Project:** PROJECT_PATH · **Started:** TIMESTAMP · **Duration:** DURATIONs
-**Tokens:** 0 in / 0 out · **Model:** gpt-4o
+**Tokens:** 0 in / 0 out · **Model:** gpt-4o · **Cost:** $0.0000 (published rates)
 
 **Risk level:** LOW (score 10) · **Findings:** 1 · **Files scanned:** 3
 

--- a/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
+++ b/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
@@ -331,8 +331,8 @@ final class BudgetTrackerTest extends TestCase
         $budgetTracker->recordCall(LLMResponse::of('x', 'ollama/llama3.2', 'end_turn', TokenUsageSnapshot::of(500_000, 100_000)));
 
         self::assertSame([
-            'claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_000_000, 'output_tokens' => 200_000, 'estimated_cost_usd' => 6.0],
-            'ollama/llama3.2' => ['model' => 'ollama/llama3.2', 'input_tokens' => 500_000, 'output_tokens' => 100_000, 'estimated_cost_usd' => 0.0],
+            'claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_000_000, 'output_tokens' => 200_000, 'cache_read_tokens' => 0, 'cache_creation_tokens' => 0, 'estimated_cost_usd' => 6.0],
+            'ollama/llama3.2' => ['model' => 'ollama/llama3.2', 'input_tokens' => 500_000, 'output_tokens' => 100_000, 'cache_read_tokens' => 0, 'cache_creation_tokens' => 0, 'estimated_cost_usd' => 0.0],
         ], $budgetTracker->usageByModel());
     }
 
@@ -348,7 +348,7 @@ final class BudgetTrackerTest extends TestCase
         $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(400_000, 50_000)));
 
         self::assertSame(
-            ['model' => 'claude-opus-5', 'input_tokens' => 1_400_000, 'output_tokens' => 250_000, 'estimated_cost_usd' => 7.95],
+            ['model' => 'claude-opus-5', 'input_tokens' => 1_400_000, 'output_tokens' => 250_000, 'cache_read_tokens' => 0, 'cache_creation_tokens' => 0, 'estimated_cost_usd' => 7.95],
             $budgetTracker->usageByModel()['claude-opus-5'],
         );
     }

--- a/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
+++ b/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
@@ -327,12 +327,12 @@ final class BudgetTrackerTest extends TestCase
     {
         $budgetTracker = $this->splitModelBudgetTracker();
 
-        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 0)));
-        $budgetTracker->recordCall(LLMResponse::of('x', 'ollama/llama3.2', 'end_turn', TokenUsageSnapshot::of(500_000, 0)));
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 200_000)));
+        $budgetTracker->recordCall(LLMResponse::of('x', 'ollama/llama3.2', 'end_turn', TokenUsageSnapshot::of(500_000, 100_000)));
 
         self::assertSame([
-            'claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_000_000, 'output_tokens' => 0, 'estimated_cost_usd' => 3.0],
-            'ollama/llama3.2' => ['model' => 'ollama/llama3.2', 'input_tokens' => 500_000, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0],
+            'claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_000_000, 'output_tokens' => 200_000, 'estimated_cost_usd' => 6.0],
+            'ollama/llama3.2' => ['model' => 'ollama/llama3.2', 'input_tokens' => 500_000, 'output_tokens' => 100_000, 'estimated_cost_usd' => 0.0],
         ], $budgetTracker->usageByModel());
     }
 
@@ -344,11 +344,11 @@ final class BudgetTrackerTest extends TestCase
     {
         $budgetTracker = $this->splitModelBudgetTracker();
 
-        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 0)));
-        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 0)));
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 200_000)));
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(400_000, 50_000)));
 
         self::assertSame(
-            ['model' => 'claude-opus-5', 'input_tokens' => 2_000_000, 'output_tokens' => 0, 'estimated_cost_usd' => 6.0],
+            ['model' => 'claude-opus-5', 'input_tokens' => 1_400_000, 'output_tokens' => 250_000, 'estimated_cost_usd' => 7.95],
             $budgetTracker->usageByModel()['claude-opus-5'],
         );
     }

--- a/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
+++ b/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
@@ -319,6 +319,92 @@ final class BudgetTrackerTest extends TestCase
         $budgetTracker->assertWithinBudget();
     }
 
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_it_attributes_usage_to_the_model_of_each_call(): void
+    {
+        $budgetTracker = $this->splitModelBudgetTracker();
+
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 0)));
+        $budgetTracker->recordCall(LLMResponse::of('x', 'ollama/llama3.2', 'end_turn', TokenUsageSnapshot::of(500_000, 0)));
+
+        self::assertSame([
+            'claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_000_000, 'output_tokens' => 0, 'estimated_cost_usd' => 3.0],
+            'ollama/llama3.2' => ['model' => 'ollama/llama3.2', 'input_tokens' => 500_000, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0],
+        ], $budgetTracker->usageByModel());
+    }
+
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_it_sums_repeated_calls_to_the_same_model(): void
+    {
+        $budgetTracker = $this->splitModelBudgetTracker();
+
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 0)));
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 0)));
+
+        self::assertSame(
+            ['model' => 'claude-opus-5', 'input_tokens' => 2_000_000, 'output_tokens' => 0, 'estimated_cost_usd' => 6.0],
+            $budgetTracker->usageByModel()['claude-opus-5'],
+        );
+    }
+
+    /**
+     * @throws BudgetExceededException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_reset_clears_the_per_model_attribution(): void
+    {
+        $budgetTracker = $this->splitModelBudgetTracker();
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(1_000_000, 0)));
+
+        $budgetTracker->reset();
+
+        self::assertSame([], $budgetTracker->usageByModel());
+    }
+
+    /** A tracker whose pricing provider knows `claude-opus-5` and prices everything else at zero, as an unlisted or self-hosted model does. */
+    private function splitModelBudgetTracker(): BudgetTracker
+    {
+        $pricingProvider = new class implements CacheAwarePricingProviderInterface {
+            #[Override]
+            public function pricePerMillionInputTokens(string $model): float
+            {
+                return 'claude-opus-5' === $model ? 3.0 : 0.0;
+            }
+
+            #[Override]
+            public function pricePerMillionOutputTokens(string $model): float
+            {
+                return 'claude-opus-5' === $model ? 15.0 : 0.0;
+            }
+
+            #[Override]
+            public function cacheReadPricePerMillionTokens(string $model): float
+            {
+                return 0.0;
+            }
+
+            #[Override]
+            public function cacheCreationPricePerMillionTokens(string $model): float
+            {
+                return 0.0;
+            }
+
+            #[Override]
+            public function hasModel(string $model): bool
+            {
+                return 'claude-opus-5' === $model;
+            }
+        };
+
+        return new BudgetTracker(AuditBudget::unlimited(), new CostCalculator($pricingProvider));
+    }
+
     private function budgetTracker(
         AuditBudget $auditBudget,
         float $inputPrice = 0.0,

--- a/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
+++ b/tests/Phpunit/Unit/Application/Budget/BudgetTrackerTest.php
@@ -337,6 +337,27 @@ final class BudgetTrackerTest extends TestCase
     }
 
     /**
+     * Cached prompt traffic accumulates the same way fresh input does: two
+     * calls to one model must report the sum of both, not the last one and
+     * not their difference.
+     *
+     * @throws BudgetExceededException
+     * @throws InvalidTokenUsageException
+     */
+    public function test_it_sums_cached_prompt_tokens_across_repeated_calls(): void
+    {
+        $budgetTracker = $this->splitModelBudgetTracker();
+
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(0, 0, 300_000, 40_000)));
+        $budgetTracker->recordCall(LLMResponse::of('x', 'claude-opus-5', 'end_turn', TokenUsageSnapshot::of(0, 0, 100_000, 10_000)));
+
+        $usage = $budgetTracker->usageByModel()['claude-opus-5'];
+
+        self::assertSame(400_000, $usage['cache_read_tokens']);
+        self::assertSame(50_000, $usage['cache_creation_tokens']);
+    }
+
+    /**
      * @throws BudgetExceededException
      * @throws InvalidTokenUsageException
      */

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -45,6 +45,33 @@ final class AuditCostTest extends TestCase
     /**
      * @throws InvalidAuditCostException
      */
+    public function test_has_published_pricing_is_true_when_cost_is_nonzero(): void
+    {
+        $auditCost = AuditCost::of(100, 50, 0.05, 'claude-opus-4-7');
+
+        self::assertTrue($auditCost->hasPublishedPricing());
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     */
+    public function test_has_published_pricing_is_false_when_tokens_were_spent_but_cost_is_zero(): void
+    {
+        $auditCost = AuditCost::of(100, 50, 0.0, 'ollama/llama3.2');
+
+        self::assertFalse($auditCost->hasPublishedPricing());
+    }
+
+    public function test_has_published_pricing_is_true_when_no_tokens_were_tracked_yet(): void
+    {
+        $auditCost = AuditCost::zero('');
+
+        self::assertTrue($auditCost->hasPublishedPricing());
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     */
     public function test_cost_is_rounded_to_six_decimal_places(): void
     {
         $auditCost = AuditCost::of(0, 0, 0.0000005, 'm');

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -113,6 +113,22 @@ final class AuditCostTest extends TestCase
     }
 
     /**
+     * Cache reads are billed, so a model whose entire spend arrived as cached
+     * prompt tokens has still been charged — and priced at zero it is still a
+     * pricing gap, even though its fresh input and output are both zero.
+     *
+     * @throws InvalidAuditCostException
+     */
+    public function test_has_published_pricing_counts_cached_prompt_tokens_as_spend(): void
+    {
+        $auditCost = AuditCost::of(0, 0, 0.0, 'ollama/llama3.2')->withUsageByModel([
+            'ollama/llama3.2' => ['model' => 'ollama/llama3.2', 'input_tokens' => 0, 'output_tokens' => 0, 'cache_read_tokens' => 4_000, 'cache_creation_tokens' => 1_000, 'estimated_cost_usd' => 0.0],
+        ]);
+
+        self::assertFalse($auditCost->hasPublishedPricing());
+    }
+
+    /**
      * "Some tokens were spent" is the sum of input and output, not their
      * difference: an entry that happens to spend as many output tokens as
      * input ones is still spend, and must still be checked for a price.
@@ -194,7 +210,7 @@ final class AuditCostTest extends TestCase
         ]);
 
         self::assertEquals(
-            (object) ['claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_111, 'output_tokens' => 777, 'estimated_cost_usd' => 0.104916]],
+            (object) ['claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_111, 'output_tokens' => 777, 'cache_read_tokens' => 0, 'cache_creation_tokens' => 0, 'estimated_cost_usd' => 0.104916]],
             $auditCost->toArray()['by_model'],
         );
     }
@@ -212,7 +228,7 @@ final class AuditCostTest extends TestCase
         ]);
 
         self::assertEquals(
-            (object) ['gemini-flash-lite' => ['model' => 'gemini-flash-lite', 'input_tokens' => 1, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0]],
+            (object) ['gemini-flash-lite' => ['model' => 'gemini-flash-lite', 'input_tokens' => 1, 'output_tokens' => 0, 'cache_read_tokens' => 0, 'cache_creation_tokens' => 0, 'estimated_cost_usd' => 0.0]],
             $auditCost->toArray()['by_model'],
         );
     }

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -113,6 +113,22 @@ final class AuditCostTest extends TestCase
     }
 
     /**
+     * "Some tokens were spent" is the sum of input and output, not their
+     * difference: an entry that happens to spend as many output tokens as
+     * input ones is still spend, and must still be checked for a price.
+     *
+     * @throws InvalidAuditCostException
+     */
+    public function test_has_published_pricing_counts_input_and_output_tokens_together(): void
+    {
+        $auditCost = AuditCost::of(2_000, 2_000, 0.0, 'ollama/llama3.2')->withUsageByModel([
+            'ollama/llama3.2' => ['model' => 'ollama/llama3.2', 'input_tokens' => 2_000, 'output_tokens' => 2_000, 'estimated_cost_usd' => 0.0],
+        ]);
+
+        self::assertFalse($auditCost->hasPublishedPricing());
+    }
+
+    /**
      * @throws InvalidAuditCostException
      */
     public function test_has_published_pricing_still_falls_back_to_the_aggregate_without_any_breakdown(): void

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -83,6 +83,36 @@ final class AuditCostTest extends TestCase
     }
 
     /**
+     * A real run has no per-role breakdown to check, so it cannot see that one
+     * role's model is unpriced while the aggregate is nonzero. Documented in
+     * `AuditCost::hasPublishedPricing()`; pinned here so the day per-role usage
+     * reaches `RunAuditUseCase` this test fails and gets revisited.
+     *
+     * @throws InvalidAuditCostException
+     */
+    public function test_has_published_pricing_falls_back_to_the_aggregate_without_a_role_breakdown(): void
+    {
+        self::assertFalse($this->splitRunReportsPublishedPricing(withRoleBreakdown: true));
+        self::assertTrue($this->splitRunReportsPublishedPricing(withRoleBreakdown: false));
+    }
+
+    /**
+     * A priced cloud attacker paired with an unpriced local reviewer: nonzero
+     * in aggregate, unpriced for one role.
+     *
+     * @throws InvalidAuditCostException
+     */
+    private function splitRunReportsPublishedPricing(bool $withRoleBreakdown): bool
+    {
+        $byRole = $withRoleBreakdown ? [
+            'attacker' => ['model' => 'claude-opus-5', 'input_tokens' => 100_000, 'output_tokens' => 7_000, 'estimated_cost_usd' => 1.87],
+            'reviewer' => ['model' => 'ollama/llama3.2', 'input_tokens' => 20_000, 'output_tokens' => 1_000, 'estimated_cost_usd' => 0.0],
+        ] : [];
+
+        return AuditCost::of(120_000, 8_000, 1.87, 'claude-opus-5', $byRole)->hasPublishedPricing();
+    }
+
+    /**
      * @throws InvalidAuditCostException
      */
     public function test_has_published_pricing_is_true_when_every_split_role_prices_above_zero(): void

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -180,6 +180,60 @@ final class AuditCostTest extends TestCase
     }
 
     /**
+     * The top-level cost and the dry-run's per-role costs are both rounded to
+     * six decimals, so accumulated float noise must not leave one field in the
+     * same document reading `0.10491600000000001` while another reads
+     * `0.104916`.
+     *
+     * @throws InvalidAuditCostException
+     */
+    public function test_to_array_rounds_per_model_cost_to_the_same_precision_as_the_total(): void
+    {
+        $auditCost = AuditCost::of(1_111, 777, 0.104916, 'claude-opus-5')->withUsageByModel([
+            'claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_111, 'output_tokens' => 777, 'estimated_cost_usd' => 0.10491600000000001],
+        ]);
+
+        self::assertEquals(
+            (object) ['claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 1_111, 'output_tokens' => 777, 'estimated_cost_usd' => 0.104916]],
+            $auditCost->toArray()['by_model'],
+        );
+    }
+
+    /**
+     * Six decimals, not seven: the same precision `BudgetTracker::costUsdUsed()`
+     * and the dry-run's per-role costs use.
+     *
+     * @throws InvalidAuditCostException
+     */
+    public function test_to_array_rounds_per_model_cost_to_six_decimals(): void
+    {
+        $auditCost = AuditCost::of(1, 0, 0.0, 'gemini-flash-lite')->withUsageByModel([
+            'gemini-flash-lite' => ['model' => 'gemini-flash-lite', 'input_tokens' => 1, 'output_tokens' => 0, 'estimated_cost_usd' => 0.00000015],
+        ]);
+
+        self::assertEquals(
+            (object) ['gemini-flash-lite' => ['model' => 'gemini-flash-lite', 'input_tokens' => 1, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0]],
+            $auditCost->toArray()['by_model'],
+        );
+    }
+
+    /**
+     * Rounding is for display only. A model too cheap to register at six
+     * decimals is still a priced model, so the published-pricing check must
+     * read the unrounded cost or it would call it self-hosted.
+     *
+     * @throws InvalidAuditCostException
+     */
+    public function test_a_sub_microdollar_cost_still_counts_as_published_pricing(): void
+    {
+        $auditCost = AuditCost::of(1, 0, 0.0, 'gemini-flash-lite')->withUsageByModel([
+            'gemini-flash-lite' => ['model' => 'gemini-flash-lite', 'input_tokens' => 1, 'output_tokens' => 0, 'estimated_cost_usd' => 0.00000015],
+        ]);
+
+        self::assertTrue($auditCost->hasPublishedPricing());
+    }
+
+    /**
      * @throws InvalidAuditCostException
      */
     public function test_to_array_carries_per_role_breakdown_when_provided(): void

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -72,6 +72,32 @@ final class AuditCostTest extends TestCase
     /**
      * @throws InvalidAuditCostException
      */
+    public function test_has_published_pricing_is_false_when_one_split_role_prices_at_zero(): void
+    {
+        $auditCost = AuditCost::of(150, 75, 0.05, 'claude-opus-4-7', [
+            'attacker' => ['model' => 'claude-opus-4-7', 'input_tokens' => 100, 'output_tokens' => 50, 'estimated_cost_usd' => 0.05],
+            'reviewer' => ['model' => 'ollama/llama3.2', 'input_tokens' => 50, 'output_tokens' => 25, 'estimated_cost_usd' => 0.0],
+        ]);
+
+        self::assertFalse($auditCost->hasPublishedPricing());
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     */
+    public function test_has_published_pricing_is_true_when_every_split_role_prices_above_zero(): void
+    {
+        $auditCost = AuditCost::of(150, 75, 0.05, 'claude-opus-4-7', [
+            'attacker' => ['model' => 'claude-opus-4-7', 'input_tokens' => 100, 'output_tokens' => 50, 'estimated_cost_usd' => 0.04],
+            'reviewer' => ['model' => 'claude-haiku-4-5-20251001', 'input_tokens' => 50, 'output_tokens' => 25, 'estimated_cost_usd' => 0.01],
+        ]);
+
+        self::assertTrue($auditCost->hasPublishedPricing());
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     */
     public function test_cost_is_rounded_to_six_decimal_places(): void
     {
         $auditCost = AuditCost::of(0, 0, 0.0000005, 'm');

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -113,6 +113,23 @@ final class AuditCostTest extends TestCase
     }
 
     /**
+     * The per-role breakdown carries no cache-token keys, so `billableTokens()`
+     * falls back for both. That fallback must be exactly zero: an entry that
+     * spent nothing and priced to nothing is not a pricing gap, and any other
+     * default would invent spend and report one.
+     *
+     * @throws InvalidAuditCostException
+     */
+    public function test_has_published_pricing_treats_a_role_entry_without_tokens_as_no_gap(): void
+    {
+        $auditCost = AuditCost::of(0, 0, 0.0, 'claude-opus-5', [
+            'attacker' => ['model' => 'claude-opus-5', 'input_tokens' => 0, 'output_tokens' => 0, 'estimated_cost_usd' => 0.0],
+        ]);
+
+        self::assertTrue($auditCost->hasPublishedPricing());
+    }
+
+    /**
      * Cache reads are billed, so a model whose entire spend arrived as cached
      * prompt tokens has still been charged — and priced at zero it is still a
      * pricing gap, even though its fresh input and output are both zero.

--- a/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
+++ b/tests/Phpunit/Unit/Domain/Model/AuditCostTest.php
@@ -83,33 +83,43 @@ final class AuditCostTest extends TestCase
     }
 
     /**
-     * A real run has no per-role breakdown to check, so it cannot see that one
-     * role's model is unpriced while the aggregate is nonzero. Documented in
-     * `AuditCost::hasPublishedPricing()`; pinned here so the day per-role usage
-     * reaches `RunAuditUseCase` this test fails and gets revisited.
+     * A priced cloud attacker paired with an unpriced local reviewer sums to a
+     * nonzero total, so only a breakdown can catch it. A real run has no roles
+     * to attribute, but it does record the model of every call.
      *
      * @throws InvalidAuditCostException
      */
-    public function test_has_published_pricing_falls_back_to_the_aggregate_without_a_role_breakdown(): void
+    public function test_has_published_pricing_spots_an_unpriced_model_in_a_real_run(): void
     {
-        self::assertFalse($this->splitRunReportsPublishedPricing(withRoleBreakdown: true));
-        self::assertTrue($this->splitRunReportsPublishedPricing(withRoleBreakdown: false));
+        $auditCost = AuditCost::of(120_000, 8_000, 1.87, 'claude-opus-5')->withUsageByModel([
+            'claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 100_000, 'output_tokens' => 7_000, 'estimated_cost_usd' => 1.87],
+            'ollama/llama3.2' => ['model' => 'ollama/llama3.2', 'input_tokens' => 20_000, 'output_tokens' => 1_000, 'estimated_cost_usd' => 0.0],
+        ]);
+
+        self::assertFalse($auditCost->hasPublishedPricing());
     }
 
     /**
-     * A priced cloud attacker paired with an unpriced local reviewer: nonzero
-     * in aggregate, unpriced for one role.
-     *
      * @throws InvalidAuditCostException
      */
-    private function splitRunReportsPublishedPricing(bool $withRoleBreakdown): bool
+    public function test_has_published_pricing_is_true_when_every_model_in_a_real_run_prices_above_zero(): void
     {
-        $byRole = $withRoleBreakdown ? [
-            'attacker' => ['model' => 'claude-opus-5', 'input_tokens' => 100_000, 'output_tokens' => 7_000, 'estimated_cost_usd' => 1.87],
-            'reviewer' => ['model' => 'ollama/llama3.2', 'input_tokens' => 20_000, 'output_tokens' => 1_000, 'estimated_cost_usd' => 0.0],
-        ] : [];
+        $auditCost = AuditCost::of(120_000, 8_000, 1.88, 'claude-opus-5')->withUsageByModel([
+            'claude-opus-5' => ['model' => 'claude-opus-5', 'input_tokens' => 100_000, 'output_tokens' => 7_000, 'estimated_cost_usd' => 1.87],
+            'claude-haiku-4-5-20251001' => ['model' => 'claude-haiku-4-5-20251001', 'input_tokens' => 20_000, 'output_tokens' => 1_000, 'estimated_cost_usd' => 0.01],
+        ]);
 
-        return AuditCost::of(120_000, 8_000, 1.87, 'claude-opus-5', $byRole)->hasPublishedPricing();
+        self::assertTrue($auditCost->hasPublishedPricing());
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     */
+    public function test_has_published_pricing_still_falls_back_to_the_aggregate_without_any_breakdown(): void
+    {
+        $auditCost = AuditCost::of(120_000, 8_000, 1.87, 'claude-opus-5');
+
+        self::assertTrue($auditCost->hasPublishedPricing());
     }
 
     /**
@@ -149,6 +159,7 @@ final class AuditCostTest extends TestCase
             'estimated_cost_usd' => 0.04,
             'primary_model' => 'claude-sonnet-4-5',
             'by_role' => (object) [],
+            'by_model' => (object) [],
         ], $auditCost->toArray());
     }
 

--- a/tests/Phpunit/Unit/Infrastructure/Report/ConsoleReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ConsoleReportRendererTest.php
@@ -547,13 +547,22 @@ final class ConsoleReportRendererTest extends AbstractReportRendererTestCase
         ));
         $output = $this->renderer->render($auditReport);
 
-        self::assertStringNotContainsString('Cost', $output);
-        self::assertStringNotContainsString('$0.3755', $output);
-        self::assertStringNotContainsString('$0.0350', $output);
-        self::assertStringNotContainsString('$0.0050', $output);
+        self::assertStringContainsString('$0.3755', $output);
+        self::assertStringNotContainsString('(estimate)', $output);
         self::assertStringNotContainsString('{{cost}}', $output);
-        self::assertStringNotContainsString('{{costBreakdown}}', $output);
         self::assertStringContainsString('100 in / 50 out (claude-opus-4-7)', $output);
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     * @throws InvalidAuditContextException
+     */
+    public function test_render_labels_cost_as_computed_from_published_rates(): void
+    {
+        $auditReport = $this->makeReportWithCost(AuditCost::of(100, 50, 0.0123, 'claude-opus-4-7'));
+        $output = $this->renderer->render($auditReport);
+
+        self::assertStringContainsString('$0.0123 (published rates)', $output);
     }
 
     /**

--- a/tests/Phpunit/Unit/Infrastructure/Report/ConsoleReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/ConsoleReportRendererTest.php
@@ -569,6 +569,18 @@ final class ConsoleReportRendererTest extends AbstractReportRendererTestCase
      * @throws InvalidAuditCostException
      * @throws InvalidAuditContextException
      */
+    public function test_render_caveats_zero_cost_when_tokens_were_spent_but_the_model_has_no_published_pricing(): void
+    {
+        $auditReport = $this->makeReportWithCost(AuditCost::of(100, 50, 0.0, 'ollama/llama3.2'));
+        $output = $this->renderer->render($auditReport);
+
+        self::assertStringContainsString('$0.0000 (no published pricing, or a self-hosted model)', $output);
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     * @throws InvalidAuditContextException
+     */
     public function test_render_substitutes_actual_model_name_when_primary_model_is_set(): void
     {
         $auditReport = $this->makeReportWithCost(AuditCost::of(100, 50, 0.05, 'claude-opus-4-7'));

--- a/tests/Phpunit/Unit/Infrastructure/Report/HtmlReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/HtmlReportRendererTest.php
@@ -15,6 +15,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Report;
 
 use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditContextException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCostException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityNarrativeException;
@@ -123,6 +124,17 @@ final class HtmlReportRendererTest extends AbstractReportRendererTestCase
         $output = $this->renderer->render($this->makeReportWithCost(AuditCost::zero('')));
 
         self::assertStringContainsString('unknown model', $output);
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     * @throws InvalidAuditContextException
+     */
+    public function test_render_shows_the_cost_labeled_as_published_rates(): void
+    {
+        $output = $this->renderer->render($this->makeReportWithCost(AuditCost::of(100, 50, 0.0123, 'claude-opus-4-7')));
+
+        self::assertStringContainsString('$0.0123 (published rates)', $output);
     }
 
     /**

--- a/tests/Phpunit/Unit/Infrastructure/Report/HtmlReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/HtmlReportRendererTest.php
@@ -138,6 +138,17 @@ final class HtmlReportRendererTest extends AbstractReportRendererTestCase
     }
 
     /**
+     * @throws InvalidAuditCostException
+     * @throws InvalidAuditContextException
+     */
+    public function test_render_caveats_zero_cost_when_tokens_were_spent_but_the_model_has_no_published_pricing(): void
+    {
+        $output = $this->renderer->render($this->makeReportWithCost(AuditCost::of(100, 50, 0.0, 'ollama/llama3.2')));
+
+        self::assertStringContainsString('$0.0000 (no published pricing, or a self-hosted model)', $output);
+    }
+
+    /**
      * @throws InvalidCodeLocationException
      * @throws InvalidVulnerabilityClassificationException
      * @throws InvalidAuditContextException

--- a/tests/Phpunit/Unit/Infrastructure/Report/MarkdownReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/MarkdownReportRendererTest.php
@@ -122,6 +122,17 @@ final class MarkdownReportRendererTest extends AbstractReportRendererTestCase
     }
 
     /**
+     * @throws InvalidAuditCostException
+     * @throws InvalidAuditContextException
+     */
+    public function test_render_caveats_zero_cost_when_tokens_were_spent_but_the_model_has_no_published_pricing(): void
+    {
+        $output = $this->renderer->render($this->makeReportWithCost(AuditCost::of(100, 50, 0.0, 'ollama/llama3.2')));
+
+        self::assertStringContainsString('**Cost:** $0.0000 (no published pricing, or a self-hosted model)', $output);
+    }
+
+    /**
      * @throws InvalidAuditContextException
      */
     public function test_render_shows_safe_message_when_no_vulnerabilities(): void

--- a/tests/Phpunit/Unit/Infrastructure/Report/MarkdownReportRendererTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Report/MarkdownReportRendererTest.php
@@ -16,6 +16,7 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\Report;
 use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditContextException;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidAuditCostException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidCodeLocationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityClassificationException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Exception\InvalidVulnerabilityNarrativeException;
@@ -107,6 +108,17 @@ final class MarkdownReportRendererTest extends AbstractReportRendererTestCase
         $output = $this->renderer->render($this->makeReportWithCost(AuditCost::zero('')));
 
         self::assertStringContainsString('unknown model', $output);
+    }
+
+    /**
+     * @throws InvalidAuditCostException
+     * @throws InvalidAuditContextException
+     */
+    public function test_render_shows_the_cost_labeled_as_published_rates(): void
+    {
+        $output = $this->renderer->render($this->makeReportWithCost(AuditCost::of(100, 50, 0.0123, 'claude-opus-4-7')));
+
+        self::assertStringContainsString('**Cost:** $0.0123 (published rates)', $output);
     }
 
     /**


### PR DESCRIPTION
## Summary

`AuditCost::estimatedCostUsd()` was already computed from the LLM provider's real per-call token usage but never rendered outside `--format=json`/`--format=sarif` or `--dry-run`. The console, Markdown, and HTML reports now show a `Cost` line labeled "published rates" — the caveat that the USD conversion comes from a published pricing snapshot, not necessarily the provider's exact invoice.

Closes #315

## Type of change

- [x] New feature

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPStan, PHP CS Fixer, Deptrac, PHPUnit (100% coverage)
- [x] 100% MSI maintained: `bin/infection` (scoped to the touched files)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)