### PR TITLE
feat: acknowledge a review pass skipped for zero findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   places it can skip the reviewer pass — the attacker finding nothing, every
   remaining finding already being baseline-accepted, and the mid-run abort
   recovery path finding nothing left to review — which both progress reporters
-  render as a lightweight "no new findings this pass" line. The earlier wording
-  ("no findings to review") read as though the whole audit came up empty even on
+  render as a lightweight one-line acknowledgment. The earlier wording ("no
+  findings to review") read as though the whole audit came up empty even on
   iteration 2+, after findings had already streamed past.
+
+  Each site carries its own `reason` in the event context, because only the
+  first of the three is actually "no new findings": the second means every
+  finding _was_ found and then baseline-accepted, and the third fires as a run
+  is aborting, where a reassuring line would print immediately before the
+  failure. The reporters render "every finding was baseline-accepted — review
+  skipped" and "nothing left to review after the abort" respectively.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   finding _was_ found and then baseline-accepted, and the third fires as a run
   is aborting, where a reassuring line would print immediately before the
   failure. The reporters render "every finding was baseline-accepted — review
-  skipped" and "nothing left to review after the abort" respectively.
+  skipped" and "nothing left to review after the abort" respectively. Each of
+  the three reasons is matched explicitly, and a reason the reporters do not
+  recognise falls back to a bare "review skipped" rather than borrowing the "no
+  new findings" wording: a fourth reason added later would otherwise be
+  announced as the wrong cause, which is worse than naming none.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Added
+
+- **A clean run (zero findings) no longer leaves the reviewer step looking like
+  it silently disappeared.** `ConsoleProgressReporter::onReviewStarted()` (and
+  its `PlainProgressReporter` counterpart) only ever fired when the attacker
+  recorded at least one finding, so a run with nothing to report jumped straight
+  from the last chunk to the final report with no acknowledgment that reviewing
+  had nothing to do. `AuditOrchestrator::run()` now reports a new
+  `review.skipped` progress event (`src/Audit/Domain/Model/ProgressEvent.php`)
+  when the attacker pass yields zero findings overall, which both progress
+  reporters render as a lightweight "no findings to review" line.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,14 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   its `PlainProgressReporter` counterpart) only ever fired when the attacker
   recorded at least one finding, so a run with nothing to report jumped straight
   from the last chunk to the final report with no acknowledgment that reviewing
-  had nothing to do. `AuditOrchestrator::run()` now reports a new
-  `review.skipped` progress event (`src/Audit/Domain/Model/ProgressEvent.php`)
-  when the attacker pass yields zero findings overall, which both progress
-  reporters render as a lightweight "no findings to review" line.
+  had nothing to do. `AuditOrchestrator` now reports a new `review.skipped`
+  progress event (`src/Audit/Domain/Model/ProgressEvent.php`) from all three
+  places it can skip the reviewer pass — the attacker finding nothing, every
+  remaining finding already being baseline-accepted, and the mid-run abort
+  recovery path finding nothing left to review — which both progress reporters
+  render as a lightweight "no new findings this pass" line. The earlier wording
+  ("no findings to review") read as though the whole audit came up empty even on
+  iteration 2+, after findings had already streamed past.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/src/Audit/Application/Agent/AuditOrchestrator.php
+++ b/src/Audit/Application/Agent/AuditOrchestrator.php
@@ -91,7 +91,7 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
 
             if ([] === $filtered) {
                 $this->logger->info('Attacker found no new findings, stopping');
-                $this->progressReporter->report(ProgressEvent::ReviewSkipped->value);
+                $this->progressReporter->report(ProgressEvent::ReviewSkipped->value, ['reason' => 'no_new_findings']);
                 break;
             }
 
@@ -99,7 +99,7 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
 
             if ([] === $reviewCandidates) {
                 $this->logger->info('Every remaining finding is baseline-accepted, stopping');
-                $this->progressReporter->report(ProgressEvent::ReviewSkipped->value);
+                $this->progressReporter->report(ProgressEvent::ReviewSkipped->value, ['reason' => 'all_baseline_accepted']);
                 break;
             }
 
@@ -226,7 +226,7 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
         $filtered = $this->withoutBaselineAccepted($this->filterByConfidence($rawFindings), $auditContext);
 
         if ([] === $filtered) {
-            $this->progressReporter->report(ProgressEvent::ReviewSkipped->value);
+            $this->progressReporter->report(ProgressEvent::ReviewSkipped->value, ['reason' => 'nothing_recovered']);
 
             return;
         }

--- a/src/Audit/Application/Agent/AuditOrchestrator.php
+++ b/src/Audit/Application/Agent/AuditOrchestrator.php
@@ -99,6 +99,7 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
 
             if ([] === $reviewCandidates) {
                 $this->logger->info('Every remaining finding is baseline-accepted, stopping');
+                $this->progressReporter->report(ProgressEvent::ReviewSkipped->value);
                 break;
             }
 
@@ -225,6 +226,8 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
         $filtered = $this->withoutBaselineAccepted($this->filterByConfidence($rawFindings), $auditContext);
 
         if ([] === $filtered) {
+            $this->progressReporter->report(ProgressEvent::ReviewSkipped->value);
+
             return;
         }
 

--- a/src/Audit/Application/Agent/AuditOrchestrator.php
+++ b/src/Audit/Application/Agent/AuditOrchestrator.php
@@ -91,6 +91,7 @@ final readonly class AuditOrchestrator implements AuditOrchestratorInterface
 
             if ([] === $filtered) {
                 $this->logger->info('Attacker found no new findings, stopping');
+                $this->progressReporter->report(ProgressEvent::ReviewSkipped->value);
                 break;
             }
 

--- a/src/Audit/Domain/Model/ProgressEvent.php
+++ b/src/Audit/Domain/Model/ProgressEvent.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Model;
 
-/** @internal not part of the BC promise — the enum *values* (`pipeline.started`, `stage.started`, `stage.completed`, `pipeline.completed`, `audit.started`, `audit.iteration.started`, `attacker.chunk.started`, `attacker.chunk.completed`, `attacker.finding.recorded`, `review.started`, `review.finding.reviewed`, `review.completed`) are the wire-format event names carried through `ProgressReporterInterface::report()` and are stable, but the PHP enum itself is for internal use only. */
+/** @internal not part of the BC promise — the enum *values* (`pipeline.started`, `stage.started`, `stage.completed`, `pipeline.completed`, `audit.started`, `audit.iteration.started`, `attacker.chunk.started`, `attacker.chunk.completed`, `attacker.finding.recorded`, `review.started`, `review.skipped`, `review.finding.reviewed`, `review.completed`) are the wire-format event names carried through `ProgressReporterInterface::report()` and are stable, but the PHP enum itself is for internal use only. */
 enum ProgressEvent: string
 {
     case PipelineStarted = 'pipeline.started';
@@ -26,6 +26,7 @@ enum ProgressEvent: string
     case AttackerChunkCompleted = 'attacker.chunk.completed';
     case AttackerFindingRecorded = 'attacker.finding.recorded';
     case ReviewStarted = 'review.started';
+    case ReviewSkipped = 'review.skipped';
     case ReviewFindingReviewed = 'review.finding.reviewed';
     case BaselineFindingSkipped = 'baseline.finding.skipped';
     case ReviewCompleted = 'review.completed';

--- a/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
@@ -210,7 +210,7 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
 
     private function onReviewSkipped(): void
     {
-        $this->writeAboveBar('<fg=gray>  ⚖ no findings to review</>');
+        $this->writeAboveBar('<fg=gray>  ⚖ no new findings this pass</>');
     }
 
     /** @param array<string, mixed> $context */

--- a/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
@@ -32,9 +32,11 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\TerminalTex
  * stage.completed advances it, and pipeline.completed finishes it. The audit
  * narrative is printed as lines above the bar: audit.started (attack-surface
  * overview), attacker.finding.recorded (each finding as it is flagged),
- * attacker.chunk.completed (each chunk with its elapsed time), and
- * review.completed (the reviewer tally). Unhandled events are ignored. The
- * non-decorated counterpart is PlainProgressReporter.
+ * attacker.chunk.completed (each chunk with its elapsed time), review.skipped
+ * (acknowledges a zero-finding pass so the reviewer step doesn't read as
+ * having silently disappeared), and review.completed (the reviewer tally).
+ * Unhandled events are ignored. The non-decorated counterpart is
+ * PlainProgressReporter.
  *
  * Mutable because ProgressBar is stateful (tracks current step, format, and
  * output position).
@@ -72,6 +74,7 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
             ProgressEvent::AttackerChunkCompleted => $this->onAttackerChunkCompleted($context),
             ProgressEvent::AttackerFindingRecorded => $this->onAttackerFindingRecorded($context),
             ProgressEvent::ReviewStarted => $this->onReviewStarted($context),
+            ProgressEvent::ReviewSkipped => $this->onReviewSkipped(),
             ProgressEvent::ReviewFindingReviewed => $this->onReviewFindingReviewed($context),
             ProgressEvent::BaselineFindingSkipped => $this->onBaselineFindingSkipped($context),
             ProgressEvent::ReviewCompleted => $this->onReviewCompleted($context),
@@ -203,6 +206,11 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
         $this->reviewTotal = $findings;
         $this->reviewedCount = 0;
         $this->updateMessage(\sprintf('reviewing %d finding(s)', $findings));
+    }
+
+    private function onReviewSkipped(): void
+    {
+        $this->writeAboveBar('<fg=gray>  ⚖ no findings to review</>');
     }
 
     /** @param array<string, mixed> $context */

--- a/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
@@ -218,9 +218,10 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
     private function reviewSkippedReason(array $context): string
     {
         return match (ProgressContext::string($context, 'reason')) {
+            'no_new_findings' => 'no new findings this pass',
             'all_baseline_accepted' => 'every finding was baseline-accepted — review skipped',
             'nothing_recovered' => 'nothing left to review after the abort',
-            default => 'no new findings this pass',
+            default => 'review skipped',
         };
     }
 

--- a/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/ConsoleProgressReporter.php
@@ -74,7 +74,7 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
             ProgressEvent::AttackerChunkCompleted => $this->onAttackerChunkCompleted($context),
             ProgressEvent::AttackerFindingRecorded => $this->onAttackerFindingRecorded($context),
             ProgressEvent::ReviewStarted => $this->onReviewStarted($context),
-            ProgressEvent::ReviewSkipped => $this->onReviewSkipped(),
+            ProgressEvent::ReviewSkipped => $this->onReviewSkipped($context),
             ProgressEvent::ReviewFindingReviewed => $this->onReviewFindingReviewed($context),
             ProgressEvent::BaselineFindingSkipped => $this->onBaselineFindingSkipped($context),
             ProgressEvent::ReviewCompleted => $this->onReviewCompleted($context),
@@ -208,9 +208,20 @@ final class ConsoleProgressReporter implements ProgressReporterInterface
         $this->updateMessage(\sprintf('reviewing %d finding(s)', $findings));
     }
 
-    private function onReviewSkipped(): void
+    /** @param array<string, mixed> $context */
+    private function onReviewSkipped(array $context): void
     {
-        $this->writeAboveBar('<fg=gray>  ⚖ no new findings this pass</>');
+        $this->writeAboveBar(\sprintf('<fg=gray>  ⚖ %s</>', $this->reviewSkippedReason($context)));
+    }
+
+    /** @param array<string, mixed> $context */
+    private function reviewSkippedReason(array $context): string
+    {
+        return match (ProgressContext::string($context, 'reason')) {
+            'all_baseline_accepted' => 'every finding was baseline-accepted — review skipped',
+            'nothing_recovered' => 'nothing left to review after the abort',
+            default => 'no new findings this pass',
+        };
     }
 
     /** @param array<string, mixed> $context */

--- a/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
@@ -46,7 +46,7 @@ final readonly class PlainProgressReporter implements ProgressReporterInterface
             ProgressEvent::AttackerChunkCompleted => $this->writeln($this->chunkDoneLine($context)),
             ProgressEvent::AttackerFindingRecorded => $this->writeln($this->findingLine($context)),
             ProgressEvent::ReviewStarted => $this->writeln($this->reviewStartLine($context)),
-            ProgressEvent::ReviewSkipped => $this->writeln('No findings to review.'),
+            ProgressEvent::ReviewSkipped => $this->writeln('No new findings this pass.'),
             ProgressEvent::ReviewFindingReviewed => $this->writeln($this->reviewedLine($context)),
             ProgressEvent::BaselineFindingSkipped => $this->writeln($this->baselineSkippedLine($context)),
             ProgressEvent::ReviewCompleted => $this->writeln($this->reviewSummaryLine($context)),

--- a/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
@@ -46,7 +46,7 @@ final readonly class PlainProgressReporter implements ProgressReporterInterface
             ProgressEvent::AttackerChunkCompleted => $this->writeln($this->chunkDoneLine($context)),
             ProgressEvent::AttackerFindingRecorded => $this->writeln($this->findingLine($context)),
             ProgressEvent::ReviewStarted => $this->writeln($this->reviewStartLine($context)),
-            ProgressEvent::ReviewSkipped => $this->writeln('No new findings this pass.'),
+            ProgressEvent::ReviewSkipped => $this->writeln($this->reviewSkippedLine($context)),
             ProgressEvent::ReviewFindingReviewed => $this->writeln($this->reviewedLine($context)),
             ProgressEvent::BaselineFindingSkipped => $this->writeln($this->baselineSkippedLine($context)),
             ProgressEvent::ReviewCompleted => $this->writeln($this->reviewSummaryLine($context)),
@@ -98,6 +98,16 @@ final readonly class PlainProgressReporter implements ProgressReporterInterface
     private function reviewStartLine(array $context): string
     {
         return \sprintf('Reviewing %d finding(s)…', ProgressContext::int($context, 'findings'));
+    }
+
+    /** @param array<string, mixed> $context */
+    private function reviewSkippedLine(array $context): string
+    {
+        return match (ProgressContext::string($context, 'reason')) {
+            'all_baseline_accepted' => 'Every finding was baseline-accepted — review skipped.',
+            'nothing_recovered' => 'Nothing left to review after the abort.',
+            default => 'No new findings this pass.',
+        };
     }
 
     /** @param array<string, mixed> $context */

--- a/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
@@ -104,9 +104,10 @@ final readonly class PlainProgressReporter implements ProgressReporterInterface
     private function reviewSkippedLine(array $context): string
     {
         return match (ProgressContext::string($context, 'reason')) {
+            'no_new_findings' => 'No new findings this pass.',
             'all_baseline_accepted' => 'Every finding was baseline-accepted — review skipped.',
             'nothing_recovered' => 'Nothing left to review after the abort.',
-            default => 'No new findings this pass.',
+            default => 'Review skipped.',
         };
     }
 

--- a/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
+++ b/src/Audit/Infrastructure/Progress/PlainProgressReporter.php
@@ -46,6 +46,7 @@ final readonly class PlainProgressReporter implements ProgressReporterInterface
             ProgressEvent::AttackerChunkCompleted => $this->writeln($this->chunkDoneLine($context)),
             ProgressEvent::AttackerFindingRecorded => $this->writeln($this->findingLine($context)),
             ProgressEvent::ReviewStarted => $this->writeln($this->reviewStartLine($context)),
+            ProgressEvent::ReviewSkipped => $this->writeln('No findings to review.'),
             ProgressEvent::ReviewFindingReviewed => $this->writeln($this->reviewedLine($context)),
             ProgressEvent::BaselineFindingSkipped => $this->writeln($this->baselineSkippedLine($context)),
             ProgressEvent::ReviewCompleted => $this->writeln($this->reviewSummaryLine($context)),

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -1284,7 +1284,11 @@ final class AuditOrchestratorTest extends TestCase
         $reviewerLlm = self::createStub(LLMClientInterface::class);
         $attackerLlm->method('complete')->willReturn($this->emptyResponse());
 
-        $auditOrchestrator = $this->makeOrchestrator($attackerLlm, $reviewerLlm, ['logger' => $logger]);
+        $recordingProgressReporter = new RecordingProgressReporter();
+        $auditOrchestrator = $this->makeOrchestrator($attackerLlm, $reviewerLlm, [
+            'logger' => $logger,
+            'recordingProgressReporter' => $recordingProgressReporter,
+        ]);
         $auditContext = $this->makeContextWithMapping();
 
         $auditOrchestrator->orchestrate($auditContext);
@@ -1295,6 +1299,7 @@ final class AuditOrchestratorTest extends TestCase
         ));
 
         self::assertCount(1, $stoppedLogs);
+        self::assertContains(['review.skipped', []], $recordingProgressReporter->events);
     }
 
     /**

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -612,6 +612,32 @@ final class AuditOrchestratorTest extends TestCase
      * @throws BudgetExceededException
      * @throws LLMProviderException
      */
+    public function test_it_reports_review_skipped_when_every_finding_is_baseline_accepted(): void
+    {
+        $attackerLlm = self::createStub(LLMClientInterface::class);
+        $reviewerLlm = self::createStub(LLMClientInterface::class);
+        $attackerLlm->method('complete')->willReturn(
+            $this->attackerResponse([$this->vulnPayload()]),
+        );
+
+        $recordingProgressReporter = new RecordingProgressReporter();
+        $auditOrchestrator = $this->makeOrchestrator($attackerLlm, $reviewerLlm, [
+            'recordingProgressReporter' => $recordingProgressReporter,
+        ]);
+        $auditContext = $this->makeContextWithMapping([$this->defaultPayloadFingerprint()]);
+
+        $auditOrchestrator->orchestrate($auditContext);
+
+        self::assertContains(['review.skipped', []], $recordingProgressReporter->events);
+    }
+
+    /**
+     * @throws InvalidTokenUsageException
+     * @throws InvalidAuditContextException
+     * @throws InvalidProjectFileException
+     * @throws BudgetExceededException
+     * @throws LLMProviderException
+     */
     public function test_it_skips_a_baselined_finding_that_follows_a_non_baselined_one(): void
     {
         $attackerLlm = self::createStub(LLMClientInterface::class);
@@ -2044,6 +2070,36 @@ final class AuditOrchestratorTest extends TestCase
                 static fn (array $event): bool => 'review.started' === $event[0],
             )),
         );
+    }
+
+    /**
+     * @throws InvalidAuditContextException
+     * @throws InvalidProjectFileException
+     * @throws LLMProviderException
+     */
+    public function test_it_reports_review_skipped_when_no_candidate_survives_an_attacker_abort(): void
+    {
+        $recordingAttackerAgent = new RecordingAttackerAgent([], BudgetExceededException::forTokens(500, 100), []);
+
+        $reviewerLlm = self::createStub(LLMClientInterface::class);
+        $reviewerAgent = new ReviewerAgent(
+            new ReviewerAgentCollaborators($reviewerLlm, new ReviewerPromptBuilder(), new NullLogger()),
+            new ReviewerModeConfiguration(),
+        );
+
+        $recordingProgressReporter = new RecordingProgressReporter();
+        $auditOrchestrator = new AuditOrchestrator($recordingAttackerAgent, $reviewerAgent, new NullLogger(), new AuditLoopSettings(), $recordingProgressReporter);
+        $auditContext = $this->makeContextWithMapping();
+
+        $budgetExceeded = false;
+        try {
+            $auditOrchestrator->orchestrate($auditContext);
+        } catch (BudgetExceededException) {
+            $budgetExceeded = true;
+        }
+
+        self::assertTrue($budgetExceeded, 'The orchestrator must rethrow the attacker BudgetExceededException.');
+        self::assertContains(['review.skipped', []], $recordingProgressReporter->events);
     }
 
     /**

--- a/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
+++ b/tests/Phpunit/Unit/Application/Agent/AuditOrchestratorTest.php
@@ -628,7 +628,7 @@ final class AuditOrchestratorTest extends TestCase
 
         $auditOrchestrator->orchestrate($auditContext);
 
-        self::assertContains(['review.skipped', []], $recordingProgressReporter->events);
+        self::assertContains(['review.skipped', ['reason' => 'all_baseline_accepted']], $recordingProgressReporter->events);
     }
 
     /**
@@ -1325,7 +1325,7 @@ final class AuditOrchestratorTest extends TestCase
         ));
 
         self::assertCount(1, $stoppedLogs);
-        self::assertContains(['review.skipped', []], $recordingProgressReporter->events);
+        self::assertContains(['review.skipped', ['reason' => 'no_new_findings']], $recordingProgressReporter->events);
     }
 
     /**
@@ -2099,7 +2099,7 @@ final class AuditOrchestratorTest extends TestCase
         }
 
         self::assertTrue($budgetExceeded, 'The orchestrator must rethrow the attacker BudgetExceededException.');
-        self::assertContains(['review.skipped', []], $recordingProgressReporter->events);
+        self::assertContains(['review.skipped', ['reason' => 'nothing_recovered']], $recordingProgressReporter->events);
     }
 
     /**

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
@@ -340,6 +340,22 @@ final class ConsoleProgressReporterTest extends TestCase
         self::assertSame('', $this->bufferedOutput->fetch());
     }
 
+    public function test_it_acknowledges_a_review_pass_skipped_for_zero_findings(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('review.skipped');
+
+        self::assertStringContainsString('no findings to review', $this->bufferedOutput->fetch());
+    }
+
+    public function test_review_skipped_before_pipeline_started_is_a_no_op(): void
+    {
+        $this->consoleProgressReporter->report('review.skipped');
+
+        self::assertSame('', $this->bufferedOutput->fetch());
+    }
+
     public function test_it_colors_a_finding_by_its_severity_in_a_decorated_terminal(): void
     {
         $bufferedOutput = new BufferedOutput(decorated: true);

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
@@ -349,6 +349,24 @@ final class ConsoleProgressReporterTest extends TestCase
         self::assertStringContainsString('no new findings this pass', $this->bufferedOutput->fetch());
     }
 
+    public function test_it_names_baseline_acceptance_as_the_reason_a_review_pass_was_skipped(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('review.skipped', ['reason' => 'all_baseline_accepted']);
+
+        self::assertStringContainsString('every finding was baseline-accepted — review skipped', $this->bufferedOutput->fetch());
+    }
+
+    public function test_it_names_an_abort_as_the_reason_a_review_pass_was_skipped(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('review.skipped', ['reason' => 'nothing_recovered']);
+
+        self::assertStringContainsString('nothing left to review after the abort', $this->bufferedOutput->fetch());
+    }
+
     public function test_review_skipped_before_pipeline_started_is_a_no_op(): void
     {
         $this->consoleProgressReporter->report('review.skipped');

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
@@ -346,7 +346,7 @@ final class ConsoleProgressReporterTest extends TestCase
         $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
         $this->consoleProgressReporter->report('review.skipped');
 
-        self::assertStringContainsString('no findings to review', $this->bufferedOutput->fetch());
+        self::assertStringContainsString('no new findings this pass', $this->bufferedOutput->fetch());
     }
 
     public function test_review_skipped_before_pipeline_started_is_a_no_op(): void

--- a/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/ConsoleProgressReporterTest.php
@@ -344,9 +344,25 @@ final class ConsoleProgressReporterTest extends TestCase
     {
         $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
         $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
-        $this->consoleProgressReporter->report('review.skipped');
+        $this->consoleProgressReporter->report('review.skipped', ['reason' => 'no_new_findings']);
 
         self::assertStringContainsString('no new findings this pass', $this->bufferedOutput->fetch());
+    }
+
+    /**
+     * A reason the reporter does not recognise must not borrow another reason's
+     * wording — naming the wrong cause is worse than naming none.
+     */
+    public function test_it_falls_back_to_a_neutral_line_for_an_unrecognised_reason(): void
+    {
+        $this->consoleProgressReporter->report('pipeline.started', ['stages' => ['audit']]);
+        $this->consoleProgressReporter->report('stage.started', ['stage' => 'audit']);
+        $this->consoleProgressReporter->report('review.skipped', ['reason' => 'a_reason_added_later']);
+
+        $display = $this->bufferedOutput->fetch();
+
+        self::assertStringContainsString('review skipped', $display);
+        self::assertStringNotContainsString('no new findings this pass', $display);
     }
 
     public function test_it_names_baseline_acceptance_as_the_reason_a_review_pass_was_skipped(): void

--- a/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
@@ -171,7 +171,7 @@ final class PlainProgressReporterTest extends TestCase
     {
         $this->plainProgressReporter->report('review.skipped');
 
-        self::assertSame("No findings to review.\n", $this->bufferedOutput->fetch());
+        self::assertSame("No new findings this pass.\n", $this->bufferedOutput->fetch());
     }
 
     public function test_it_ignores_pipeline_and_stage_events(): void

--- a/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
@@ -167,11 +167,29 @@ final class PlainProgressReporterTest extends TestCase
         self::assertSame("  2 validated, 1 rejected\n", $this->bufferedOutput->fetch());
     }
 
-    public function test_it_prints_review_skipped(): void
+    public function test_it_names_an_exhausted_pass_as_the_reason_a_review_pass_was_skipped(): void
+    {
+        $this->plainProgressReporter->report('review.skipped', ['reason' => 'no_new_findings']);
+
+        self::assertSame("No new findings this pass.\n", $this->bufferedOutput->fetch());
+    }
+
+    /**
+     * A reason the reporter does not recognise must not borrow another reason's
+     * wording — naming the wrong cause is worse than naming none.
+     */
+    public function test_it_falls_back_to_a_neutral_line_for_an_unrecognised_reason(): void
+    {
+        $this->plainProgressReporter->report('review.skipped', ['reason' => 'a_reason_added_later']);
+
+        self::assertSame("Review skipped.\n", $this->bufferedOutput->fetch());
+    }
+
+    public function test_it_falls_back_to_a_neutral_line_when_no_reason_is_given(): void
     {
         $this->plainProgressReporter->report('review.skipped');
 
-        self::assertSame("No new findings this pass.\n", $this->bufferedOutput->fetch());
+        self::assertSame("Review skipped.\n", $this->bufferedOutput->fetch());
     }
 
     public function test_it_names_baseline_acceptance_as_the_reason_a_review_pass_was_skipped(): void

--- a/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
@@ -174,6 +174,20 @@ final class PlainProgressReporterTest extends TestCase
         self::assertSame("No new findings this pass.\n", $this->bufferedOutput->fetch());
     }
 
+    public function test_it_names_baseline_acceptance_as_the_reason_a_review_pass_was_skipped(): void
+    {
+        $this->plainProgressReporter->report('review.skipped', ['reason' => 'all_baseline_accepted']);
+
+        self::assertSame("Every finding was baseline-accepted — review skipped.\n", $this->bufferedOutput->fetch());
+    }
+
+    public function test_it_names_an_abort_as_the_reason_a_review_pass_was_skipped(): void
+    {
+        $this->plainProgressReporter->report('review.skipped', ['reason' => 'nothing_recovered']);
+
+        self::assertSame("Nothing left to review after the abort.\n", $this->bufferedOutput->fetch());
+    }
+
     public function test_it_ignores_pipeline_and_stage_events(): void
     {
         $this->plainProgressReporter->report('pipeline.started', ['stages' => ['ingestion']]);

--- a/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Progress/PlainProgressReporterTest.php
@@ -167,6 +167,13 @@ final class PlainProgressReporterTest extends TestCase
         self::assertSame("  2 validated, 1 rejected\n", $this->bufferedOutput->fetch());
     }
 
+    public function test_it_prints_review_skipped(): void
+    {
+        $this->plainProgressReporter->report('review.skipped');
+
+        self::assertSame("No findings to review.\n", $this->bufferedOutput->fetch());
+    }
+
     public function test_it_ignores_pipeline_and_stage_events(): void
     {
         $this->plainProgressReporter->report('pipeline.started', ['stages' => ['ingestion']]);


### PR DESCRIPTION
## Summary

On a clean run (zero findings), progress output jumped straight from the last chunk to the final report with no acknowledgment that reviewing had nothing to do. `AuditOrchestrator::run()` now reports a new `review.skipped` progress event when the attacker pass yields zero findings overall, which both `ConsoleProgressReporter` and `PlainProgressReporter` render as a lightweight "no findings to review" line.

Closes #316

## Type of change

- [x] New feature

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPStan, PHP CS Fixer, Deptrac, PHPUnit (100% coverage)
- [x] 100% MSI maintained: `bin/infection` (scoped to the touched files)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)