### PR TITLE
feat: surface the bundled models-dev pricing version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `ModelsDevPricingProvider::effectiveCatalogPath()` is the single resolution
   point both `loadCatalog()` and the check go through. An override path that
   does not exist yet falls through to the packaged catalog instead of shadowing
-  it, so pointing the check at the refresh location before anything writes
-  there is safe. When neither an override nor a packaged catalog is readable,
-  the check warns as before.
+  it, so pointing the check at the refresh location before anything writes there
+  is safe. When neither an override nor a packaged catalog is readable, the
+  check warns as before.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Added
+
+- **`doctor` and `--version` now surface which `symfony/models-dev` pricing
+  snapshot is bundled.** A standalone install's cost figures (`--dry-run`,
+  the report's `Cost` line) come from whatever `symfony/models-dev` catalog
+  was newest on Packagist when that release's binary was built, with no way
+  to see which snapshot that is. `EnvironmentDoctor::diagnose()`
+  (`src/Command/EnvironmentDoctor.php`) gains a "Pricing catalog" check
+  reporting the installed version (`Composer\InstalledVersions`), and the
+  standalone binary's `--version` output now appends it too, via a new
+  `StandaloneApplication` (`src/Standalone/StandaloneApplication.php`)
+  overriding `getLongVersion()` — the bare `Symfony\Component\Console\Application`
+  used by `StandaloneApplicationFactory` had no other extension point for this.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   had no other extension point for this. The `'symfony/models-dev'` package name
   now lives in one place, `ModelsDevPricingProvider::CATALOG_PACKAGE` (made
   `public`); `EnvironmentDoctor` and `StandaloneApplicationFactory` reference it
-  instead of each restating their own copy of the string.
+  instead of each restating their own copy of the string. The check names the
+  catalog **file** it resolved, not just the packaged version, so it can never
+  report a snapshot the run is not actually pricing from once `self-update`
+  starts writing a refreshed catalog into the XDG cache directory — a new
+  `ModelsDevPricingProvider::effectiveCatalogPath()` is the single resolution
+  point both `loadCatalog()` and the check go through. An override path that
+  does not exist yet falls through to the packaged catalog instead of shadowing
+  it, so pointing the check at the refresh location before anything writes
+  there is safe. When neither an override nor a packaged catalog is readable,
+  the check warns as before.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `StandaloneApplication` (`src/Standalone/StandaloneApplication.php`)
   overriding `getLongVersion()` — the bare
   `Symfony\Component\Console\Application` used by `StandaloneApplicationFactory`
-  had no other extension point for this.
+  had no other extension point for this. The `'symfony/models-dev'` package name
+  now lives in one place, `ModelsDevPricingProvider::CATALOG_PACKAGE` (made
+  `public`); `EnvironmentDoctor` and `StandaloneApplicationFactory` reference it
+  instead of each restating their own copy of the string.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,24 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   newest on Packagist when that release's binary was built, with no way to see
   which snapshot that is. `EnvironmentDoctor::diagnose()`
   (`src/Command/EnvironmentDoctor.php`) gains a "Pricing catalog" check
-  reporting the installed version (`Composer\InstalledVersions`), and the
-  standalone binary's `--version` output now appends it too, via a new
-  `StandaloneApplication` (`src/Standalone/StandaloneApplication.php`)
-  overriding `getLongVersion()` — the bare
-  `Symfony\Component\Console\Application` used by `StandaloneApplicationFactory`
-  had no other extension point for this. The `'symfony/models-dev'` package name
-  now lives in one place, `ModelsDevPricingProvider::CATALOG_PACKAGE` (made
-  `public`); `EnvironmentDoctor` and `StandaloneApplicationFactory` reference it
-  instead of each restating their own copy of the string. The check names the
-  catalog **file** it resolved, not just the packaged version, so it can never
-  report a snapshot the run is not actually pricing from once `self-update`
-  starts writing a refreshed catalog into the XDG cache directory — a new
+  reporting the installed version (`Composer\InstalledVersions`) and the
+  resolved catalog file, canonicalized through
+  `Symfony\Component\Filesystem\Path` — `InstalledVersions::getInstallPath()`
+  answers relative to the Composer directory, so the raw path printed a
+  `vendor/composer/../symfony/models-dev/…` detour at the user, and `realpath()`
+  cannot collapse it because it returns `false` for the `phar://` path a
+  packaged binary reports. The standalone binary's `--version` output now
+  appends it too, via a new `StandaloneApplication`
+  (`src/Standalone/StandaloneApplication.php`) overriding `getLongVersion()` —
+  the bare `Symfony\Component\Console\Application` used by
+  `StandaloneApplicationFactory` had no other extension point for this. The
+  `'symfony/models-dev'` package name now lives in one place,
+  `ModelsDevPricingProvider::CATALOG_PACKAGE` (made `public`);
+  `EnvironmentDoctor` and `StandaloneApplicationFactory` reference it instead of
+  each restating their own copy of the string. The check names the catalog
+  **file** it resolved, not just the packaged version, so it can never report a
+  snapshot the run is not actually pricing from once `self-update` starts
+  writing a refreshed catalog into the XDG cache directory — a new
   `ModelsDevPricingProvider::effectiveCatalogPath()` is the single resolution
   point both `loadCatalog()` and the check go through. An override path that
   does not exist yet falls through to the packaged catalog instead of shadowing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   is safe. When neither an override nor a packaged catalog is readable, the
   check warns as before.
 
+  The version and the path are reported together only when they describe the
+  same file. `InstalledVersions::getPrettyVersion()` describes the packaged
+  catalog and nothing else, so when the resolved path is a refreshed override —
+  whose contents came from upstream `main` at refresh time — the check names the
+  override and says the bundled package is unused, rather than stamping a
+  version onto a file that does not have it.
+  `ModelsDevPricingProvider::packagedCatalogPath()` (the former private
+  `defaultCatalogPath()`, now `public`) is what the check compares against.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,17 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 ### Added
 
 - **`doctor` and `--version` now surface which `symfony/models-dev` pricing
-  snapshot is bundled.** A standalone install's cost figures (`--dry-run`,
-  the report's `Cost` line) come from whatever `symfony/models-dev` catalog
-  was newest on Packagist when that release's binary was built, with no way
-  to see which snapshot that is. `EnvironmentDoctor::diagnose()`
+  snapshot is bundled.** A standalone install's cost figures (`--dry-run`, the
+  report's `Cost` line) come from whatever `symfony/models-dev` catalog was
+  newest on Packagist when that release's binary was built, with no way to see
+  which snapshot that is. `EnvironmentDoctor::diagnose()`
   (`src/Command/EnvironmentDoctor.php`) gains a "Pricing catalog" check
   reporting the installed version (`Composer\InstalledVersions`), and the
   standalone binary's `--version` output now appends it too, via a new
   `StandaloneApplication` (`src/Standalone/StandaloneApplication.php`)
-  overriding `getLongVersion()` — the bare `Symfony\Component\Console\Application`
-  used by `StandaloneApplicationFactory` had no other extension point for this.
+  overriding `getLongVersion()` — the bare
+  `Symfony\Component\Console\Application` used by `StandaloneApplicationFactory`
+  had no other extension point for this.
 
 ## [1.19.1] — 2026-08-13 — Lineage
 

--- a/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
+++ b/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
@@ -18,6 +18,7 @@ use JsonException;
 use OutOfBoundsException;
 use Override;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Path;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CacheAwarePricingProviderInterface;
 
 /**
@@ -271,6 +272,11 @@ final class ModelsDevPricingProvider implements CacheAwarePricingProviderInterfa
      * the only file whose contents `InstalledVersions::getPrettyVersion()`
      * actually describes, which is why `doctor` compares against it before
      * naming a version.
+     *
+     * `InstalledVersions::getInstallPath()` resolves relative to the Composer
+     * directory, so it hands back a `vendor/composer/../symfony/...` detour.
+     * `Path::canonicalize()` collapses it lexically — `realpath()` cannot, it
+     * returns `false` for the `phar://` path a packaged binary reports.
      */
     public function packagedCatalogPath(): ?string
     {
@@ -280,7 +286,7 @@ final class ModelsDevPricingProvider implements CacheAwarePricingProviderInterfa
             return null;
         }
 
-        return null === $installPath ? null : \sprintf('%s/%s', $installPath, self::CATALOG_FILENAME);
+        return null === $installPath ? null : Path::canonicalize(\sprintf('%s/%s', $installPath, self::CATALOG_FILENAME));
     }
 
     /** @return array<array-key, mixed> */

--- a/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
+++ b/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
@@ -31,7 +31,7 @@ final class ModelsDevPricingProvider implements CacheAwarePricingProviderInterfa
 {
     public const string CATALOG_PACKAGE = 'symfony/models-dev';
 
-    private const string CATALOG_FILENAME = 'models-dev.json';
+    public const string CATALOG_FILENAME = 'models-dev.json';
 
     /**
      * Official first-party provider keys, in resolution priority order. A bare
@@ -235,7 +235,7 @@ final class ModelsDevPricingProvider implements CacheAwarePricingProviderInterfa
     /** @return array<array-key, mixed> */
     private function loadCatalog(): array
     {
-        $path = $this->catalogPath ?? $this->defaultCatalogPath();
+        $path = $this->effectiveCatalogPath();
         $contents = null !== $path && is_file($path) ? file_get_contents($path) : false;
         if (false === $contents) {
             return $this->disablePricing('catalog file not found or unreadable', $path);
@@ -248,6 +248,22 @@ final class ModelsDevPricingProvider implements CacheAwarePricingProviderInterfa
         }
 
         return \is_array($decoded) ? $decoded : $this->disablePricing('catalog root is not an object', $path);
+    }
+
+    /**
+     * The catalog file this provider actually reads, so `doctor` can name it
+     * instead of assuming the packaged one — a `self-update` refresh writes an
+     * override that takes precedence. An override that does not exist yet falls
+     * through to the packaged catalog rather than shadowing it, which is what
+     * makes the override location safe to point at before anything writes there.
+     */
+    public function effectiveCatalogPath(): ?string
+    {
+        if (null !== $this->catalogPath && is_file($this->catalogPath)) {
+            return $this->catalogPath;
+        }
+
+        return $this->defaultCatalogPath() ?? $this->catalogPath;
     }
 
     private function defaultCatalogPath(): ?string

--- a/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
+++ b/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
@@ -263,10 +263,16 @@ final class ModelsDevPricingProvider implements CacheAwarePricingProviderInterfa
             return $this->catalogPath;
         }
 
-        return $this->defaultCatalogPath() ?? $this->catalogPath;
+        return $this->packagedCatalogPath() ?? $this->catalogPath;
     }
 
-    private function defaultCatalogPath(): ?string
+    /**
+     * The catalog shipped with the installed `symfony/models-dev` package —
+     * the only file whose contents `InstalledVersions::getPrettyVersion()`
+     * actually describes, which is why `doctor` compares against it before
+     * naming a version.
+     */
+    public function packagedCatalogPath(): ?string
     {
         try {
             $installPath = InstalledVersions::getInstallPath($this->catalogPackage);

--- a/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
+++ b/src/Audit/Infrastructure/Pricing/ModelsDevPricingProvider.php
@@ -29,7 +29,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Domain\Port\CacheAwarePricingProv
  */
 final class ModelsDevPricingProvider implements CacheAwarePricingProviderInterface
 {
-    private const string CATALOG_PACKAGE = 'symfony/models-dev';
+    public const string CATALOG_PACKAGE = 'symfony/models-dev';
 
     private const string CATALOG_FILENAME = 'models-dev.json';
 

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
 use Override;
+use Psr\Log\NullLogger;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MalformedProjectConfigException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingPlatformException;
@@ -48,6 +49,7 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
         private XdgConfigPathResolver $xdgConfigPathResolver,
         private ComposerAvailabilityCheckerInterface $composerAvailabilityChecker,
         private AuditPreflightInterface $auditPreflight,
+        private ModelsDevPricingProvider $modelsDevPricingProvider = new ModelsDevPricingProvider(new NullLogger()),
         private string $pricingCatalogPackage = ModelsDevPricingProvider::CATALOG_PACKAGE,
     ) {}
 
@@ -132,12 +134,20 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
             : new DoctorCheckResult('Composer', DoctorCheckStatus::Warning, 'Not found — needed only to run "init" or switch providers, not to audit.');
     }
 
+    /**
+     * Names the catalog file actually in use rather than only the packaged
+     * version: once `self-update` has refreshed the catalog, the run reads an
+     * override and reporting the package version alone would describe a file
+     * the audit is not pricing from.
+     */
     private function pricingCatalogCheck(): DoctorCheckResult
     {
-        $version = (new ReportPackage($this->pricingCatalogPackage))->version();
+        $catalogPath = $this->modelsDevPricingProvider->effectiveCatalogPath();
 
-        return ReportPackage::UNKNOWN_VERSION === $version
-            ? new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Warning, \sprintf('%s not found — cost figures will show $0.00.', $this->pricingCatalogPackage))
-            : new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Ok, \sprintf('%s %s.', $this->pricingCatalogPackage, $version));
+        if (null === $catalogPath || !is_file($catalogPath)) {
+            return new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Warning, \sprintf('%s not found — cost figures will show $0.00.', $this->pricingCatalogPackage));
+        }
+
+        return new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Ok, \sprintf('%s %s (%s).', $this->pricingCatalogPackage, (new ReportPackage($this->pricingCatalogPackage))->version(), $catalogPath));
     }
 }

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -22,6 +22,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\P
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
 
 use function Symfony\Component\String\b;
 
@@ -41,11 +42,14 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
 {
     private const string BRIDGE_AUTOLOAD_RELATIVE_PATH = 'vendor/autoload.php';
 
+    private const string MODELS_DEV_PACKAGE = 'symfony/models-dev';
+
     public function __construct(
         private StandaloneConfigLoader $standaloneConfigLoader,
         private XdgConfigPathResolver $xdgConfigPathResolver,
         private ComposerAvailabilityCheckerInterface $composerAvailabilityChecker,
         private AuditPreflightInterface $auditPreflight,
+        private string $pricingCatalogPackage = self::MODELS_DEV_PACKAGE,
     ) {}
 
     /**
@@ -60,6 +64,7 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
             $doctorCheckResult,
             $this->bridgeCheck(DoctorCheckStatus::Ok === $doctorCheckResult->status),
             $this->composerCheck(),
+            $this->pricingCatalogCheck(),
         ];
     }
 
@@ -126,5 +131,14 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
         return $this->composerAvailabilityChecker->isAvailable()
             ? new DoctorCheckResult('Composer', DoctorCheckStatus::Ok, 'Available.')
             : new DoctorCheckResult('Composer', DoctorCheckStatus::Warning, 'Not found — needed only to run "init" or switch providers, not to audit.');
+    }
+
+    private function pricingCatalogCheck(): DoctorCheckResult
+    {
+        $version = (new ReportPackage($this->pricingCatalogPackage))->version();
+
+        return ReportPackage::UNKNOWN_VERSION === $version
+            ? new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Warning, \sprintf('%s not found — cost figures will show $0.00.', $this->pricingCatalogPackage))
+            : new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Ok, \sprintf('%s %s.', $this->pricingCatalogPackage, $version));
     }
 }

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -22,6 +22,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\P
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Pricing\ModelsDevPricingProvider;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
 
 use function Symfony\Component\String\b;
@@ -42,14 +43,12 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
 {
     private const string BRIDGE_AUTOLOAD_RELATIVE_PATH = 'vendor/autoload.php';
 
-    private const string MODELS_DEV_PACKAGE = 'symfony/models-dev';
-
     public function __construct(
         private StandaloneConfigLoader $standaloneConfigLoader,
         private XdgConfigPathResolver $xdgConfigPathResolver,
         private ComposerAvailabilityCheckerInterface $composerAvailabilityChecker,
         private AuditPreflightInterface $auditPreflight,
-        private string $pricingCatalogPackage = self::MODELS_DEV_PACKAGE,
+        private string $pricingCatalogPackage = ModelsDevPricingProvider::CATALOG_PACKAGE,
     ) {}
 
     /**

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace VinceAmstoutz\SymfonySecurityAuditor\Command;
 
 use Override;
-use Psr\Log\NullLogger;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MalformedProjectConfigException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingPlatformException;
@@ -49,7 +48,7 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
         private XdgConfigPathResolver $xdgConfigPathResolver,
         private ComposerAvailabilityCheckerInterface $composerAvailabilityChecker,
         private AuditPreflightInterface $auditPreflight,
-        private ModelsDevPricingProvider $modelsDevPricingProvider = new ModelsDevPricingProvider(new NullLogger()),
+        private ModelsDevPricingProvider $modelsDevPricingProvider,
         private string $pricingCatalogPackage = ModelsDevPricingProvider::CATALOG_PACKAGE,
     ) {}
 

--- a/src/Command/EnvironmentDoctor.php
+++ b/src/Command/EnvironmentDoctor.php
@@ -147,6 +147,21 @@ final readonly class EnvironmentDoctor implements EnvironmentDoctorInterface
             return new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Warning, \sprintf('%s not found — cost figures will show $0.00.', $this->pricingCatalogPackage));
         }
 
-        return new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Ok, \sprintf('%s %s (%s).', $this->pricingCatalogPackage, (new ReportPackage($this->pricingCatalogPackage))->version(), $catalogPath));
+        return new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Ok, $this->pricingCatalogDetail($catalogPath));
+    }
+
+    /**
+     * The package version describes the packaged catalog and nothing else. A
+     * `self-update` refresh writes an override whose contents come from
+     * upstream `main` at refresh time, so stamping the bundled version onto it
+     * would assert a version that file does not have.
+     */
+    private function pricingCatalogDetail(string $catalogPath): string
+    {
+        if ($catalogPath !== $this->modelsDevPricingProvider->packagedCatalogPath()) {
+            return \sprintf('refreshed catalog (%s); bundled %s unused.', $catalogPath, $this->pricingCatalogPackage);
+        }
+
+        return \sprintf('%s %s (%s).', $this->pricingCatalogPackage, (new ReportPackage($this->pricingCatalogPackage))->version(), $catalogPath);
     }
 }

--- a/src/Standalone/StandaloneApplication.php
+++ b/src/Standalone/StandaloneApplication.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Standalone;
+
+use Override;
+use Symfony\Component\Console\Application;
+
+/**
+ * Extends the bare Symfony `Application` only to append the bundled
+ * `symfony/models-dev` pricing-catalog version to `--version` — the base
+ * class offers no other extension point for this.
+ *
+ * @internal not part of the BC promise — see docs/versioning.md
+ */
+final class StandaloneApplication extends Application
+{
+    public function __construct(
+        string $name,
+        string $version,
+        private readonly string $modelsDevVersion,
+    ) {
+        parent::__construct($name, $version);
+    }
+
+    #[Override]
+    public function getLongVersion(): string
+    {
+        return \sprintf('%s (symfony/models-dev %s)', parent::getLongVersion(), $this->modelsDevVersion);
+    }
+}

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -61,6 +61,8 @@ final readonly class StandaloneApplicationFactory
 {
     private const string APPLICATION_NAME = 'symfony-security-auditor';
 
+    private const string MODELS_DEV_PACKAGE = 'symfony/models-dev';
+
     private const string PROJECT_CONFIG_FILENAME = '.symfony-security-auditor.yaml';
 
     private const string UPDATE_CHECK_OPT_OUT_VARIABLE = 'SSA_NO_UPDATE_CHECK';
@@ -138,7 +140,7 @@ final readonly class StandaloneApplicationFactory
 
     public function create(): Application
     {
-        $application = new Application(self::APPLICATION_NAME, (new ReportPackage())->version());
+        $application = new StandaloneApplication(self::APPLICATION_NAME, (new ReportPackage())->version(), (new ReportPackage(self::MODELS_DEV_PACKAGE))->version());
         $application->addCommand($this->initCommand());
         $application->addCommand($this->selfUpdateCommand());
         $application->addCommand($this->doctorCommand());

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -233,8 +233,23 @@ final readonly class StandaloneApplicationFactory
                     $this->standaloneContainerFactory,
                     $this->standaloneConsoleCommandFactory,
                 ),
+                new ModelsDevPricingProvider(new NullLogger(), self::refreshedCatalogPath($this->xdgConfigPathResolver)),
             ),
         );
+    }
+
+    /**
+     * Where a refreshed pricing catalog lands. `doctor` builds its provider
+     * with the same override the audit container passes, so the two never
+     * disagree about which catalog file the run prices from.
+     */
+    private static function refreshedCatalogPath(XdgConfigPathResolver $xdgConfigPathResolver): ?string
+    {
+        try {
+            return \sprintf('%s/%s', $xdgConfigPathResolver->cacheDir(), ModelsDevPricingProvider::CATALOG_FILENAME);
+        } catch (UnresolvableConfigPathException) {
+            return null;
+        }
     }
 
     private function lazyAuditCommand(): LazyCommand

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -233,7 +233,7 @@ final readonly class StandaloneApplicationFactory
                     $this->standaloneContainerFactory,
                     $this->standaloneConsoleCommandFactory,
                 ),
-                new ModelsDevPricingProvider(new NullLogger(), self::refreshedCatalogPath($this->xdgConfigPathResolver)),
+                new ModelsDevPricingProvider(new NullLogger(), $this->refreshedCatalogPath()),
             ),
         );
     }
@@ -243,10 +243,10 @@ final readonly class StandaloneApplicationFactory
      * with the same override the audit container passes, so the two never
      * disagree about which catalog file the run prices from.
      */
-    private static function refreshedCatalogPath(XdgConfigPathResolver $xdgConfigPathResolver): ?string
+    private function refreshedCatalogPath(): ?string
     {
         try {
-            return \sprintf('%s/%s', $xdgConfigPathResolver->cacheDir(), ModelsDevPricingProvider::CATALOG_FILENAME);
+            return \sprintf('%s/%s', $this->xdgConfigPathResolver->cacheDir(), ModelsDevPricingProvider::CATALOG_FILENAME);
         } catch (UnresolvableConfigPathException) {
             return null;
         }

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -36,6 +36,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneC
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfigResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\YamlStandaloneConfigWriter;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Pricing\ModelsDevPricingProvider;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Report\ReportPackage;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\FilesystemUpdateCheckStore;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\GitHubBinaryAssetResolver;
@@ -60,8 +61,6 @@ use VinceAmstoutz\SymfonySecurityAuditor\Standalone\Exception\UnresolvableAuditC
 final readonly class StandaloneApplicationFactory
 {
     private const string APPLICATION_NAME = 'symfony-security-auditor';
-
-    private const string MODELS_DEV_PACKAGE = 'symfony/models-dev';
 
     private const string PROJECT_CONFIG_FILENAME = '.symfony-security-auditor.yaml';
 
@@ -140,7 +139,7 @@ final readonly class StandaloneApplicationFactory
 
     public function create(): StandaloneApplication
     {
-        $standaloneApplication = new StandaloneApplication(self::APPLICATION_NAME, (new ReportPackage())->version(), (new ReportPackage(self::MODELS_DEV_PACKAGE))->version());
+        $standaloneApplication = new StandaloneApplication(self::APPLICATION_NAME, (new ReportPackage())->version(), (new ReportPackage(ModelsDevPricingProvider::CATALOG_PACKAGE))->version());
         $standaloneApplication->addCommand($this->initCommand());
         $standaloneApplication->addCommand($this->selfUpdateCommand());
         $standaloneApplication->addCommand($this->doctorCommand());

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -138,16 +138,16 @@ final readonly class StandaloneApplicationFactory
         return \sprintf('%s/vendor/autoload.php', self::resolverFromEnvironment($environment)->dataDir());
     }
 
-    public function create(): Application
+    public function create(): StandaloneApplication
     {
-        $application = new StandaloneApplication(self::APPLICATION_NAME, (new ReportPackage())->version(), (new ReportPackage(self::MODELS_DEV_PACKAGE))->version());
-        $application->addCommand($this->initCommand());
-        $application->addCommand($this->selfUpdateCommand());
-        $application->addCommand($this->doctorCommand());
-        $application->addCommand($this->lazyAuditCommand());
-        $this->registerUpdateAvailabilityNotice($application);
+        $standaloneApplication = new StandaloneApplication(self::APPLICATION_NAME, (new ReportPackage())->version(), (new ReportPackage(self::MODELS_DEV_PACKAGE))->version());
+        $standaloneApplication->addCommand($this->initCommand());
+        $standaloneApplication->addCommand($this->selfUpdateCommand());
+        $standaloneApplication->addCommand($this->doctorCommand());
+        $standaloneApplication->addCommand($this->lazyAuditCommand());
+        $this->registerUpdateAvailabilityNotice($standaloneApplication);
 
-        return $application;
+        return $standaloneApplication;
     }
 
     private static function processWorkingDirectory(): ?string

--- a/tests/Phpunit/EndToEnd/StandaloneAuditEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/StandaloneAuditEndToEndTest.php
@@ -78,12 +78,12 @@ final class StandaloneAuditEndToEndTest extends TestCase
     #[MaximumDuration(4000)]
     public function test_the_standalone_application_audits_a_project_end_to_end_in_dry_run(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => $this->configHome,
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
-        $commandTester = new CommandTester($application->find(AuditCommand::NAME));
+        $commandTester = new CommandTester($standaloneApplication->find(AuditCommand::NAME));
 
         $exitCode = $commandTester->execute(['project-path' => $this->projectDir, '--dry-run' => true]);
 

--- a/tests/Phpunit/EndToEnd/StandaloneDoctorEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/StandaloneDoctorEndToEndTest.php
@@ -101,12 +101,12 @@ final class StandaloneDoctorEndToEndTest extends TestCase
 
     private function doctorCommandTester(): CommandTester
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => $this->configHome,
             'XDG_CACHE_HOME' => $this->cacheHome,
             'XDG_DATA_HOME' => $this->dataHome,
         ])->create();
 
-        return new CommandTester($application->find(DoctorCommand::NAME));
+        return new CommandTester($standaloneApplication->find(DoctorCommand::NAME));
     }
 }

--- a/tests/Phpunit/EndToEnd/StandaloneInitEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/StandaloneInitEndToEndTest.php
@@ -82,12 +82,12 @@ final class StandaloneInitEndToEndTest extends TestCase
     {
         $xdgConfigPathResolver = new XdgConfigPathResolver($this->configHome, null, null, $this->dataHome);
 
-        $application = (new StandaloneApplicationFactory(
+        $standaloneApplication = (new StandaloneApplicationFactory(
             new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver()),
             $xdgConfigPathResolver,
             bridgeInstaller: $this->recordingBridgeInstaller,
         ))->create();
 
-        return new CommandTester($application->find(InitCommand::NAME));
+        return new CommandTester($standaloneApplication->find(InitCommand::NAME));
     }
 }

--- a/tests/Phpunit/EndToEnd/StandaloneUpdateNoticeEndToEndTest.php
+++ b/tests/Phpunit/EndToEnd/StandaloneUpdateNoticeEndToEndTest.php
@@ -84,15 +84,15 @@ final class StandaloneUpdateNoticeEndToEndTest extends TestCase
         $updateAvailabilityNotifier->method('availableUpdateNotice')->willReturn($notice);
 
         $xdgConfigPathResolver = new XdgConfigPathResolver($this->configHome, $this->cacheHome, null);
-        $application = (new StandaloneApplicationFactory(
+        $standaloneApplication = (new StandaloneApplicationFactory(
             new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver()),
             $xdgConfigPathResolver,
             self::createStub(BridgeInstallerInterface::class),
             updateAvailabilityConsoleListener: new UpdateAvailabilityConsoleListener($updateAvailabilityNotifier, '1.0.0', $disabled),
         ))->create();
-        $application->setAutoExit(false);
+        $standaloneApplication->setAutoExit(false);
 
-        $applicationTester = new ApplicationTester($application);
+        $applicationTester = new ApplicationTester($standaloneApplication);
         $applicationTester->run(['command' => 'list'], ['interactive' => $interactive, 'capture_stderr_separately' => true]);
 
         return $applicationTester;

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -85,7 +85,17 @@ final class EnvironmentDoctorTest extends TestCase
         $refreshed = $this->cacheHome.'/symfony-security-auditor/models-dev.json';
         (new Filesystem())->dumpFile($refreshed, '{"anthropic":{}}');
 
-        $environmentDoctor = $this->doctorWith($this->resolver(), [], true, pricingProvider: new ModelsDevPricingProvider(new NullLogger(), $refreshed));
+        $xdgConfigPathResolver = $this->resolver();
+        $composerAvailabilityChecker = self::createStub(ComposerAvailabilityCheckerInterface::class);
+        $composerAvailabilityChecker->method('isAvailable')->willReturn(true);
+
+        $environmentDoctor = new EnvironmentDoctor(
+            new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver([])),
+            $xdgConfigPathResolver,
+            $composerAvailabilityChecker,
+            self::createStub(AuditPreflightInterface::class),
+            new ModelsDevPricingProvider(new NullLogger(), $refreshed),
+        );
 
         $results = $environmentDoctor->diagnose();
 
@@ -272,7 +282,7 @@ final class EnvironmentDoctorTest extends TestCase
     /**
      * @param array<string, string> $environment
      */
-    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable, ?string $preflightFailure = null, ?string $projectConfigFile = null, ?ModelsDevPricingProvider $pricingProvider = null): EnvironmentDoctor
+    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable, ?string $preflightFailure = null, ?string $projectConfigFile = null): EnvironmentDoctor
     {
         $composerAvailabilityChecker = self::createStub(ComposerAvailabilityCheckerInterface::class);
         $composerAvailabilityChecker->method('isAvailable')->willReturn($composerAvailable);
@@ -285,7 +295,7 @@ final class EnvironmentDoctorTest extends TestCase
             $xdgConfigPathResolver,
             $composerAvailabilityChecker,
             $auditPreflight,
-            $pricingProvider ?? new ModelsDevPricingProvider(new NullLogger()),
+            new ModelsDevPricingProvider(new NullLogger()),
         );
     }
 

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -101,6 +101,11 @@ final class EnvironmentDoctorTest extends TestCase
 
         self::assertSame(DoctorCheckStatus::Ok, $results[3]->status);
         self::assertStringContainsString($refreshed, $results[3]->detail, 'doctor must name the refreshed catalog the run actually prices from, not the bundled one');
+        self::assertDoesNotMatchRegularExpression(
+            '/symfony\/models-dev v?[0-9]/',
+            $results[3]->detail,
+            'the bundled package version describes the packaged catalog only; stamping it onto a refreshed override asserts a version that file does not have',
+        );
     }
 
     public function test_it_warns_when_the_pricing_catalog_package_is_not_installed(): void

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -61,7 +61,45 @@ final class EnvironmentDoctorTest extends TestCase
             new DoctorCheckResult('Configuration', DoctorCheckStatus::Ok, 'Config resolves and the API-key variable is set.'),
             new DoctorCheckResult('Provider bridge', DoctorCheckStatus::Ok, 'Installed and the audit boots with it.'),
             new DoctorCheckResult('Composer', DoctorCheckStatus::Ok, 'Available.'),
-        ], $results);
+        ], \array_slice($results, 0, 3));
+    }
+
+    public function test_it_reports_the_bundled_pricing_catalog_version(): void
+    {
+        $this->writeConfig("platform:\n    openai:\n        api_key: 'sk-test'\nmodel: 'gpt-4'\n");
+        $this->installBridge();
+
+        $results = $this->doctorWith($this->resolver(), [], true)->diagnose();
+
+        self::assertSame('Pricing catalog', $results[3]->label);
+        self::assertSame(DoctorCheckStatus::Ok, $results[3]->status);
+        self::assertMatchesRegularExpression('/^symfony\/models-dev v?[0-9]+(\.[0-9]+)*\.$/', $results[3]->detail);
+    }
+
+    public function test_it_warns_when_the_pricing_catalog_package_is_not_installed(): void
+    {
+        $this->writeConfig("platform:\n    openai:\n        api_key: 'sk-test'\nmodel: 'gpt-4'\n");
+        $this->installBridge();
+
+        $xdgConfigPathResolver = $this->resolver();
+        $composerAvailabilityChecker = self::createStub(ComposerAvailabilityCheckerInterface::class);
+        $composerAvailabilityChecker->method('isAvailable')->willReturn(true);
+        $auditPreflight = self::createStub(AuditPreflightInterface::class);
+
+        $environmentDoctor = new EnvironmentDoctor(
+            new StandaloneConfigLoader($xdgConfigPathResolver, new StandalonePlatformConfigResolver([])),
+            $xdgConfigPathResolver,
+            $composerAvailabilityChecker,
+            $auditPreflight,
+            'vinceamstoutz/definitely-not-installed',
+        );
+
+        $results = $environmentDoctor->diagnose();
+
+        self::assertEquals(
+            new DoctorCheckResult('Pricing catalog', DoctorCheckStatus::Warning, 'vinceamstoutz/definitely-not-installed not found — cost figures will show $0.00.'),
+            $results[3],
+        );
     }
 
     public function test_it_fails_the_bridge_check_when_the_installed_bridge_cannot_boot_the_audit(): void

--- a/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
+++ b/tests/Phpunit/Integration/Command/EnvironmentDoctorTest.php
@@ -15,12 +15,14 @@ namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command;
 
 use Override;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\MissingEnvironmentVariableException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\Exception\UnresolvableConfigPathException;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandaloneConfigLoader;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\StandalonePlatformConfigResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Pricing\ModelsDevPricingProvider;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\AuditPreflightInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\ComposerAvailabilityCheckerInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\DoctorCheckResult;
@@ -73,7 +75,22 @@ final class EnvironmentDoctorTest extends TestCase
 
         self::assertSame('Pricing catalog', $results[3]->label);
         self::assertSame(DoctorCheckStatus::Ok, $results[3]->status);
-        self::assertMatchesRegularExpression('/^symfony\/models-dev v?[0-9]+(\.[0-9]+)*\.$/', $results[3]->detail);
+        self::assertMatchesRegularExpression('/^symfony\/models-dev v?[0-9]+(\.[0-9]+)* \(.+models-dev\.json\)\.$/', $results[3]->detail);
+    }
+
+    public function test_it_reports_a_refreshed_catalog_instead_of_the_bundled_one(): void
+    {
+        $this->writeConfig("platform:\n    openai:\n        api_key: 'sk-test'\n");
+        $this->installBridge();
+        $refreshed = $this->cacheHome.'/symfony-security-auditor/models-dev.json';
+        (new Filesystem())->dumpFile($refreshed, '{"anthropic":{}}');
+
+        $environmentDoctor = $this->doctorWith($this->resolver(), [], true, pricingProvider: new ModelsDevPricingProvider(new NullLogger(), $refreshed));
+
+        $results = $environmentDoctor->diagnose();
+
+        self::assertSame(DoctorCheckStatus::Ok, $results[3]->status);
+        self::assertStringContainsString($refreshed, $results[3]->detail, 'doctor must name the refreshed catalog the run actually prices from, not the bundled one');
     }
 
     public function test_it_warns_when_the_pricing_catalog_package_is_not_installed(): void
@@ -91,6 +108,7 @@ final class EnvironmentDoctorTest extends TestCase
             $xdgConfigPathResolver,
             $composerAvailabilityChecker,
             $auditPreflight,
+            new ModelsDevPricingProvider(new NullLogger(), null, 'vinceamstoutz/definitely-not-installed'),
             'vinceamstoutz/definitely-not-installed',
         );
 
@@ -254,7 +272,7 @@ final class EnvironmentDoctorTest extends TestCase
     /**
      * @param array<string, string> $environment
      */
-    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable, ?string $preflightFailure = null, ?string $projectConfigFile = null): EnvironmentDoctor
+    private function doctorWith(XdgConfigPathResolver $xdgConfigPathResolver, array $environment, bool $composerAvailable, ?string $preflightFailure = null, ?string $projectConfigFile = null, ?ModelsDevPricingProvider $pricingProvider = null): EnvironmentDoctor
     {
         $composerAvailabilityChecker = self::createStub(ComposerAvailabilityCheckerInterface::class);
         $composerAvailabilityChecker->method('isAvailable')->willReturn($composerAvailable);
@@ -267,6 +285,7 @@ final class EnvironmentDoctorTest extends TestCase
             $xdgConfigPathResolver,
             $composerAvailabilityChecker,
             $auditPreflight,
+            $pricingProvider ?? new ModelsDevPricingProvider(new NullLogger()),
         );
     }
 

--- a/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
@@ -51,87 +51,87 @@ final class StandaloneApplicationFactoryTest extends TestCase
     #[RunInSeparateProcess]
     public function test_it_builds_a_console_application_exposing_the_audit_command_and_alias(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => $this->configHome,
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
-        self::assertTrue($application->has('audit:run'));
-        self::assertTrue($application->has('audit'));
+        self::assertTrue($standaloneApplication->has('audit:run'));
+        self::assertTrue($standaloneApplication->has('audit'));
     }
 
     public function test_it_registers_the_audit_command_without_reading_a_config_file(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
-        self::assertTrue($application->has('audit:run'));
+        self::assertTrue($standaloneApplication->has('audit:run'));
     }
 
     public function test_it_reports_the_installed_package_version_instead_of_unknown(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
-        self::assertSame((new ReportPackage())->version(), $application->getVersion());
+        self::assertSame((new ReportPackage())->version(), $standaloneApplication->getVersion());
     }
 
     public function test_it_includes_the_bundled_models_dev_version_in_the_long_version(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
         self::assertStringContainsString(
             \sprintf('symfony/models-dev %s', (new ReportPackage('symfony/models-dev'))->version()),
-            $application->getLongVersion(),
+            $standaloneApplication->getLongVersion(),
         );
     }
 
     public function test_it_registers_the_init_command(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
-        self::assertTrue($application->has('init'));
+        self::assertTrue($standaloneApplication->has('init'));
     }
 
     public function test_it_registers_the_self_update_command(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
             'XDG_CACHE_HOME' => $this->cacheHome,
         ], '/usr/local/bin/symfony-security-auditor')->create();
 
-        self::assertTrue($application->has('self-update'));
+        self::assertTrue($standaloneApplication->has('self-update'));
     }
 
     public function test_it_registers_the_doctor_command(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
-        self::assertTrue($application->has('doctor'));
+        self::assertTrue($standaloneApplication->has('doctor'));
     }
 
     public function test_it_builds_the_application_when_update_checks_are_disabled(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
             'XDG_CACHE_HOME' => $this->cacheHome,
             'SSA_NO_UPDATE_CHECK' => '1',
         ])->create();
 
-        self::assertTrue($application->has('audit:run'));
+        self::assertTrue($standaloneApplication->has('audit:run'));
     }
 
     /**
@@ -157,12 +157,12 @@ final class StandaloneApplicationFactoryTest extends TestCase
 
     public function test_it_registers_the_audit_command_as_visible(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
-        self::assertFalse($application->get('audit:run')->isHidden());
+        self::assertFalse($standaloneApplication->get('audit:run')->isHidden());
     }
 
     /**
@@ -210,12 +210,12 @@ final class StandaloneApplicationFactoryTest extends TestCase
     #[MaximumDuration(4000)]
     public function test_the_registered_audit_command_keeps_the_full_cli_option_surface(): void
     {
-        $application = StandaloneApplicationFactory::fromEnvironment([
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([
             'XDG_CONFIG_HOME' => $this->configHome,
             'XDG_CACHE_HOME' => $this->cacheHome,
         ])->create();
 
-        $inputDefinition = $application->find('audit:run')->getDefinition();
+        $inputDefinition = $standaloneApplication->find('audit:run')->getDefinition();
         $optionNames = array_keys($inputDefinition->getOptions());
 
         self::assertSame([], array_diff(

--- a/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
@@ -113,6 +113,13 @@ final class StandaloneApplicationFactoryTest extends TestCase
         self::assertTrue($standaloneApplication->has('self-update'));
     }
 
+    public function test_it_builds_the_application_when_no_cache_directory_can_be_resolved(): void
+    {
+        $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([])->create();
+
+        self::assertTrue($standaloneApplication->has('doctor'), 'an environment with no HOME and no XDG variables leaves the refreshed-catalog location unresolvable, which must not stop the application from building');
+    }
+
     public function test_it_registers_the_doctor_command(): void
     {
         $standaloneApplication = StandaloneApplicationFactory::fromEnvironment([

--- a/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
+++ b/tests/Phpunit/Integration/Standalone/StandaloneApplicationFactoryTest.php
@@ -80,6 +80,19 @@ final class StandaloneApplicationFactoryTest extends TestCase
         self::assertSame((new ReportPackage())->version(), $application->getVersion());
     }
 
+    public function test_it_includes_the_bundled_models_dev_version_in_the_long_version(): void
+    {
+        $application = StandaloneApplicationFactory::fromEnvironment([
+            'XDG_CONFIG_HOME' => sys_get_temp_dir().'/ssa-absent-'.bin2hex(random_bytes(6)),
+            'XDG_CACHE_HOME' => $this->cacheHome,
+        ])->create();
+
+        self::assertStringContainsString(
+            \sprintf('symfony/models-dev %s', (new ReportPackage('symfony/models-dev'))->version()),
+            $application->getLongVersion(),
+        );
+    }
+
     public function test_it_registers_the_init_command(): void
     {
         $application = StandaloneApplicationFactory::fromEnvironment([

--- a/tests/Phpunit/Unit/Infrastructure/Pricing/ModelsDevPricingProviderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Pricing/ModelsDevPricingProviderTest.php
@@ -273,6 +273,14 @@ final class ModelsDevPricingProviderTest extends TestCase
         self::fail('Expected a "catalog unavailable" warning but none was logged.');
     }
 
+    public function test_a_missing_override_catalog_path_falls_back_to_the_default_catalog(): void
+    {
+        $modelsDevPricingProvider = new ModelsDevPricingProvider($this->warningCapturingLogger(), '/does/not/exist/models-dev.json');
+
+        self::assertTrue($modelsDevPricingProvider->hasModel('claude-opus-4-8'));
+        self::assertSame([], $this->loggedWarnings);
+    }
+
     public function test_a_missing_catalog_package_disables_pricing_without_throwing(): void
     {
         $modelsDevPricingProvider = new ModelsDevPricingProvider($this->warningCapturingLogger(), null, 'vinceamstoutz/not-a-real-package');
@@ -318,7 +326,7 @@ final class ModelsDevPricingProviderTest extends TestCase
 
     private function providerForCatalog(string $fixture): ModelsDevPricingProvider
     {
-        return new ModelsDevPricingProvider($this->warningCapturingLogger(), __DIR__.'/Fixture/'.$fixture);
+        return new ModelsDevPricingProvider($this->warningCapturingLogger(), __DIR__.'/Fixture/'.$fixture, 'vinceamstoutz/not-a-real-package');
     }
 
     private function warningCapturingLogger(): LoggerInterface

--- a/tests/Phpunit/Unit/Infrastructure/Pricing/ModelsDevPricingProviderTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/Pricing/ModelsDevPricingProviderTest.php
@@ -281,6 +281,21 @@ final class ModelsDevPricingProviderTest extends TestCase
         self::assertSame([], $this->loggedWarnings);
     }
 
+    /**
+     * `InstalledVersions::getInstallPath()` answers relative to the Composer
+     * directory, so the raw join carries a `vendor/composer/../symfony/...`
+     * detour that `doctor` would print verbatim at the user.
+     */
+    public function test_the_packaged_catalog_path_is_free_of_parent_directory_detours(): void
+    {
+        $packagedCatalogPath = (new ModelsDevPricingProvider($this->warningCapturingLogger()))->packagedCatalogPath();
+
+        self::assertIsString($packagedCatalogPath);
+        self::assertStringNotContainsString('/../', $packagedCatalogPath);
+        self::assertStringNotContainsString('/composer/', $packagedCatalogPath);
+        self::assertStringEndsWith('/symfony/models-dev/models-dev.json', $packagedCatalogPath);
+    }
+
     public function test_a_missing_catalog_package_disables_pricing_without_throwing(): void
     {
         $modelsDevPricingProvider = new ModelsDevPricingProvider($this->warningCapturingLogger(), null, 'vinceamstoutz/not-a-real-package');

--- a/tests/Phpunit/Unit/Standalone/StandaloneApplicationTest.php
+++ b/tests/Phpunit/Unit/Standalone/StandaloneApplicationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the vinceamstoutz/symfony-security-auditor package.
+ *
+ * (c) Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Standalone;
+
+use PHPUnit\Framework\TestCase;
+use VinceAmstoutz\SymfonySecurityAuditor\Standalone\StandaloneApplication;
+
+final class StandaloneApplicationTest extends TestCase
+{
+    public function test_it_appends_the_models_dev_version_to_the_long_version(): void
+    {
+        $standaloneApplication = new StandaloneApplication('symfony-security-auditor', '1.2.3', '132.0');
+
+        self::assertSame(
+            'symfony-security-auditor <info>1.2.3</info> (symfony/models-dev 132.0)',
+            $standaloneApplication->getLongVersion(),
+        );
+    }
+
+    public function test_it_reports_the_configured_short_version(): void
+    {
+        $standaloneApplication = new StandaloneApplication('symfony-security-auditor', '1.2.3', '132.0');
+
+        self::assertSame('1.2.3', $standaloneApplication->getVersion());
+    }
+}


### PR DESCRIPTION
## Summary

A standalone install's cost figures come from whatever `symfony/models-dev` catalog was newest when that release's binary was built, with no way to see which snapshot that is. `doctor` now reports the installed version as a new "Pricing catalog" check, and `--version` appends it too via a small `StandaloneApplication` subclass overriding `getLongVersion()`.

Closes #319

## Type of change

- [x] New feature

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: PHPStan, PHP CS Fixer, Deptrac, PHPUnit (100% coverage)
- [x] 100% MSI maintained: `bin/infection` (scoped to the touched files)
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)