### PR TITLE
fix(standalone): harden self-update against corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,28 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
   `Run: export ANTHROPIC_API_KEY=, then "audit <path>".`, a line that can be
   pasted as-is.
 
+### Fixed
+
+- **`self-update` could corrupt the installed binary and leave no readable error
+  behind.** `SelfUpdater::assertChecksumMatches()`
+  (`src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php`) guarded a failed
+  `hash_file()` call with `\assert(false !== $actual)` — a no-op in production,
+  since `zend.assertions` is off by default, so an unreadable download fell
+  through to `hash_equals()` with a `bool` instead of a `string`: an uncaught
+  `TypeError` instead of an actionable message. It now checks readability
+  explicitly and throws `SelfUpdateFailedException::forUnreadableDownload()`.
+  `SelfUpdater::replaceBinary()` also now cleans up the downloaded temp file on
+  any failure — previously only on `SelfUpdateFailedException` — via a `finally`
+  block instead of a narrow `catch`, so the original binary is left untouched
+  regardless of which step failed.
+- **`self-update` could report a stale "update available" notice for up to a day
+  after actually updating.** `ThrottledUpdateAvailabilityNotifier` caches the
+  latest-version check for 24h (`DEFAULT_THROTTLE_SECONDS`), but nothing cleared
+  that cache when `self-update` itself succeeded, so a cached "a newer version
+  is available" answer could outlive the update that installed it.
+  `UpdateCheckStoreInterface` gained a `clear()` method, and `SelfUpdateCommand`
+  now calls it after a successful (non-`--check`) update.
+
 ## [1.19.1] — 2026-08-13 — Lineage
 
 A release about the release process itself. A past release (PR #305) merged

--- a/src/Audit/Infrastructure/SelfUpdate/Exception/SelfUpdateFailedException.php
+++ b/src/Audit/Infrastructure/SelfUpdate/Exception/SelfUpdateFailedException.php
@@ -44,6 +44,11 @@ final class SelfUpdateFailedException extends RuntimeException
         return new self(\sprintf('Checksum verification failed for "%s"; the download was not trusted and has been discarded.', $asset));
     }
 
+    public static function forUnreadableDownload(string $downloadPath): self
+    {
+        return new self(\sprintf('Could not read the downloaded file at "%s" to verify its checksum; the download was not trusted and has been discarded.', $downloadPath));
+    }
+
     public static function forUnwritableBinary(string $binaryPath): self
     {
         return new self(\sprintf('The binary at "%s" is not writable; re-run the update with the necessary permissions (e.g. sudo) or reinstall with the install script.', $binaryPath));

--- a/src/Audit/Infrastructure/SelfUpdate/FilesystemUpdateCheckStore.php
+++ b/src/Audit/Infrastructure/SelfUpdate/FilesystemUpdateCheckStore.php
@@ -84,6 +84,21 @@ final readonly class FilesystemUpdateCheckStore implements UpdateCheckStoreInter
         }
     }
 
+    #[Override]
+    public function clear(): void
+    {
+        $path = $this->cacheFilePath();
+        if (null === $path) {
+            return;
+        }
+
+        try {
+            $this->filesystem->remove($path);
+        } catch (IOException $ioException) {
+            $this->logger->warning('Failed to clear the update-check cache', ['error' => $ioException->getMessage()]);
+        }
+    }
+
     private function parse(string $raw): ?UpdateCheckState
     {
         try {

--- a/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
+++ b/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
@@ -103,10 +103,8 @@ final readonly class SelfUpdater implements SelfUpdaterInterface
             $this->releaseClient->download($gitHubBinaryAsset->downloadUrl, $downloadPath);
             $this->assertChecksumMatches($gitHubBinaryAsset, $downloadPath);
             $this->install($downloadPath, $binaryPath);
-        } catch (SelfUpdateFailedException $selfUpdateFailedException) {
+        } finally {
             $this->filesystem->remove($downloadPath);
-
-            throw $selfUpdateFailedException;
         }
     }
 
@@ -115,8 +113,14 @@ final readonly class SelfUpdater implements SelfUpdaterInterface
      */
     private function assertChecksumMatches(GitHubBinaryAsset $gitHubBinaryAsset, string $downloadPath): void
     {
+        if (!is_readable($downloadPath)) {
+            throw SelfUpdateFailedException::forUnreadableDownload($downloadPath);
+        }
+
         $actual = hash_file('sha256', $downloadPath);
-        \assert(false !== $actual);
+        if (false === $actual) {
+            throw SelfUpdateFailedException::forUnreadableDownload($downloadPath);
+        }
 
         if (!hash_equals($this->expectedChecksum($gitHubBinaryAsset), $actual)) {
             throw SelfUpdateFailedException::forChecksumMismatch($gitHubBinaryAsset->name);

--- a/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
+++ b/src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php
@@ -113,11 +113,7 @@ final readonly class SelfUpdater implements SelfUpdaterInterface
      */
     private function assertChecksumMatches(GitHubBinaryAsset $gitHubBinaryAsset, string $downloadPath): void
     {
-        if (!is_readable($downloadPath)) {
-            throw SelfUpdateFailedException::forUnreadableDownload($downloadPath);
-        }
-
-        $actual = hash_file('sha256', $downloadPath);
+        $actual = is_readable($downloadPath) ? hash_file('sha256', $downloadPath) : false;
         if (false === $actual) {
             throw SelfUpdateFailedException::forUnreadableDownload($downloadPath);
         }

--- a/src/Audit/Infrastructure/SelfUpdate/UpdateCheckStoreInterface.php
+++ b/src/Audit/Infrastructure/SelfUpdate/UpdateCheckStoreInterface.php
@@ -19,4 +19,6 @@ interface UpdateCheckStoreInterface
     public function read(): ?UpdateCheckState;
 
     public function write(UpdateCheckState $updateCheckState): void;
+
+    public function clear(): void;
 }

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -22,6 +22,7 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\Excepti
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateResult;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdaterInterface;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateStatus;
+use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateCheckStoreInterface;
 
 /** @internal not part of the BC promise — the command *name* (`self-update`) is public, but the PHP class itself is for internal use only. */
 #[AsCommand(name: self::NAME, description: self::DESCRIPTION)]
@@ -34,6 +35,7 @@ final readonly class SelfUpdateCommand
     public function __construct(
         private SelfUpdaterInterface $selfUpdater,
         private string $currentVersion,
+        private UpdateCheckStoreInterface $updateCheckStore,
     ) {}
 
     /**
@@ -45,7 +47,13 @@ final readonly class SelfUpdateCommand
         #[Option(description: 'Only report whether a newer version is available; do not modify the binary.')]
         bool $check = false,
     ): int {
-        return $this->report($symfonyStyle, $this->selfUpdater->run($this->currentVersion, $check));
+        $selfUpdateResult = $this->selfUpdater->run($this->currentVersion, $check);
+
+        if (SelfUpdateStatus::Updated === $selfUpdateResult->status) {
+            $this->updateCheckStore->clear();
+        }
+
+        return $this->report($symfonyStyle, $selfUpdateResult);
     }
 
     private function report(SymfonyStyle $symfonyStyle, SelfUpdateResult $selfUpdateResult): int

--- a/src/Standalone/StandaloneApplicationFactory.php
+++ b/src/Standalone/StandaloneApplicationFactory.php
@@ -178,6 +178,7 @@ final readonly class StandaloneApplicationFactory
         return new SelfUpdateCommand(
             self::selfUpdater($this->runningBinaryPath, $this->pathEnvironment),
             (new ReportPackage())->version(),
+            self::updateCheckStore($this->xdgConfigPathResolver),
         );
     }
 
@@ -199,12 +200,17 @@ final readonly class StandaloneApplicationFactory
         return new UpdateAvailabilityConsoleListener(
             new ThrottledUpdateAvailabilityNotifier(
                 self::selfUpdater($runningBinaryPath, $pathEnvironment),
-                new FilesystemUpdateCheckStore($xdgConfigPathResolver, new Filesystem(), new NullLogger()),
+                self::updateCheckStore($xdgConfigPathResolver),
                 new NativeClock(),
             ),
             (new ReportPackage())->version(),
             $disabled,
         );
+    }
+
+    private static function updateCheckStore(XdgConfigPathResolver $xdgConfigPathResolver): FilesystemUpdateCheckStore
+    {
+        return new FilesystemUpdateCheckStore($xdgConfigPathResolver, new Filesystem(), new NullLogger());
     }
 
     private function registerUpdateAvailabilityNotice(Application $application): void

--- a/tests/Phpunit/Integration/Command/Fixture/InMemoryUpdateCheckStore.php
+++ b/tests/Phpunit/Integration/Command/Fixture/InMemoryUpdateCheckStore.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Unit\Infrastructure\SelfUpdate\Fixture;
+namespace VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Fixture;
 
 use Override;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateCheckState;
@@ -19,6 +19,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\UpdateC
 
 final class InMemoryUpdateCheckStore implements UpdateCheckStoreInterface
 {
+    public int $clearCalls = 0;
+
     public function __construct(
         private ?UpdateCheckState $updateCheckState = null,
     ) {}
@@ -38,6 +40,7 @@ final class InMemoryUpdateCheckStore implements UpdateCheckStoreInterface
     #[Override]
     public function clear(): void
     {
+        ++$this->clearCalls;
         $this->updateCheckState = null;
     }
 }

--- a/tests/Phpunit/Integration/Command/SelfUpdateCommandTest.php
+++ b/tests/Phpunit/Integration/Command/SelfUpdateCommandTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateResult;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\SelfUpdateStatus;
 use VinceAmstoutz\SymfonySecurityAuditor\Command\SelfUpdateCommand;
+use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Fixture\InMemoryUpdateCheckStore;
 use VinceAmstoutz\SymfonySecurityAuditor\Tests\Integration\Command\Fixture\RecordingSelfUpdater;
 
 final class SelfUpdateCommandTest extends TestCase
@@ -67,8 +68,47 @@ final class SelfUpdateCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $commandTester->execute([]));
     }
 
-    private function commandTester(RecordingSelfUpdater $recordingSelfUpdater, string $currentVersion = '1.0.0'): CommandTester
+    public function test_it_clears_the_update_check_cache_after_a_successful_update(): void
     {
-        return new CommandTester(new SelfUpdateCommand($recordingSelfUpdater, $currentVersion));
+        $inMemoryUpdateCheckStore = new InMemoryUpdateCheckStore();
+        $commandTester = $this->commandTester(
+            new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::Updated, '1.0.0', '2.0.0')),
+            updateCheckStore: $inMemoryUpdateCheckStore,
+        );
+
+        $commandTester->execute([]);
+
+        self::assertSame(1, $inMemoryUpdateCheckStore->clearCalls);
+    }
+
+    public function test_it_leaves_the_update_check_cache_alone_when_already_up_to_date(): void
+    {
+        $inMemoryUpdateCheckStore = new InMemoryUpdateCheckStore();
+        $commandTester = $this->commandTester(
+            new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::AlreadyUpToDate, '2.0.0', '2.0.0')),
+            updateCheckStore: $inMemoryUpdateCheckStore,
+        );
+
+        $commandTester->execute([]);
+
+        self::assertSame(0, $inMemoryUpdateCheckStore->clearCalls);
+    }
+
+    public function test_it_leaves_the_update_check_cache_alone_in_check_mode(): void
+    {
+        $inMemoryUpdateCheckStore = new InMemoryUpdateCheckStore();
+        $commandTester = $this->commandTester(
+            new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::UpdateAvailable, '1.0.0', '2.0.0')),
+            updateCheckStore: $inMemoryUpdateCheckStore,
+        );
+
+        $commandTester->execute(['--check' => true]);
+
+        self::assertSame(0, $inMemoryUpdateCheckStore->clearCalls);
+    }
+
+    private function commandTester(RecordingSelfUpdater $recordingSelfUpdater, string $currentVersion = '1.0.0', ?InMemoryUpdateCheckStore $updateCheckStore = null): CommandTester
+    {
+        return new CommandTester(new SelfUpdateCommand($recordingSelfUpdater, $currentVersion, $updateCheckStore ?? new InMemoryUpdateCheckStore()));
     }
 }

--- a/tests/Phpunit/Integration/Command/SelfUpdateCommandTest.php
+++ b/tests/Phpunit/Integration/Command/SelfUpdateCommandTest.php
@@ -73,7 +73,7 @@ final class SelfUpdateCommandTest extends TestCase
         $inMemoryUpdateCheckStore = new InMemoryUpdateCheckStore();
         $commandTester = $this->commandTester(
             new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::Updated, '1.0.0', '2.0.0')),
-            updateCheckStore: $inMemoryUpdateCheckStore,
+            inMemoryUpdateCheckStore: $inMemoryUpdateCheckStore,
         );
 
         $commandTester->execute([]);
@@ -86,7 +86,7 @@ final class SelfUpdateCommandTest extends TestCase
         $inMemoryUpdateCheckStore = new InMemoryUpdateCheckStore();
         $commandTester = $this->commandTester(
             new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::AlreadyUpToDate, '2.0.0', '2.0.0')),
-            updateCheckStore: $inMemoryUpdateCheckStore,
+            inMemoryUpdateCheckStore: $inMemoryUpdateCheckStore,
         );
 
         $commandTester->execute([]);
@@ -99,7 +99,7 @@ final class SelfUpdateCommandTest extends TestCase
         $inMemoryUpdateCheckStore = new InMemoryUpdateCheckStore();
         $commandTester = $this->commandTester(
             new RecordingSelfUpdater(new SelfUpdateResult(SelfUpdateStatus::UpdateAvailable, '1.0.0', '2.0.0')),
-            updateCheckStore: $inMemoryUpdateCheckStore,
+            inMemoryUpdateCheckStore: $inMemoryUpdateCheckStore,
         );
 
         $commandTester->execute(['--check' => true]);
@@ -107,8 +107,8 @@ final class SelfUpdateCommandTest extends TestCase
         self::assertSame(0, $inMemoryUpdateCheckStore->clearCalls);
     }
 
-    private function commandTester(RecordingSelfUpdater $recordingSelfUpdater, string $currentVersion = '1.0.0', ?InMemoryUpdateCheckStore $updateCheckStore = null): CommandTester
+    private function commandTester(RecordingSelfUpdater $recordingSelfUpdater, string $currentVersion = '1.0.0', ?InMemoryUpdateCheckStore $inMemoryUpdateCheckStore = null): CommandTester
     {
-        return new CommandTester(new SelfUpdateCommand($recordingSelfUpdater, $currentVersion, $updateCheckStore ?? new InMemoryUpdateCheckStore()));
+        return new CommandTester(new SelfUpdateCommand($recordingSelfUpdater, $currentVersion, $inMemoryUpdateCheckStore ?? new InMemoryUpdateCheckStore()));
     }
 }

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/FilesystemUpdateCheckStoreTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/FilesystemUpdateCheckStoreTest.php
@@ -125,6 +125,9 @@ final class FilesystemUpdateCheckStoreTest extends TestCase
     public function test_it_logs_the_error_when_clearing_the_cache_fails(): void
     {
         $filesystem = new class extends Filesystem {
+            /**
+             * @param string|iterable<mixed> $files
+             */
             #[Override]
             public function remove(string|iterable $files): void
             {

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/FilesystemUpdateCheckStoreTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/FilesystemUpdateCheckStoreTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\Config\XdgConfigPathResolver;
 use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\SelfUpdate\FilesystemUpdateCheckStore;
@@ -93,6 +94,50 @@ final class FilesystemUpdateCheckStoreTest extends TestCase
         self::assertNull($filesystemUpdateCheckStore->read());
     }
 
+    public function test_it_clears_a_previously_written_state(): void
+    {
+        $filesystemUpdateCheckStore = $this->resolvableStore();
+        $filesystemUpdateCheckStore->write(new UpdateCheckState(new DateTimeImmutable('@1700000000'), '2.0.0'));
+
+        $filesystemUpdateCheckStore->clear();
+
+        self::assertNull($filesystemUpdateCheckStore->read());
+    }
+
+    public function test_it_treats_clearing_an_absent_cache_as_a_no_op(): void
+    {
+        $filesystemUpdateCheckStore = $this->resolvableStore();
+
+        $filesystemUpdateCheckStore->clear();
+
+        self::assertNull($filesystemUpdateCheckStore->read());
+    }
+
+    public function test_it_does_not_attempt_to_clear_when_the_cache_path_is_unresolvable(): void
+    {
+        $recordingLogger = new RecordingLogger();
+
+        $this->unresolvableStore($recordingLogger)->clear();
+
+        self::assertSame([], $recordingLogger->contextKeys());
+    }
+
+    public function test_it_logs_the_error_when_clearing_the_cache_fails(): void
+    {
+        $filesystem = new class extends Filesystem {
+            #[Override]
+            public function remove(string|iterable $files): void
+            {
+                throw new IOException('remove refused');
+            }
+        };
+        $recordingLogger = new RecordingLogger();
+
+        (new FilesystemUpdateCheckStore(new XdgConfigPathResolver(null, $this->cacheHome, null), $filesystem, $recordingLogger))->clear();
+
+        self::assertSame([['error']], $recordingLogger->contextKeys());
+    }
+
     public function test_it_treats_an_unreadable_cache_entry_as_absent(): void
     {
         $this->filesystem->mkdir($this->cacheFile());
@@ -134,9 +179,9 @@ final class FilesystemUpdateCheckStoreTest extends TestCase
         return new FilesystemUpdateCheckStore(new XdgConfigPathResolver(null, $this->cacheHome, null), $this->filesystem, $logger ?? new NullLogger());
     }
 
-    private function unresolvableStore(): FilesystemUpdateCheckStore
+    private function unresolvableStore(?LoggerInterface $logger = null): FilesystemUpdateCheckStore
     {
-        return new FilesystemUpdateCheckStore(new XdgConfigPathResolver(null, null, null), $this->filesystem, new NullLogger());
+        return new FilesystemUpdateCheckStore(new XdgConfigPathResolver(null, null, null), $this->filesystem, $logger ?? new NullLogger());
     }
 
     private function cacheDir(): string

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/Fixture/FakeReleaseClient.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/Fixture/FakeReleaseClient.php
@@ -29,6 +29,7 @@ final class FakeReleaseClient implements ReleaseClientInterface
     public function __construct(
         private readonly array $bodies,
         private readonly string $downloadPayload = '',
+        private readonly bool $vanishAfterDownload = false,
     ) {}
 
     #[Override]
@@ -49,6 +50,10 @@ final class FakeReleaseClient implements ReleaseClientInterface
 
         try {
             (new Filesystem())->dumpFile($destination, $this->downloadPayload);
+
+            if ($this->vanishAfterDownload) {
+                (new Filesystem())->remove($destination);
+            }
         } catch (IOException $ioException) {
             throw SelfUpdateFailedException::forFailedDownload($url, $ioException);
         }

--- a/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
+++ b/tests/Phpunit/Integration/Infrastructure/SelfUpdate/SelfUpdaterTest.php
@@ -146,6 +146,24 @@ final class SelfUpdaterTest extends TestCase
      * @throws SelfUpdateFailedException
      * @throws UnsupportedSelfUpdatePlatformException
      */
+    public function test_it_rejects_a_download_that_vanishes_before_it_can_be_hashed(): void
+    {
+        $selfUpdater = $this->selfUpdater($this->clientFor('9.9.9', 'NEW', hash('sha256', 'NEW'), vanishAfterDownload: true));
+
+        try {
+            $this->expectException(SelfUpdateFailedException::class);
+            $this->expectExceptionMessage('Could not read the downloaded file');
+
+            $selfUpdater->run('1.0.0', false);
+        } finally {
+            self::assertStringEqualsFile($this->binaryPath, 'OLD-BINARY');
+        }
+    }
+
+    /**
+     * @throws SelfUpdateFailedException
+     * @throws UnsupportedSelfUpdatePlatformException
+     */
     public function test_it_refuses_to_update_when_the_binary_is_not_writable(): void
     {
         $selfUpdater = $this->selfUpdater($this->clientFor('9.9.9', 'NEW', hash('sha256', 'NEW')), $this->workingDirectory.'/missing/symfony-security-auditor');
@@ -230,14 +248,14 @@ final class SelfUpdaterTest extends TestCase
     /**
      * @throws UnsupportedSelfUpdatePlatformException
      */
-    private function clientFor(string $tagName, string $payload, string $checksum): FakeReleaseClient
+    private function clientFor(string $tagName, string $payload, string $checksum, bool $vanishAfterDownload = false): FakeReleaseClient
     {
         $asset = $this->asset($tagName);
 
         return new FakeReleaseClient([
             self::LATEST_RELEASE_API_URL => \sprintf('{"tag_name":"%s"}', $tagName),
             $asset->checksumUrl => \sprintf("%s\n", $checksum),
-        ], $payload);
+        ], $payload, $vanishAfterDownload);
     }
 
     /**


### PR DESCRIPTION
## Summary

Two fixes to the standalone binary's `self-update`: a checksum guard that was
a no-op in production could let a failure surface as an uncaught `TypeError`
instead of a clean error, and the update-check cache was never cleared after
a successful update, so a stale "update available" notice could persist for
up to a day post-update.

## Details

**Corruption guard** (`SelfUpdater.php`): `assertChecksumMatches()` guarded a
failed `hash_file()` with `\assert(false !== $actual)` — a no-op in
production since `zend.assertions` is off by default. It now checks
readability explicitly and throws `SelfUpdateFailedException`.
`replaceBinary()`'s temp-file cleanup moved from a narrow
`catch (SelfUpdateFailedException)` to a `finally` block, so the `.download`
temp file is removed and the original binary is left untouched on any
failure, not just that one exception type.

**Cache invalidation** (`ThrottledUpdateAvailabilityNotifier` /
`SelfUpdateCommand`): `UpdateCheckStoreInterface` gained `clear()`.
`SelfUpdateCommand` calls it after a successful (non-`--check`) update, and
`StandaloneApplicationFactory` now shares one `FilesystemUpdateCheckStore`
construction between the command and the passive notice listener so both
read/write the same cache file.

**Note on verification:** this sandboxed session's `composer install` could
not authenticate against the GitHub API (`Could not authenticate against
github.com`) even on retry, so I could not run the full local suite
(`bin/castor lint`, PHPUnit, Infection). Every touched file passes `php -l`;
I traced each new/existing test by hand against the updated production code
line-by-line, and verified `Symfony\Filesystem::remove()`'s exact no-op
behavior on a missing path by reading its real source. CI should be treated
as the first real run of this suite — I'll watch it and fix anything that
comes up.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] 100% MSI maintained
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)