### PR TITLE
fix(scan): close two secret-scrubbing gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ## [Unreleased]
 
+### Security
+
+- **Secret scrubbing now redacts `Authorization: Basic` credentials and Slack
+  app-level tokens.** `RegexSecretScrubber::DEFAULT_PATTERNS` covered
+  `Authorization: Bearer` but not `Basic`, so a committed
+  `Authorization: Basic <base64>` — which decodes straight back to
+  `user:password` — was sent verbatim to the configured LLM provider on the
+  default `scan.secret_scrubbing.enabled` path. The same gap applied within a
+  provider already covered: `xox[abprs]-` tokens and `hooks.slack.com` webhook
+  URLs were redacted while Slack's `xapp-` app-level tokens were not. Both are
+  now matched, and the Basic pattern keeps the header name and scheme
+  (`Authorization: Basic ***REDACTED:basic_authorization***`) so the audit can
+  still see that the request authenticates and how. The pattern requires the
+  header or an assignment before the credential, so prose such as "use basic
+  authentication over TLS" is left alone. `SecretPatternLabel` gains
+  `BasicAuthorization`.
+
 ### Changed
 
 - **`init`'s success message now prints a copy-pasteable `export` line instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **`docs/architecture.md`'s command reference no longer contradicts
+  `docs/configuration.md`.** Its exit-code summary read "`0`
+  (SAFE/LOW/MEDIUM/HIGH), `1` (CRITICAL risk or invalid path or unexpected
+  failure), `2` (budget exceeded)", which predates three behaviours the
+  canonical table in `docs/configuration.md` already documents: `audit.fail_on`
+  is configurable, so HIGH exits `1` whenever it is set below `critical`; a scan
+  that discovers no file at all exits `1`; a score below `--min-score` exits
+  `1`; and `2` also covers a run that never started because an unpriced model
+  makes `audit.budget.max_cost_usd` unenforceable. The same table listed three
+  `--format` values when `OutputFormat` has nine. Both rows are corrected and
+  the exit-code paragraph now points at the canonical table rather than
+  restating it.
 - **`scan.code_slicing`'s configuration reference no longer promises whole
   method bodies.** The `info()` text — what
   `config:dump-reference symfony_security_auditor` prints — said the slicer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org). See
 
 ### Fixed
 
+- **`scan.code_slicing`'s configuration reference no longer promises whole
+  method bodies.** The `info()` text — what
+  `config:dump-reference symfony_security_auditor` prints — said the slicer
+  keeps "the FULL body of methods that touch security-relevant tokens".
+  `RegexCodeSlicer` retains per line, not per method, which
+  `test_inert_body_lines_are_elided()` pins deliberately: on a textbook
+  vulnerable controller the source (`$name = $request->request->get('name')`)
+  and the sink (`$this->conn->executeStatement($sql)`) are both kept while the
+  `$sql` concatenation between them is elided, so the slice shows `$sql` used
+  but never assigned, and a reflected-XSS built the same way disappears
+  entirely. The text now states that retention is per line, that an inert line
+  inside a matched method is still elided, and that a file should go unsliced
+  when the taint flow between source and sink matters more than the tokens.
+  Behaviour is unchanged; only the description was wrong. `code_slicing` follows
+  the active profile when unset, so this is the documented default on `fast`.
 - **`self-update` could corrupt the installed binary and leave no readable error
   behind.** `SelfUpdater::assertChecksumMatches()`
   (`src/Audit/Infrastructure/SelfUpdate/SelfUpdater.php`) guarded a failed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -850,19 +850,25 @@ Parameters exposed for debugging: `symfony_security_auditor.attacker_model`,
 
 Console command `audit:run` (alias `audit`). Arguments and options:
 
-| Name            | Type     | Default    | Purpose                                           |
-| --------------- | -------- | ---------- | ------------------------------------------------- |
-| `project-path`  | argument | `getcwd()` | Path to target project; defaults to CWD           |
-| `--format / -f` | option   | `console`  | `console`, `json`, or `sarif`                     |
-| `--output / -o` | option   | `null`     | Write JSON/SARIF report to file                   |
-| `--dry-run`     | option   | `false`    | Estimate cost without invoking the LLM; exits `0` |
+| Name            | Type     | Default    | Purpose                                                                                                                    |
+| --------------- | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `project-path`  | argument | `getcwd()` | Path to target project; defaults to CWD                                                                                    |
+| `--format / -f` | option   | `console`  | Any `OutputFormat` value: `console`, `executive`, `json`, `sarif`, `html`, `markdown`, `junit`, `github`, `github-comment` |
+| `--output / -o` | option   | `null`     | Write JSON/SARIF report to file                                                                                            |
+| `--dry-run`     | option   | `false`    | Estimate cost without invoking the LLM; exits `0`                                                                          |
 
 Input mapping and resolution live in `AuditCommandInput`; output writing in
 `ReportWriter`; user-facing messaging in `AuditPresenter`; exit code policy in
 `AuditExitCodeResolver`. `AuditCommand` itself only orchestrates.
 
-Exit codes: `0` (SAFE/LOW/MEDIUM/HIGH), `1` (CRITICAL risk or invalid path or
-unexpected failure), `2` (budget exceeded — partial report still emitted).
+Exit codes: `0` when the aggregate risk level is below the `fail_on` threshold
+(default `critical`, so SAFE/LOW/MEDIUM/HIGH) and any `--min-score` is met; `1`
+when it is at or above the threshold, the normalized score is below
+`--min-score`, the scan discovered no file to audit at all, the path was
+invalid, or the audit itself failed; `2` when the budget could not be honored —
+either aborted mid-run with a partial report still emitted, or never started
+because an unpriced model makes `audit.budget.max_cost_usd` unenforceable. The
+canonical table lives in [`docs/configuration.md`](configuration.md#exit-codes).
 
 ## Extension Points
 

--- a/src/Audit/Domain/Model/SecretPatternLabel.php
+++ b/src/Audit/Domain/Model/SecretPatternLabel.php
@@ -28,6 +28,7 @@ enum SecretPatternLabel: string
     case MultilineAssignment = 'multiline_assignment';
     case ConnectionUri = 'connection_uri';
     case BearerToken = 'bearer_token';
+    case BasicAuthorization = 'basic_authorization';
     case OpenAiApiKey = 'openai_api_key';
     case SlackWebhookUrl = 'slack_webhook_url';
     case Unscannable = 'unscannable';

--- a/src/Audit/Infrastructure/Config/AuditConfigurationDefinition.php
+++ b/src/Audit/Infrastructure/Config/AuditConfigurationDefinition.php
@@ -293,7 +293,7 @@ final readonly class AuditConfigurationDefinition
                         ->end()
                         ->arrayNode('code_slicing')
                             ->addDefaultsIfNotSet()
-                            ->info('Trim large PHP files down to security-relevant slices before they reach the LLM. The slicer keeps imports, attributes, class signatures, properties, and the FULL body of methods that touch security-relevant tokens (Request, Doctrine query builder, unserialize, shell exec, mailer, HttpClient, …). All other lines are replaced one-for-one with a `// elided` placeholder so line numbers stay accurate. Typical saving: 50-70% input tokens on controllers / services over 100 lines.')
+                            ->info('Trim large PHP files down to security-relevant slices before they reach the LLM. The slicer keeps imports, attributes, class signatures, properties, and the individual lines that touch security-relevant tokens (Request, Doctrine query builder, unserialize, shell exec, mailer, HttpClient, …), extended across a multi-line signature or heredoc body such a line opens. Retention is per line, not per method: an inert line inside a method that matched is still elided, so a variable assigned on an elided line can appear used but undefined in the slice — send the file unsliced when the taint flow between source and sink matters more than the tokens. All other lines are replaced one-for-one with a `// elided` placeholder so line numbers stay accurate. Typical saving: 50-70% input tokens on controllers / services over 100 lines.')
                             ->children()
                                 ->booleanNode('enabled')
                                     ->defaultNull()

--- a/src/Audit/Infrastructure/FileSystem/RegexSecretScrubber.php
+++ b/src/Audit/Infrastructure/FileSystem/RegexSecretScrubber.php
@@ -26,7 +26,8 @@ use VinceAmstoutz\SymfonySecurityAuditor\Audit\Infrastructure\FileSystem\Excepti
  * The pattern set covers common high-signal leaks: cloud provider keys, version-control
  * tokens, payment processor keys, generic credential assignments, JWT-shaped tokens,
  * PEM-encoded private keys, env-style token assignments, connection-string URIs with
- * embedded credentials (e.g. `postgres://user:pass@host`), `Authorization: Bearer` headers,
+ * embedded credentials (e.g. `postgres://user:pass@host`), `Authorization: Bearer` and
+ * `Authorization: Basic` headers,
  * OpenAI-style `sk-`/`sk-proj-` keys, and Slack incoming webhook URLs. Each match is replaced
  * with `***REDACTED:<label>***` so downstream prompt builders can still emit a coherent
  * file context without exposing the secret to the LLM.
@@ -45,7 +46,7 @@ final readonly class RegexSecretScrubber implements SecretScrubberInterface
         SecretPatternLabel::AwsAccessKey->value => '/\bAKIA[0-9A-Z]{16}\b/',
         SecretPatternLabel::GithubToken->value => '/\b(?:gh[pousr]_[A-Za-z0-9]{36,255}|github_pat_\w{22,255})\b/',
         SecretPatternLabel::StripeKey->value => '/\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,99}\b/',
-        SecretPatternLabel::SlackToken->value => '/\bxox[abprs]-[A-Za-z0-9-]{10,72}\b/',
+        SecretPatternLabel::SlackToken->value => '/\b(?:xox[abprs]-[A-Za-z0-9-]{10,72}|xapp-[0-9]-[A-Za-z0-9-]{10,120})\b/',
         SecretPatternLabel::GoogleApiKey->value => '/\bAIza[0-9A-Za-z_\-]{35}(?![0-9A-Za-z_\-])/',
         SecretPatternLabel::Jwt->value => '/\beyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\b/',
         SecretPatternLabel::PemPrivateKey->value => '/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----/',
@@ -54,6 +55,7 @@ final readonly class RegexSecretScrubber implements SecretScrubberInterface
         SecretPatternLabel::InlineAssignment->value => '/(["\']?(?:password|passwd|pwd|passphrase|secret|credentials|api[_-]?key|api[_-]?token|access[_-]?token|auth[_-]?token|client[_-]?secret|private[_-]?key|account[_-]?key)(?:[_-][a-z0-9]+)*["\']?\s*(?:=>|[:=])[ \t]*)(?!\*\*\*REDACTED:)(?:(["\'])((?:\\\\.|(?!\2)[^\n]){4,}+)\2|([^"\'\s]\S{3,}(?:[ \t]+[A-Za-z0-9]+)*))/i',
         SecretPatternLabel::MultilineAssignment->value => '/(["\']?(?:password|passwd|pwd|passphrase|secret|credentials|api[_-]?key|api[_-]?token|access[_-]?token|auth[_-]?token|client[_-]?secret|private[_-]?key|account[_-]?key)(?:[_-][a-z0-9]+)*["\']?\s*(?:=>|[:=]))[ \t]*\r?\n[ \t]*(["\'])((?:\\\\.|(?!\2)[^\n]){4,}+)\2/mi',
         SecretPatternLabel::BearerToken->value => '/\bBearer\s+[A-Za-z0-9\-_.]{20,4096}\b/i',
+        SecretPatternLabel::BasicAuthorization->value => '~\b((?:proxy-)?authorization\b["\']?\s*(?::|=>|=)\s*["\']?basic\s+)[A-Za-z0-9+/=_\-]{8,4096}~i',
         SecretPatternLabel::OpenAiApiKey->value => '/\bsk-(?:proj-)?[A-Za-z0-9_\-]{20,200}\b/',
         SecretPatternLabel::SlackWebhookUrl->value => '~\bhttps://hooks\.slack\.com/services/[A-Za-z0-9]+/[A-Za-z0-9]+/[A-Za-z0-9]+\b~',
     ];
@@ -130,6 +132,7 @@ final readonly class RegexSecretScrubber implements SecretScrubberInterface
         return match (SecretPatternLabel::tryFrom($label)) {
             SecretPatternLabel::EnvAssignment => \sprintf('$1=***REDACTED:%s***', $label),
             SecretPatternLabel::ConnectionUri => \sprintf('$1***REDACTED:%s***@', $label),
+            SecretPatternLabel::BasicAuthorization => \sprintf('$1***REDACTED:%s***', $label),
             default => \sprintf('***REDACTED:%s***', $label),
         };
     }

--- a/tests/Phpunit/Unit/Infrastructure/FileSystem/RegexSecretScrubberTest.php
+++ b/tests/Phpunit/Unit/Infrastructure/FileSystem/RegexSecretScrubberTest.php
@@ -127,10 +127,49 @@ final class RegexSecretScrubberTest extends TestCase
             self::OPENAI_SK.'-'.str_repeat('a1B2', 10),
             '***REDACTED:openai_api_key***',
         ];
+        yield 'basic_authorization_header' => [
+            'Authorization: Basic '.base64_encode('admin:s3cr3tValue1'),
+            '***REDACTED:basic_authorization***',
+        ];
+        yield 'basic_authorization_proxy_header' => [
+            'Proxy-Authorization: Basic '.base64_encode('admin:s3cr3tValue1'),
+            '***REDACTED:basic_authorization***',
+        ];
+        yield 'basic_authorization_php_array' => [
+            "'Authorization' => 'Basic ".base64_encode('admin:s3cr3tValue1')."'",
+            '***REDACTED:basic_authorization***',
+        ];
+        yield 'slack_app_level_token' => [
+            'xapp-1-A012345678-1234567890123-'.str_repeat('a1B2', 8),
+            '***REDACTED:slack_token***',
+        ];
         yield 'slack_incoming_webhook_url' => [
             'https://hooks.slack.com/services/T00000000/B00000000/'.str_repeat('X', 24),
             '***REDACTED:slack_webhook_url***',
         ];
+    }
+
+    /**
+     * The credential is redacted but the header name and scheme are kept, so the
+     * LLM still sees that the request authenticates and how — removing them
+     * would hide the auth mechanism the audit is meant to reason about.
+     */
+    public function test_a_basic_authorization_header_keeps_its_scheme_and_redacts_only_the_credential(): void
+    {
+        $scrubbed = $this->regexSecretScrubber->scrub('Authorization: Basic '.base64_encode('admin:s3cr3tValue'));
+
+        self::assertSame('Authorization: Basic ***REDACTED:basic_authorization***', $scrubbed);
+    }
+
+    /**
+     * `basic` and `authorization` are ordinary English words; only the two
+     * together, in an assignment, followed by a credential-shaped value, are a
+     * secret. Prose that happens to use them must survive untouched.
+     */
+    public function test_prose_mentioning_basic_authorization_is_not_redacted(): void
+    {
+        self::assertSame('Use basic authentication over TLS.', $this->regexSecretScrubber->scrub('Use basic authentication over TLS.'));
+        self::assertSame('Authorization: required', $this->regexSecretScrubber->scrub('Authorization: required'));
     }
 
     public function test_an_azure_storage_account_key_is_redacted(): void


### PR DESCRIPTION
## Summary

`RegexSecretScrubber` matched `Authorization: Bearer` but not `Basic`, so a
committed Basic credential — which base64-decodes back to `user:password` — was
sent verbatim to the LLM provider on the default scrubbing path. Slack was
covered twice over (`xox[abprs]-`, webhook URLs) while `xapp-` app-level tokens
leaked. Both are now redacted. Two documentation references that contradicted
the code are corrected alongside.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## Checklist

- [x] Tests added or updated (unit + integration where applicable)
- [x] All checks pass: `bin/castor lint`
- [x] 100% MSI maintained: `docker compose exec php bin/infection`
- [x] No `createMock` without a matching `expects()` (use `createStub` otherwise)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)