### PR TITLE
fix(ci): keep the release a draft until built

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -83,10 +83,15 @@ jobs:
           fi
 
           second_parent="${parents[2]}"
-          git fetch origin 1.x --quiet
-          if ! git merge-base --is-ancestor "$second_parent" origin/1.x; then
-            echo "::error::This release commit's second parent ($second_parent) is not part of 1.x's history, so it doesn't look like a genuine 1.x-into-main merge — see docs/versioning.md#branches--maintenance."
-            exit 1
+          # 1.x can already be gone by the time this runs (e.g. "delete branch
+          # on merge"), so only cross-check against it when it still exists —
+          # the parent-count check above is what actually catches #305.
+          if git ls-remote --exit-code --heads origin 1.x >/dev/null 2>&1; then
+            git fetch origin 1.x --quiet
+            if ! git merge-base --is-ancestor "$second_parent" origin/1.x; then
+              echo "::error::This release commit's second parent ($second_parent) is not part of 1.x's history, so it doesn't look like a genuine 1.x-into-main merge — see docs/versioning.md#branches--maintenance."
+              exit 1
+            fi
           fi
 
   tag-and-draft-release:
@@ -171,18 +176,11 @@ jobs:
             echo "name=$VERSION" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve whether to publish immediately
+      - name: Resolve whether the built release should auto-publish
         id: publish-state
         env:
           PUBLISH: ${{ github.event.inputs.publish }}
-        run: |
-          set -euo pipefail
-
-          if [ "$PUBLISH" = "true" ]; then
-            echo "draft=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "draft=true" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "publish=${PUBLISH:-false}" >> "$GITHUB_OUTPUT"
 
       - name: Draft the GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # zizmor: ignore[superfluous-actions] v3.0.2 -- not a security issue per zizmor's own docs; migrating to `gh release` is a separate follow-up
@@ -190,15 +188,20 @@ jobs:
           tag_name: ${{ needs.detect.outputs.version }}
           name: ${{ steps.release-name.outputs.name }}
           body_path: release-notes.md
-          draft: ${{ steps.publish-state.outputs.draft }}
+          # Always starts as a draft, whatever `publish` was dispatched with:
+          # the binaries don't exist yet, so the release can't be finished at
+          # this point regardless of intent. release.yaml's `finalize` job
+          # publishes it once every asset is actually attached.
+          draft: true
 
       - name: Trigger the binary build against the drafted release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           VERSION: ${{ needs.detect.outputs.version }}
+          PUBLISH_WHEN_DONE: ${{ steps.publish-state.outputs.publish }}
         run: |
           set -euo pipefail
 
           # GITHUB_TOKEN-authored events don't cascade into other workflows (GitHub's anti-recursion guard), so dispatch explicitly rather than rely on release:published.
-          gh workflow run release.yaml --repo "$REPO" --field tag="$VERSION"
+          gh workflow run release.yaml --repo "$REPO" --field tag="$VERSION" --field keep_draft=true --field publish_when_done="$PUBLISH_WHEN_DONE"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,20 @@ on:
         description: 'Existing release tag to build and attach the binaries to (e.g. 1.13.0)'
         required: true
         type: string
+      keep_draft:
+        description:
+          "Set by Auto Release for a freshly drafted release: keep it a draft
+          while assets attach, so it never appears finished before every
+          binary exists. Leave false when repairing an already-published
+          release."
+        required: false
+        type: boolean
+        default: false
+      publish_when_done:
+        description: "Only with keep_draft: publish the release once every asset is attached."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -277,6 +291,11 @@ jobs:
           # rebuild does not, so target the tag explicitly (the input on
           # dispatch, the pushed tag on a release event).
           tag_name: ${{ inputs.tag || github.ref_name }}
+          # softprops/action-gh-release always sends its draft input (default
+          # false) rather than leaving the field untouched, so every call must
+          # state the release's intended draft state explicitly or it gets
+          # published on the first asset attached.
+          draft: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_draft }}
           # Replace an asset of the same name instead of erroring or
           # accumulating duplicates when the workflow is re-dispatched to
           # repair a partially-published release.
@@ -301,6 +320,7 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # zizmor: ignore[superfluous-actions] v3.0.2 -- not a security issue per zizmor's own docs; migrating to `gh release` is a separate follow-up
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
+          draft: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_draft }}
           overwrite_files: true
           # Published so the documented URLs can resolve through
           # `releases/latest/download/` — which always serves the newest
@@ -356,3 +376,20 @@ jobs:
                 ;;
             esac
           done
+
+  finalize:
+    name: Publish the release now that every asset is attached
+    runs-on: ubuntu-latest
+    needs:
+      - installers
+      - prune
+    if: github.event_name == 'workflow_dispatch' && inputs.keep_draft && inputs.publish_when_done
+    permissions:
+      contents: write
+    steps:
+      - name: Flip the release from draft to published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: gh release edit "$TAG" --draft=false


### PR DESCRIPTION
## Summary

Fixes two bugs surfaced while releasing 1.20.0: (1) Auto Release's push-triggered guard hard-fails when `1.x` no longer exists (e.g. deleted on merge), so the release commit's tag/draft step never ran; (2) `release.yaml`'s asset-attach steps omit `draft`, so `action-gh-release`'s own default silently published the release as soon as the first (fastest) attach job finished — well before the binary matrix completed.

## Type of change

- [x] Bug fix

## Target branch

- [x] `1.x` — anything for the next minor release: bug fixes and new features

## What changed

- `auto-release.yaml`: the "genuine merge of 1.x" ancestor check now only runs if `1.x` still exists remotely (`git ls-remote --exit-code --heads origin 1.x`); the parent-count check right above it already catches a squash/rebase-merged release PR (#305), so this is defense-in-depth, not the primary guard.
- `auto-release.yaml`: the drafted release now always starts `draft: true`, regardless of the `publish` input — the binaries don't exist yet at that point, so nothing can be "finished" immediately.
- `release.yaml`: both `binary-publish` and `installers` now explicitly pass `draft: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_draft }}` to `action-gh-release`, so neither can silently flip an in-progress draft to published.
- `release.yaml`: new `finalize` job, gated on both `installers` and `prune` completing, publishes the release only when `keep_draft && publish_when_done` — i.e. only once every asset genuinely exists, and only when that was requested.
- `auto-release.yaml` now dispatches `release.yaml` with `keep_draft=true` and forwards its own `publish` decision as `publish_when_done`.

No behavior change for the existing `release: published` trigger or a plain manual `workflow_dispatch` repair-rebuild (both keep the same effective `draft` value as before this change).

## Checklist

- [x] All checks pass: `bin/castor lint` (workflow files only; no PHP touched — `composer.json`/tests unaffected)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)